### PR TITLE
data verification enabled

### DIFF
--- a/agreement/agreement.go
+++ b/agreement/agreement.go
@@ -490,6 +490,8 @@ func (w *AgreementWorker) advertiseAllPolicies(location string) error {
 		resp = new(exchange.PutDeviceResponse)
 		targetURL := w.Manager.Config.Edge.ExchangeURL + "devices/" + w.deviceId + "?token=" + w.deviceToken
 
+		glog.V(3).Infof("AgreementWorker Registering microservices: %v at %v", pdr.ShortString(), targetURL)
+
 		for {
 			if err, tpErr := exchange.InvokeExchange(w.httpClient, "PUT", targetURL, pdr, &resp); err != nil {
 				return err

--- a/agreementbot/activecontracts.go
+++ b/agreementbot/activecontracts.go
@@ -1,0 +1,131 @@
+package agreementbot
+
+import (
+    "bytes"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "github.com/golang/glog"
+    "github.com/open-horizon/anax/config"
+    "net/http"
+    "os"
+    "time"
+)
+
+
+// Following test data was given for JSON schema
+// const testActiveData = `[{"id":"1","lat":41.0064,"lon":-111.9393,"contracts":[{"id":"0x0abcde","type":1,"ts":1447195061},{"id":"0x0ddddd","type":2,"ts":1447195061}]},`+
+//                          `{"id":"2","lat":-41.0064,"lon":111.9393,"contracts":[{"id":"0x0deadbeef","type":1,"ts":1447195061},{"id":"0x0beefdead","type":2,"ts":1447195061}]}]`
+
+type AgreementEntry struct {
+    Id   string `json:"id"`
+    Type int    `json:"type"`
+    Ts   uint64 `json:"ts"`
+}
+
+type DeviceEntry struct {
+    Id        string          `json:"id"`
+    Lat       float64         `json:"lat"`
+    Lon       float64         `json:"lon"`
+    Agreements []AgreementEntry `json:"contracts"`
+}
+
+func GetActiveAgreements(in_devices map[string][]string, agreement Agreement, config *config.AGConfig) ([]string, error) {
+    err := error(nil)
+
+    // If the agreement record was created with the ActiveContractsURL field, then it means that the policy which created the
+    // agreement specified a specific data verification URL. If not, then the default data verification URL is used from
+    // the config.
+
+    // This field is true when data verification is explicitly turned off in agreement's policy file.
+    if agreement.DisableDataVerificationChecks == true {
+        res := make([]string, 0, 1)
+        return res, err
+    }
+
+    activeAgreementsURL := agreement.DataVerificationURL
+    if activeAgreementsURL == "" {
+        activeAgreementsURL = config.ActiveAgreementsURL
+    }
+
+    if _, ok := in_devices[activeAgreementsURL]; !ok {
+        devices := make([]string, 0, 10)
+        response := make([]DeviceEntry, 0, 10)
+
+        // Assume the REST API is unreliable. If it fails, retry a few times before returning an
+        // error to the caller.
+        retries := 0
+        for {
+            if err = Invoke_rest("GET", activeAgreementsURL, nil, &response); err != nil {
+                glog.Errorf("Error getting active agreements: %v", err)
+                if retries == 2 {
+                    break
+                } else {
+                    retries += 1
+                    time.Sleep(1 * time.Second)
+                }
+            } else {
+                glog.V(4).Infof("Active agreement response: %v", response)
+                for _, dev := range response {
+                    for _, con := range dev.Agreements {
+                        devices = append(devices, con.Id)
+                    }
+                }
+                glog.V(3).Infof("For URL %v Gathered agreements: %v", activeAgreementsURL, devices)
+                err = error(nil)
+                break
+            }
+        }
+        in_devices[activeAgreementsURL] = devices
+        return devices, err
+    } else {
+        return in_devices[activeAgreementsURL], err
+    }
+}
+
+func ActiveAgreementsContains(activeAgreements []string, agreement Agreement) bool {
+
+    inttest_mode := os.Getenv("mtn_integration_test")
+    if inttest_mode != "" || agreement.DisableDataVerificationChecks == true {
+        return true
+    }
+
+    for _, dev := range activeAgreements {
+        if dev == agreement.CurrentAgreementId {
+            return true
+        }
+    }
+
+    return false
+}
+
+func Invoke_rest(method string, url string, body []byte, outstruct interface{}) error {
+    req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+    req.Header.Set("Content-Type", "application/json")
+
+    req.Close = true // work around to ensure that Go doesn't get connections confused. Supposed to be fixed in Go 1.6.
+
+    client := &http.Client{}
+    rawresp, err := client.Do(req)
+    if err != nil {
+        return err
+    } else if method == "GET" && rawresp.StatusCode != 200 {
+        return errors.New(fmt.Sprintf("Error response from REST GET %v call: %v", url, rawresp.Status))
+    } else if (method == "POST" || method == "PUT") && rawresp.StatusCode != 201 {
+        return errors.New(fmt.Sprintf("Error response from REST %v %v call: %v", method, url, rawresp.Status))
+    }
+
+    defer rawresp.Body.Close()
+    // glog.Infof("Raw Response: %v", rawresp.Body)
+
+    if outstruct != nil {
+        if err = json.NewDecoder(rawresp.Body).Decode(&outstruct); err != nil {
+            glog.Errorf("Error decoding http response: %v", err)
+        } else {
+            // glog.Infof("Decoded Response: %v", outstruct)
+        }
+    }
+
+    return err
+}
+

--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -510,13 +511,22 @@ func (w *AgreementBotWorker) recordConsumerAgreementState(agreementId string, wo
 
 func (w *AgreementBotWorker) ignoreDevice(dev exchange.Device) (bool, error) {
 	for _, prop := range dev.Microservices[0].Properties {
-		if prop.Name == w.Config.AgreementBot.IgnoreContractWithAttribs {
+		if listContains(w.Config.AgreementBot.IgnoreContractWithAttribs, prop.Name) {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
+func listContains(list string, target string) bool {
+    ignoreAttribs := strings.Split(list, ",")
+    for _, propName := range ignoreAttribs {
+        if propName == target {
+            return true
+        }
+    }
+    return false
+}
 
 // ==========================================================================================================
 // Utility functions

--- a/config/config.go
+++ b/config/config.go
@@ -40,20 +40,17 @@ type AGConfig struct {
 	AgreementWorkers             int
 	DBPath                       string
 	GethURL                      string
-	PayloadPath                  string
 	AgreementTimeoutS            uint64 // Number of seconds to wait before declaring agreement not finalized in blockchain
 	NoDataIntervalS              uint64 // default should be 15 mins == 15*60 == 900. Ignored if the policy has data verification disabled.
-	ActiveContractsURL           string // This field is the default and cannot be removed until all workloads are using their own URL
-	EtcdUrl                      string // default is http://localhost:2379/v2/keys. If not specified then ectd interactions are skipped.
+	ActiveAgreementsURL          string // This field is used when policy files indicate they want data verification but they dont specify a URL
 	PolicyPath                   string // The directory where policy files are kept, default /etc/provider-tremor/policy/
 	NewContractIntervalS         uint64 // default should be 1
 	ProcessGovernanceIntervalS   uint64 // How long the gov sleeps before general gov checks (new payloads, interval payments, etc).
-	// The default should be 5.
-	IgnoreContractWithAttribs string // A comma seperated list of contract attributes. If set, the contracts that contain one or more of the attributes will be ignored. The default is "ethereum_account".
-	ExchangeURL               string // The URL of the Horizon exchange. If not configured, the exchange will not be used.
-	ExchangeHeartbeat         int    // Seconds between heartbeats to the exchange
-	ExchangeId                string // The id of the agbot, not the userid of the exchange user
-	ExchangeToken             string // The agbot's authentication token
+	IgnoreContractWithAttribs    string // A comma seperated list of contract attributes. If set, the contracts that contain one or more of the attributes will be ignored. The default is "ethereum_account".
+	ExchangeURL                  string // The URL of the Horizon exchange. If not configured, the exchange will not be used.
+	ExchangeHeartbeat            int    // Seconds between heartbeats to the exchange
+	ExchangeId                   string // The id of the agbot, not the userid of the exchange user
+	ExchangeToken                string // The agbot's authentication token
 
 }
 

--- a/events/events.go
+++ b/events/events.go
@@ -57,6 +57,7 @@ const (
 
 type Message interface {
 	Event() Event
+	ShortString() string
 }
 
 type AgreementLaunchContext struct {
@@ -71,6 +72,10 @@ func (c AgreementLaunchContext) String() string {
 	return fmt.Sprintf("AgreementProtocol: %v, AgreementId: %v, Configure: %v, EnvironmentAdditions: %v", c.AgreementProtocol, c.AgreementId, c.Configure, c.EnvironmentAdditions)
 }
 
+func (c AgreementLaunchContext) ShortString() string {
+	return fmt.Sprintf("AgreementProtocol: %v, AgreementId: %v", c.AgreementProtocol, c.AgreementId)
+}
+
 // This event indicates that a new microservice has been created in the form of a policy file
 type PolicyCreatedMessage struct {
 	event    Event
@@ -79,6 +84,10 @@ type PolicyCreatedMessage struct {
 
 func (e PolicyCreatedMessage) String() string {
 	return fmt.Sprintf("event: %v, file: %v", e.event, e.fileName)
+}
+
+func (e PolicyCreatedMessage) ShortString() string {
+	return e.String()
 }
 
 func (e *PolicyCreatedMessage) Event() Event {
@@ -109,6 +118,10 @@ func (e ABPolicyCreatedMessage) String() string {
 	return fmt.Sprintf("event: %v, file: %v", e.event, e.fileName)
 }
 
+func (e ABPolicyCreatedMessage) ShortString() string {
+	return e.String()
+}
+
 func (e *ABPolicyCreatedMessage) Event() Event {
 	return e.event
 }
@@ -136,6 +149,10 @@ type EdgeRegisteredExchangeMessage struct {
 
 func (e EdgeRegisteredExchangeMessage) String() string {
 	return fmt.Sprintf("event: %v, id: %v, token: %v", e.event, e.id, e.token)
+}
+
+func (e EdgeRegisteredExchangeMessage) ShortString() string {
+	return e.String()
 }
 
 func (e *EdgeRegisteredExchangeMessage) Event() Event {
@@ -172,6 +189,10 @@ func (e AgreementReachedMessage) String() string {
 	return fmt.Sprintf("event: %v, launch context: %v", e.event, e.launchContext)
 }
 
+func (e AgreementReachedMessage) ShortString() string {
+	return fmt.Sprintf("event: %v, launch context: %v", e.event, e.launchContext.ShortString())
+}
+
 func (e *AgreementReachedMessage) Event() Event {
 	return e.event
 }
@@ -199,6 +220,10 @@ func (e WhisperSubscribeToMessage) String() string {
 	return fmt.Sprintf("event: %v, topic: %v", e.event, e.topic)
 }
 
+func (e WhisperSubscribeToMessage) ShortString() string {
+	return e.String()
+}
+
 func (e *WhisperSubscribeToMessage) Event() Event {
 	return e.event
 }
@@ -223,6 +248,10 @@ type WhisperReceivedMessage struct {
 	topics  []string
 	from    string
 	to      string
+}
+
+func (e WhisperReceivedMessage) ShortString() string {
+	return fmt.Sprintf("Event: %v, From: %v, To: %v, Topics: %v, Payload: %v", e.event, e.from, e.to, e.topics, e.payload[:40])
 }
 
 func (e WhisperReceivedMessage) String() string {
@@ -272,6 +301,14 @@ func (b *TorrentMessage) Event() Event {
 	return b.event
 }
 
+func (b *TorrentMessage) String() string {
+	return fmt.Sprintf("event: %v, imageFiles: %v, agreementLaunchContext: %v", b.event, b.ImageFiles, b.AgreementLaunchContext)
+}
+
+func (b *TorrentMessage) ShortString() string {
+	return fmt.Sprintf("event: %v, imageFiles: %v, agreementLaunchContext: %v", b.event, b.ImageFiles, b.AgreementLaunchContext.ShortString())
+}
+
 func NewTorrentMessage(id EventId, imageFiles []string, agreementLaunchContext *AgreementLaunchContext) *TorrentMessage {
 
 	return &TorrentMessage{
@@ -299,6 +336,10 @@ func (m GovernanceMaintenanceMessage) String() string {
 	return fmt.Sprintf("Event: %v, AgreementProtocol: %v, AgreementId: %v, Deployment: %v", m.event, m.AgreementProtocol, m.AgreementId, m.Deployment)
 }
 
+func (m GovernanceMaintenanceMessage) ShortString() string {
+	return m.String()
+}
+
 type GovernanceCancelationMessage struct {
 	GovernanceMaintenanceMessage
 	Message
@@ -311,6 +352,10 @@ func (m *GovernanceCancelationMessage) Event() Event {
 
 func (m GovernanceCancelationMessage) String() string {
 	return fmt.Sprintf("Event: %v, AgreementProtocol: %v, AgreementId: %v, Deployment: %v, Cause: %v", m.Event, m.AgreementProtocol, m.AgreementId, persistence.ServiceConfigNames(m.Deployment), m.Cause)
+}
+
+func (m GovernanceCancelationMessage) ShortString() string {
+	return m.String()
 }
 
 func NewGovernanceMaintenanceMessage(id EventId, protocol string, agreementId string, deployment *map[string]persistence.ServiceConfig) *GovernanceMaintenanceMessage {
@@ -346,6 +391,10 @@ func (m ContainerMessage) String() string {
 	return fmt.Sprintf("event: %v, AgreementProtocol: %v, AgreementId: %v, Deployment: %v", m.event, m.AgreementProtocol, m.AgreementId, persistence.ServiceConfigNames(m.Deployment))
 }
 
+func (m ContainerMessage) ShortString() string {
+	return m.String()
+}
+
 func (b ContainerMessage) Event() Event {
 	return b.event
 }
@@ -379,6 +428,10 @@ func (m ApiAgreementCancelationMessage) String() string {
 	return fmt.Sprintf("Event: %v, AgreementProtocol: %v, AgreementId: %v, Deployment: %v, Cause: %v", m.Event, m.AgreementProtocol, m.AgreementId, persistence.ServiceConfigNames(m.Deployment), m.Cause)
 }
 
+func (m ApiAgreementCancelationMessage) ShortString() string {
+	return m.String()
+}
+
 func NewApiAgreementCancelationMessage(id EventId, cause EndContractCause, protocol string, agreementId string, deployment *map[string]persistence.ServiceConfig) *ApiAgreementCancelationMessage {
 	return &ApiAgreementCancelationMessage{
 		event: Event{
@@ -406,6 +459,10 @@ func (m *InitAgreementCancelationMessage) Event() Event {
 
 func (m InitAgreementCancelationMessage) String() string {
 	return fmt.Sprintf("Event: %v, AgreementProtocol: %v, AgreementId: %v, Deployment: %v, Reason: %v", m.Event, m.AgreementProtocol, m.AgreementId, persistence.ServiceConfigNames(m.Deployment), m.Reason)
+}
+
+func (m InitAgreementCancelationMessage) ShortString() string {
+	return m.String()
 }
 
 func NewInitAgreementCancelationMessage(id EventId, reason uint, protocol string, agreementId string, deployment *map[string]persistence.ServiceConfig) *InitAgreementCancelationMessage {

--- a/exchange/rpc.go
+++ b/exchange/rpc.go
@@ -25,6 +25,10 @@ type MSProp struct {
 	Op       string `json:"op"`
 }
 
+func (p MSProp) String() string {
+	return fmt.Sprintf("Property %v %v %v, Type: %v,", p.Name, p.Op, p.Value, p.PropType)
+}
+
 type Microservice struct {
 	Url           string   `json:"url"`
 	Properties    []MSProp `json:"properties"`
@@ -32,12 +36,24 @@ type Microservice struct {
 	Policy        string   `json:"policy"`
 }
 
+func (m Microservice) String() string {
+	return fmt.Sprintf("URL: %v, Properties: %v, NumAgreements: %v, Policy: %v", m.Url, m.Properties, m.NumAgreements, m.Policy)
+}
+
+func (m Microservice) ShortString() string {
+	return fmt.Sprintf("URL: %v, NumAgreements: %v, Properties: %v", m.Url, m.NumAgreements, m.Properties)
+}
+
 type SearchExchangeRequest struct {
 	DesiredMicroservices []Microservice `json:"desiredMicroservices"`
 	DaysStale            int            `json:"daysStale"`
 	PropertiesToReturn   []string       `json:"propertiesToReturn"`
-	LastIndex            int            `json:"startIndex"`
+	StartIndex           int            `json:"startIndex"`
 	NumEntries           int            `json:"numEntries"`
+}
+
+func (a SearchExchangeRequest) String() string {
+	return fmt.Sprintf("Microservices: %v, DaysStale: %v, PropertiesToReturn: %v, StartIndex: %v, NumEntries: %v", a.DesiredMicroservices, a.DaysStale, a.PropertiesToReturn, a.StartIndex, a.NumEntries)
 }
 
 type Device struct {
@@ -47,9 +63,25 @@ type Device struct {
 	MsgEndPoint   string         `json:"msgEndPoint"`
 }
 
+func (d Device) String() string {
+	return fmt.Sprintf("Id: %v, Name: %v, Microservices: %v, MsgEndPoint: %v", d.Id, d.Name, d.Microservices, d.MsgEndPoint)
+}
+
+func (d Device) ShortString() string {
+	str := fmt.Sprintf("Id: %v, Name: %v, MsgEndPoint: %v, Microservice URLs:", d.Id, d.Name, d.Microservices, d.MsgEndPoint)
+	for _, ms := range d.Microservices {
+		str += fmt.Sprintf("%v,", ms.Url)
+	}
+	return str
+}
+
 type SearchExchangeResponse struct {
 	Devices   []Device `json:"devices"`
 	LastIndex int      `json:"lastIndex"`
+}
+
+func (r SearchExchangeResponse) String() string {
+	return fmt.Sprintf("Devices: %v, LastIndex: %v", r.Devices, r.LastIndex)
 }
 
 type GetDevicesResponse struct {
@@ -63,10 +95,18 @@ type AgbotAgreement struct {
 	LastUpdated string `json:"lastUpdated"`
 }
 
+func (a AgbotAgreement) String() string {
+	return fmt.Sprintf("Workload: %v, State: %v, LastUpdated: %v", a.Workload, a.State, a.LastUpdated)
+}
+
 type DeviceAgreement struct {
 	Microservice string `json:"microservice"`
 	State        string `json:"state"`
 	LastUpdated  string `json:"lastUpdated"`
+}
+
+func (a DeviceAgreement) String() string {
+	return fmt.Sprintf("Microservice: %v, State: %v, LastUpdated: %v", a.Microservice, a.State, a.LastUpdated)
 }
 
 type AllAgbotAgreementsResponse struct {
@@ -74,9 +114,17 @@ type AllAgbotAgreementsResponse struct {
 	LastIndex  int                       `json:"lastIndex"`
 }
 
+func (a AllAgbotAgreementsResponse) String() string {
+	return fmt.Sprintf("Agreements: %v, LastIndex: %v", a.Agreements, a.LastIndex)
+}
+
 type AllDeviceAgreementsResponse struct {
 	Agreements map[string]DeviceAgreement `json:"agreements`
 	LastIndex  int                        `json:"lastIndex"`
+}
+
+func (a AllDeviceAgreementsResponse) String() string {
+	return fmt.Sprintf("Agreements: %v, LastIndex: %v", a.Agreements, a.LastIndex)
 }
 
 type PutDeviceResponse map[string]string
@@ -106,12 +154,24 @@ type PutDeviceRequest struct {
 	SoftwareVersions        SoftwareVersion `json:"softwareVersions"`
 }
 
+func (p PutDeviceRequest) String() string {
+	return fmt.Sprintf("Token: %v, Name: %v, RegisteredMicroservices %v, MsgEndPoint %v, SoftwareVersions %v", p.Token, p.Name, p.RegisteredMicroservices, p.MsgEndPoint, p.SoftwareVersions)
+}
+
+func (p PutDeviceRequest) ShortString() string {
+	str := fmt.Sprintf("Token: %v, Name: %v, MsgEndPoint %v, SoftwareVersions %v, Microservice URLs: ", p.Token, p.Name, p.MsgEndPoint, p.SoftwareVersions)
+	for _, ms := range p.RegisteredMicroservices {
+		str += fmt.Sprintf("%v,", ms.Url)
+	}
+	return str
+}
+
 // This function creates the exchange search message body.
 func CreateSearchRequest() *SearchExchangeRequest {
 
 	ser := &SearchExchangeRequest{
 		DaysStale:  0,
-		LastIndex:  0,
+		StartIndex:  0,
 		NumEntries: 10,
 	}
 

--- a/main.go
+++ b/main.go
@@ -208,7 +208,8 @@ func main() {
 
 		select {
 		case msg := <-messageStream:
-			glog.V(3).Infof("Handling Message (%T): %v\n", msg, msg)
+			glog.V(3).Infof("Handling Message (%T): %v\n", msg, msg.ShortString())
+			glog.V(5).Infof("Handling Message (%T): %v\n", msg, msg)
 
 			if successMsg, err := eventHandler(msg, workers); err != nil {
 				// error! do some barfing and then continue

--- a/policy/api_spec_list.go
+++ b/policy/api_spec_list.go
@@ -29,7 +29,6 @@ type APISpecification struct {
 	SpecRef          string `json:"specRef"`          // A URL pointing to the definition of the API spec
 	Version          string `json:"version"`          // The version of the API spec in OSGI version format
 	ExclusiveAccess  bool   `json:"exclusiveAccess"`  // Whether or not exclusive access to this API spec is required
-	NumberAgreements int    `json:"numberAgreements"` // The Maximum number of agreements that a device supporting the
 	// API will allow. For a Consumer (agbot), this is likely to be 1.
 	// For a Producer, if this is zero, then no agreements, if 1 then
 	// then it's essentially exclusive access. For more than 1, then it's
@@ -38,16 +37,15 @@ type APISpecification struct {
 }
 
 func (a APISpecification) IsSame(compare APISpecification) bool {
-	return a.SpecRef == compare.SpecRef && a.Version == compare.Version && a.ExclusiveAccess == compare.ExclusiveAccess && a.NumberAgreements == compare.NumberAgreements && a.Arch == compare.Arch
+	return a.SpecRef == compare.SpecRef && a.Version == compare.Version && a.ExclusiveAccess == compare.ExclusiveAccess && a.Arch == compare.Arch
 }
 
 // This function creates API Spec objects
-func APISpecification_Factory(ref string, vers string, num_agree int, arch string) *APISpecification {
+func APISpecification_Factory(ref string, vers string, arch string) *APISpecification {
 	a := new(APISpecification)
 	a.SpecRef = ref
 	a.Version = vers
 	a.ExclusiveAccess = true
-	a.NumberAgreements = num_agree
 	a.Arch = arch
 
 	return a
@@ -60,7 +58,7 @@ func (self *APISpecList) Is_Subset_Of(super_set *APISpecList) error {
 	for _, sub_ele := range *self {
 		found := false
 		for _, super_ele := range *super_set {
-			if sub_ele.SpecRef == super_ele.SpecRef && sub_ele.Arch == super_ele.Arch && sub_ele.NumberAgreements <= super_ele.NumberAgreements {
+			if sub_ele.SpecRef == super_ele.SpecRef && sub_ele.Arch == super_ele.Arch {
 				if super_ver, err := Version_Expression_Factory(super_ele.Version); err != nil {
 					continue
 				} else if ok, err := super_ver.Is_within_range(sub_ele.Version); err != nil {

--- a/policy/api_spec_list_test.go
+++ b/policy/api_spec_list_test.go
@@ -60,8 +60,8 @@ func Test_APISpecification_subset_found(t *testing.T) {
 		}
 	}
 
-	prod1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"numberAgreements":1}]`
-	con1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "1.0.0","exclusiveAccess": false,"numberAgreements":1}]`
+	prod1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false}]`
+	con1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "1.0.0","exclusiveAccess": false}]`
 	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
 		if con_as = create_APISpecification(con1, t); con_as != nil {
 			if err := con_as.Is_Subset_Of(prod_as); err != nil {
@@ -70,8 +70,8 @@ func Test_APISpecification_subset_found(t *testing.T) {
 		}
 	}
 
-	prod1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"numberAgreements":2}]`
-	con1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "1.0.0","exclusiveAccess": false,"numberAgreements":1}]`
+	prod1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false}]`
+	con1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "1.0.0","exclusiveAccess": false}]`
 	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
 		if con_as = create_APISpecification(con1, t); con_as != nil {
 			if err := con_as.Is_Subset_Of(prod_as); err != nil {
@@ -90,8 +90,8 @@ func Test_APISpecification_subset_found(t *testing.T) {
 		}
 	}
 
-	prod1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"numberAgreements":2,"arch":"x86"}]`
-	con1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "1.0.0","exclusiveAccess": false,"numberAgreements":1,"arch":"x86"}]`
+	prod1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"arch":"x86"}]`
+	con1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "1.0.0","exclusiveAccess": false,"arch":"x86"}]`
 	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
 		if con_as = create_APISpecification(con1, t); con_as != nil {
 			if err := con_as.Is_Subset_Of(prod_as); err != nil {
@@ -164,8 +164,8 @@ func Test_APISpecification_subset_not_found(t *testing.T) {
 		}
 	}
 
-	prod1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"numberAgreements":2,"arch":"arm"}]`
-	con1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "1","exclusiveAccess": false,"numberAgreements":1,"arch":"x86"}]`
+	prod1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"arch":"arm"}]`
+	con1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "1","exclusiveAccess": false,"arch":"x86"}]`
 	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
 		if con_as = create_APISpecification(con1, t); con_as != nil {
 			if err := con_as.Is_Subset_Of(prod_as); err == nil {
@@ -174,13 +174,4 @@ func Test_APISpecification_subset_not_found(t *testing.T) {
 		}
 	}
 
-	prod1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"numberAgreements":1,"arch":"x86"}]`
-	con1 = `[{"specRef": "http://mycompany.com/dm/gps","version": "1","exclusiveAccess": false,"numberAgreements":2,"arch":"x86"}]`
-	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
-		if con_as = create_APISpecification(con1, t); con_as != nil {
-			if err := con_as.Is_Subset_Of(prod_as); err == nil {
-				t.Errorf("Error: %v is not a subset of %v.\n", con1, prod1)
-			}
-		}
-	}
 }

--- a/policy/blockchain.go
+++ b/policy/blockchain.go
@@ -90,7 +90,7 @@ func (self *BlockchainList) Intersects_With(other *BlockchainList) (*BlockchainL
 	}
 
 	if len(*inter) == 0 {
-		return nil, errors.New(fmt.Sprintf("Agreement Protocol Intersection Error: %v was not found in %v", (*self), (*other)))
+		return nil, errors.New(fmt.Sprintf("Blockchain Intersection Error: %v was not found in %v", (*self), (*other)))
 	} else {
 		return inter, nil
 	}
@@ -110,6 +110,12 @@ func (self *BlockchainList) Concatenate(new_list *BlockchainList) {
 			(*self) = append((*self), new_ele)
 		}
 	}
+}
+
+func (self *BlockchainList) Single_Element() *BlockchainList {
+	single := new(BlockchainList)
+	(*single) = append(*single, (*self)[0])
+	return single
 }
 
 // This function compares 2 Blockchain objects to see if they are equal.

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -36,7 +36,8 @@ func GeneratePolicy(e chan events.Message, sensorName string, arch string, props
 	fileName := strings.ToLower(strings.Split(sensorName, " ")[0])
 	p := Policy_Factory("Policy for " + fileName)
 
-	p.Add_API_Spec(APISpecification_Factory("https://bluehorizon.network/documentation/"+fileName+"-device-api", "1.0.0", 1, arch))
+	p.MaxAgreements = 1
+	p.Add_API_Spec(APISpecification_Factory("https://bluehorizon.network/documentation/"+fileName+"-device-api", "1.0.0", arch))
 	p.Add_Agreement_Protocol(AgreementProtocol_Factory(CitizenScientist))
 
 	// Hardwire to existing ethereum platform
@@ -91,7 +92,6 @@ func RetrieveAllProperties(policy *Policy) (*PropertyList, error) {
 
 	*pl = append(*pl, Property{Name: "version", Value: policy.APISpecs[0].Version})
 	*pl = append(*pl, Property{Name: "arch", Value: policy.APISpecs[0].Arch})
-	*pl = append(*pl, Property{Name: "dataVerification", Value: policy.DataVerify.Enabled})
 	*pl = append(*pl, Property{Name: "agreementProtocols", Value: policy.AgreementProtocols.As_String_Array()})
 
 	return pl, nil

--- a/policy/policy_file_test.go
+++ b/policy/policy_file_test.go
@@ -297,8 +297,8 @@ func Test_Policy_Creation(t *testing.T) {
 
 	pf_created := Policy_Factory("test creation")
 
-	pf_created.Add_API_Spec(APISpecification_Factory("http://mycompany.com/dm/cpu_temp", "1.0.0", 1, "arm"))
-	pf_created.Add_API_Spec(APISpecification_Factory("http://mycompany.com/dm/gps", "1.0.0", 1, "arm"))
+	pf_created.Add_API_Spec(APISpecification_Factory("http://mycompany.com/dm/cpu_temp", "1.0.0", "arm"))
+	pf_created.Add_API_Spec(APISpecification_Factory("http://mycompany.com/dm/gps", "1.0.0", "arm"))
 
 	pf_created.Add_Agreement_Protocol(AgreementProtocol_Factory(CitizenScientist))
 	pf_created.Add_Agreement_Protocol(AgreementProtocol_Factory("2Party Bitcoin"))

--- a/policy/resourcelimit.go
+++ b/policy/resourcelimit.go
@@ -1,0 +1,52 @@
+package policy
+
+import (
+    "fmt"
+)
+
+type ResourceLimit struct {
+    NetworkUpload   int `json:"networkUpload"`   // The max network upload allowed to be consumed Kbps
+    NetworkDownload int `json:"networkDownload"` // The max network download allowed to be consumed Kbps
+    Memory          int `json:"memory"`          // The max memory allowed to be consumed MB
+    CPUs            int `json:"cpus"`            // The max number of CPUs allowed to be consumed
+}
+
+func (r ResourceLimit) String() string {
+    return fmt.Sprintf("NetworkUpload: %v, NetworkDownload: %v, Memory: %v, CPUs: %v", r.NetworkUpload, r.NetworkDownload, r.Memory, r.CPUs)
+}
+
+func (self *ResourceLimit) IsSatisfiedBy(other *ResourceLimit) bool {
+
+    // If the producer doesn't care then it is easily satisfied
+    if other.NetworkUpload != 0 && self.NetworkUpload > other.NetworkUpload {
+        return false
+    } else if other.NetworkDownload != 0 && self.NetworkDownload > other.NetworkDownload {
+        return false
+    } else if other.Memory != 0 && self.Memory > other.Memory {
+        return false
+    } else if other.CPUs != 0 && self.CPUs > other.CPUs {
+        return false
+    }
+
+    return true
+}
+
+func (self *ResourceLimit) MergeProducers(other *ResourceLimit) *ResourceLimit {
+
+    max := func(a, b int) int {
+        if a > b {
+            return a
+        } else {
+            return b
+        }
+    }
+
+    // Setup the new structure to hold the merged limits
+    merged_rl := new(ResourceLimit)
+    merged_rl.NetworkUpload = max(self.NetworkUpload, other.NetworkUpload)
+    merged_rl.NetworkDownload = max(self.NetworkDownload, other.NetworkDownload)
+    merged_rl.Memory = max(self.Memory, other.Memory)
+    merged_rl.CPUs = max(self.CPUs, other.CPUs)
+
+    return merged_rl
+}

--- a/policy/test/pfcompat1/agbot.policy
+++ b/policy/test/pfcompat1/agbot.policy
@@ -32,13 +32,6 @@
             }
         }
     ],
-    "deviceType": "12345-54321-abcdef-fedcba",
-    "valueExchange": {
-        "type": "url",
-        "value": "http://mycompany.com/data_analysis",
-        "paymentRate": 0,
-        "token": "siuwer78mvakj2ere"
-    },
     "resourceLimits": {
         "networkUpload": 1024,
         "networkDownload": 1024,
@@ -50,11 +43,6 @@
         "URL": "http://data.receipt.system.com",
         "interval": 300
     },
-    "proposalRejection": {
-        "number": 5,
-        "duration": 86400
-    },
-    "maxAgreements": 0,
     "properties": [
         {"name":"conprop1", "value":"conval1"},
         {"name":"conprop2", "value":"conval2"},
@@ -76,6 +64,5 @@
                 "networkid":["http://bhnetwork.com/networkid"]
             }
         }
-    ],
-    "requiredWorkload": null
+    ]
 }

--- a/policy/test/pfcompat1/device.policy
+++ b/policy/test/pfcompat1/device.policy
@@ -20,18 +20,12 @@
             "name": "Citizen Scientist"
         }
     ],
-    "workloads": null,
-    "deviceType": "12345-54321-abcdef-fedcba",
-    "valueExchange": null,
     "resourceLimits": {
         "networkUpload": 1024,
         "networkDownload": 1024,
         "memory": 2048,
         "cpus": 2
     },
-    "dataVerification": null,
-    "proposalRejection": null,
-    "maxAgreements": 0,
     "properties": [
         {"name":"rpiprop1", "value":"rpival1"},
         {"name":"rpiprop2", "value":"rpival2"},
@@ -54,5 +48,5 @@
             }
         }
     ],
-    "requiredWorkload": null
+    "requiredWorkload": "http://mycompany.com/workload"
 }

--- a/policy/test/pfcompat2/device1.policy
+++ b/policy/test/pfcompat2/device1.policy
@@ -21,18 +21,17 @@
             "name": "2Party Bitcoin"
         }
     ],
-    "workloads": null,
-    "deviceType": "12345-54321-abcdef-fedcba",
-    "valueExchange": null,
     "resourceLimits": {
         "networkUpload": 1024,
         "networkDownload": 1024,
         "memory": 2048,
         "cpus": 2
     },
-    "dataVerification": null,
-    "proposalRejection": null,
-    "maxAgreements": 0,
+    "dataVerification": {
+        "enabled": true,
+        "URL": "http://data.receipt.system.com",
+        "interval": 300
+    },
     "properties": [
         {"name":"rpiprop1", "value":"rpival1"},
         {"name":"rpiprop2", "value":"rpival2"},
@@ -63,6 +62,5 @@
                 "networkid":["http://bhnetwork.staging.com/networkid"]
             }
         }
-    ],
-    "requiredWorkload": null
+    ]
 }

--- a/policy/test/pfcompat2/device2.policy
+++ b/policy/test/pfcompat2/device2.policy
@@ -18,18 +18,17 @@
             "name": "2Party Bitcoin"
         }
     ],
-    "workloads": null,
-    "deviceType": "12345-54321-abcdef-fedcba",
-    "valueExchange": null,
     "resourceLimits": {
         "networkUpload": 1024,
         "networkDownload": 1024,
         "memory": 2048,
         "cpus": 2
     },
-    "dataVerification": null,
-    "proposalRejection": null,
-    "maxAgreements": 0,
+    "dataVerification": {
+        "enabled": true,
+        "URL": "http://data.receipt.system.com",
+        "interval": 300
+    },
     "properties": [
         {"name":"rpiprop1", "value":"rpival1"},
         {"name":"rpiprop4", "value":"rpival4"},
@@ -69,6 +68,5 @@
                 "networkid":["http://bhnetwork.staging.com/networkid"]
             }
         }
-    ],
-    "requiredWorkload": null
+    ]
 }

--- a/policy/test/pfcompat2/expecting.policy
+++ b/policy/test/pfcompat2/expecting.policy
@@ -8,14 +8,12 @@
             "specRef": "http://mycompany.com/dm/cpu_temp",
             "version": "[1.0.0,2.0.0)",
             "exclusiveAccess": false,
-            "numberAgreements": 0,
             "arch": ""
         },
         {
             "specRef": "http://mycompany.com/dm/gps",
             "version": "[1.0.0,2.0.0)",
             "exclusiveAccess": false,
-            "numberAgreements": 0,
             "arch": ""
         }
     ],
@@ -27,8 +25,6 @@
             "name": "2Party Bitcoin"
         }
     ],
-    "workloads": null,
-    "deviceType": "",
     "valueExchange": {
         "type": "",
         "value": "",
@@ -36,21 +32,20 @@
         "token": ""
     },
     "resourceLimits": {
-        "networkUpload": 0,
-        "networkDownload": 0,
-        "memory": 0,
-        "cpus": 0
+        "networkUpload": 1024,
+        "networkDownload": 1024,
+        "memory": 2048,
+        "cpus": 2
     },
     "dataVerification": {
-        "enabled": false,
-        "URL": "",
-        "interval": 0
+        "enabled": true,
+        "URL": "http://data.receipt.system.com",
+        "interval": 300
     },
     "proposalRejection": {
         "number": 0,
         "duration": 0
     },
-    "maxAgreements": 0,
     "properties": [
         {
             "name": "rpiprop1",
@@ -136,6 +131,5 @@
                 ]
             }
         }
-    ],
-    "requiredWorkload": ""
+    ]
 }

--- a/policy/test/pfcompat2/merged.policy
+++ b/policy/test/pfcompat2/merged.policy
@@ -8,14 +8,12 @@
             "specRef": "http://mycompany.com/dm/cpu_temp",
             "version": "[1.0.0,2.0.0)",
             "exclusiveAccess": false,
-            "numberAgreements": 0,
             "arch": ""
         },
         {
             "specRef": "http://mycompany.com/dm/gps",
             "version": "[1.0.0,2.0.0)",
             "exclusiveAccess": false,
-            "numberAgreements": 0,
             "arch": ""
         }
     ],
@@ -27,8 +25,6 @@
             "name": "2Party Bitcoin"
         }
     ],
-    "workloads": null,
-    "deviceType": "",
     "valueExchange": {
         "type": "",
         "value": "",
@@ -36,21 +32,20 @@
         "token": ""
     },
     "resourceLimits": {
-        "networkUpload": 0,
-        "networkDownload": 0,
-        "memory": 0,
-        "cpus": 0
+        "networkUpload": 1024,
+        "networkDownload": 1024,
+        "memory": 2048,
+        "cpus": 2
     },
     "dataVerification": {
-        "enabled": false,
-        "URL": "",
-        "interval": 0
+        "enabled": true,
+        "URL": "http://data.receipt.system.com",
+        "interval": 300
     },
     "proposalRejection": {
         "number": 0,
         "duration": 0
     },
-    "maxAgreements": 0,
     "properties": [
         {
             "name": "rpiprop1",
@@ -136,6 +131,5 @@
                 ]
             }
         }
-    ],
-    "requiredWorkload": ""
+    ]
 }

--- a/policy/test/pfcreate/created.policy
+++ b/policy/test/pfcreate/created.policy
@@ -8,14 +8,12 @@
             "specRef": "http://mycompany.com/dm/cpu_temp",
             "version": "1.0.0",
             "exclusiveAccess": true,
-            "numberAgreements": 1,
             "arch": "arm"
         },
         {
             "specRef": "http://mycompany.com/dm/gps",
             "version": "1.0.0",
             "exclusiveAccess": true,
-            "numberAgreements": 1,
             "arch": "arm"
         }
     ],
@@ -27,8 +25,6 @@
             "name": "2Party Bitcoin"
         }
     ],
-    "workloads": null,
-    "deviceType": "",
     "valueExchange": {
         "type": "",
         "value": "",
@@ -50,7 +46,6 @@
         "number": 0,
         "duration": 0
     },
-    "maxAgreements": 0,
     "properties": [
         {
             "name": "rpiprop1",
@@ -73,7 +68,6 @@
             "value": "rpival5"
         }
     ],
-    "counterPartyProperties": null,
     "blockchains": [
         {
             "type": "ethereum",
@@ -109,6 +103,5 @@
                 ]
             }
         }
-    ],
-    "requiredWorkload": ""
+    ]
 }

--- a/policy/test/pfcreate/expecting.policy
+++ b/policy/test/pfcreate/expecting.policy
@@ -8,14 +8,12 @@
             "specRef": "http://mycompany.com/dm/cpu_temp",
             "version": "1.0.0",
             "exclusiveAccess": true,
-            "numberAgreements": 1,
             "arch": "arm"
         },
         {
             "specRef": "http://mycompany.com/dm/gps",
             "version": "1.0.0",
             "exclusiveAccess": true,
-            "numberAgreements": 1,
             "arch": "arm"
         }
     ],
@@ -27,8 +25,6 @@
             "name": "2Party Bitcoin"
         }
     ],
-    "workloads": null,
-    "deviceType": "",
     "valueExchange": {
         "type": "",
         "value": "",
@@ -50,7 +46,6 @@
         "number": 0,
         "duration": 0
     },
-    "maxAgreements": 0,
     "properties": [
         {
             "name": "rpiprop1",
@@ -73,7 +68,6 @@
             "value": "rpival5"
         }
     ],
-    "counterPartyProperties": null,
     "blockchains": [
         {
             "type": "ethereum",
@@ -109,6 +103,5 @@
                 ]
             }
         }
-    ],
-    "requiredWorkload": ""
+    ]
 }

--- a/policy/test/pfmerge1/agbot.policy
+++ b/policy/test/pfmerge1/agbot.policy
@@ -7,7 +7,8 @@
         {
             "specRef": "http://mycompany.com/dm/cpu_temp",
             "version": "1.0.1",
-            "exclusiveAccess": false
+            "exclusiveAccess": true,
+            "arch": "amd64"
         }
     ],
     "agreementProtocols": [
@@ -32,13 +33,6 @@
             }
         }
     ],
-    "deviceType": "12345-54321-abcdef-fedcba",
-    "valueExchange": {
-        "type": "url",
-        "value": "http://mycompany.com/data_analysis",
-        "paymentRate": 0,
-        "token": "siuwer78mvakj2ere"
-    },
     "resourceLimits": {
         "networkUpload": 1024,
         "networkDownload": 1024,
@@ -50,11 +44,6 @@
         "URL": "http://data.receipt.system.com",
         "interval": 300
     },
-    "proposalRejection": {
-        "number": 5,
-        "duration": 86400
-    },
-    "maxAgreements": 0,
     "properties": [
         {"name":"conprop1", "value":"conval1"},
         {"name":"conprop2", "value":"conval2"},
@@ -66,6 +55,7 @@
             {"name":"rpiprop2", "value":"rpival2"}
         ]
     },
+    "maxAgreements": 3,
     "blockchains": [
         {
             "type":"ethereum",
@@ -76,6 +66,5 @@
                 "networkid":["http://bhnetwork.com/networkid"]
             }
         }
-    ],
-    "requiredWorkload": null
+    ]
 }

--- a/policy/test/pfmerge1/device.policy
+++ b/policy/test/pfmerge1/device.policy
@@ -7,7 +7,8 @@
         {
             "specRef": "http://mycompany.com/dm/cpu_temp",
             "version": "[1.0.0,2.0.0)",
-            "exclusiveAccess": false
+            "exclusiveAccess": true,
+            "arch": "amd64"
         },
         {
             "specRef": "http://mycompany.com/dm/gps",
@@ -20,18 +21,12 @@
             "name": "Citizen Scientist"
         }
     ],
-    "workloads": null,
-    "deviceType": "12345-54321-abcdef-fedcba",
-    "valueExchange": null,
     "resourceLimits": {
         "networkUpload": 1024,
         "networkDownload": 1024,
         "memory": 2048,
         "cpus": 2
     },
-    "dataVerification": null,
-    "proposalRejection": null,
-    "maxAgreements": 0,
     "properties": [
         {"name":"rpiprop1", "value":"rpival1"},
         {"name":"rpiprop2", "value":"rpival2"},
@@ -54,5 +49,5 @@
             }
         }
     ],
-    "requiredWorkload": null
+    "requiredWorkload": "http://mycompany.com/workload1"
 }

--- a/policy/test/pfmerge1/expecting.policy
+++ b/policy/test/pfmerge1/expecting.policy
@@ -7,9 +7,8 @@
         {
             "specRef": "http://mycompany.com/dm/cpu_temp",
             "version": "1.0.1",
-            "exclusiveAccess": false,
-            "numberAgreements": 0,
-            "arch": ""
+            "exclusiveAccess": true,
+            "arch": "amd64"
         }
     ],
     "agreementProtocols": [
@@ -33,31 +32,53 @@
             }
         }
     ],
-    "deviceType": "",
     "valueExchange": {
-        "type": "url",
-        "value": "http://mycompany.com/data_analysis",
+        "type": "",
+        "value": "",
         "paymentRate": 0,
-        "token": "siuwer78mvakj2ere"
+        "token": ""
     },
     "resourceLimits": {
-        "networkUpload": 0,
-        "networkDownload": 0,
-        "memory": 0,
-        "cpus": 0
+        "networkUpload": 1024,
+        "networkDownload": 1024,
+        "memory": 2048,
+        "cpus": 2
     },
     "dataVerification": {
-        "enabled": false,
-        "URL": "",
-        "interval": 0
+        "enabled": true,
+        "URL": "http://data.receipt.system.com",
+        "interval": 300
     },
     "proposalRejection": {
         "number": 0,
         "duration": 0
     },
-    "maxAgreements": 0,
-    "properties": null,
-    "counterPartyProperties": null,
+    "properties": [
+        {
+            "name": "conprop1",
+            "value": "conval1"
+        },
+        {
+            "name": "conprop2",
+            "value": "conval2"
+        },
+        {
+            "name": "conprop3",
+            "value": "conval3"
+        },
+        {
+            "name": "rpiprop1",
+            "value": "rpival1"
+        },
+        {
+            "name": "rpiprop2",
+            "value": "rpival2"
+        },
+        {
+            "name": "rpiprop3",
+            "value": "rpival3"
+        }
+    ],
     "blockchains": [
         {
             "type": "ethereum",
@@ -77,5 +98,5 @@
             }
         }
     ],
-    "requiredWorkload": ""
+    "requiredWorkload": "http://mycompany.com/workload1"
 }

--- a/policy/test/pfmerge1/merged.policy
+++ b/policy/test/pfmerge1/merged.policy
@@ -7,9 +7,8 @@
         {
             "specRef": "http://mycompany.com/dm/cpu_temp",
             "version": "1.0.1",
-            "exclusiveAccess": false,
-            "numberAgreements": 0,
-            "arch": ""
+            "exclusiveAccess": true,
+            "arch": "amd64"
         }
     ],
     "agreementProtocols": [
@@ -33,31 +32,53 @@
             }
         }
     ],
-    "deviceType": "",
     "valueExchange": {
-        "type": "url",
-        "value": "http://mycompany.com/data_analysis",
+        "type": "",
+        "value": "",
         "paymentRate": 0,
-        "token": "siuwer78mvakj2ere"
+        "token": ""
     },
     "resourceLimits": {
-        "networkUpload": 0,
-        "networkDownload": 0,
-        "memory": 0,
-        "cpus": 0
+        "networkUpload": 1024,
+        "networkDownload": 1024,
+        "memory": 2048,
+        "cpus": 2
     },
     "dataVerification": {
-        "enabled": false,
-        "URL": "",
-        "interval": 0
+        "enabled": true,
+        "URL": "http://data.receipt.system.com",
+        "interval": 300
     },
     "proposalRejection": {
         "number": 0,
         "duration": 0
     },
-    "maxAgreements": 0,
-    "properties": null,
-    "counterPartyProperties": null,
+    "properties": [
+        {
+            "name": "conprop1",
+            "value": "conval1"
+        },
+        {
+            "name": "conprop2",
+            "value": "conval2"
+        },
+        {
+            "name": "conprop3",
+            "value": "conval3"
+        },
+        {
+            "name": "rpiprop1",
+            "value": "rpival1"
+        },
+        {
+            "name": "rpiprop2",
+            "value": "rpival2"
+        },
+        {
+            "name": "rpiprop3",
+            "value": "rpival3"
+        }
+    ],
     "blockchains": [
         {
             "type": "ethereum",
@@ -77,5 +98,5 @@
             }
         }
     ],
-    "requiredWorkload": ""
+    "requiredWorkload": "http://mycompany.com/workload1"
 }

--- a/policy/test/pftest/echo.policy
+++ b/policy/test/pftest/echo.policy
@@ -8,7 +8,6 @@
             "specRef": "http://mycompany.com/policy",
             "version": "[1.0.0,2.0.0)",
             "exclusiveAccess": false,
-            "numberAgreements": 0,
             "arch": ""
         }
     ],
@@ -54,10 +53,5 @@
     "proposalRejection": {
         "number": 5,
         "duration": 86400
-    },
-    "maxAgreements": 0,
-    "properties": null,
-    "counterPartyProperties": null,
-    "blockchains": null,
-    "requiredWorkload": ""
+    }
 }

--- a/policy/test/pftest/test1.policy
+++ b/policy/test/pftest/test1.policy
@@ -8,7 +8,6 @@
             "specRef": "http://mycompany.com/policy",
             "version": "[1.0.0,2.0.0)",
             "exclusiveAccess": false,
-            "numberAgreements": 0,
             "arch": ""
         }
     ],
@@ -54,10 +53,5 @@
     "proposalRejection": {
         "number": 5,
         "duration": 86400
-    },
-    "maxAgreements": 0,
-    "properties": null,
-    "counterPartyProperties": null,
-    "blockchains": null,
-    "requiredWorkload": ""
+    }
 }


### PR DESCRIPTION
Aside from enabling data verification (when specified in agbot policy files) and porting the code from v1 agbot, I also fixed some other stuff that has been bothering me:
1) cleaned up level3 and level 5 logging
2) put all the agbot persistence records into a bucket with a name that includes the agreement protocol name so that we can support more than 1 of those in the future
3) added checks to ignore policies that advertise the ethereum_account property (when the agbot is configured to do this)