### PR TITLE
also fixed dv bug and gov bug

### DIFF
--- a/agreementbot/activecontracts.go
+++ b/agreementbot/activecontracts.go
@@ -9,7 +9,6 @@ import (
     "github.com/open-horizon/anax/config"
     "net/http"
     "os"
-    "strings"
     "time"
 )
 
@@ -92,7 +91,7 @@ func ActiveAgreementsContains(activeAgreements []string, agreement Agreement, pr
     }
 
     for _, dev := range activeAgreements {
-        if dev == agreement.CurrentAgreementId || (prefix != "" && strings.Contains(dev, prefix)) {
+        if dev == agreement.CurrentAgreementId || dev == prefix + agreement.CurrentAgreementId {
             return true
         }
     }

--- a/agreementbot/build/Makefile
+++ b/agreementbot/build/Makefile
@@ -2,7 +2,7 @@ SHELL = /bin/bash -e
 
 ARCH = $(shell ./tools/arch-tag)
 DOCKER_REGISTRY ?= summit.hovitos.engineering
-DOCKER_TAG ?= v2.0.0
+DOCKER_TAG ?= v2.0.1
 DOCKER_OPTS ?= --no-cache
 COMPILE_CLEAN ?= clean
 

--- a/exchange/rpc.go
+++ b/exchange/rpc.go
@@ -170,9 +170,9 @@ func (p PutDeviceRequest) ShortString() string {
 func CreateSearchRequest() *SearchExchangeRequest {
 
 	ser := &SearchExchangeRequest{
-		DaysStale:  0,
+		DaysStale:  1,
 		StartIndex:  0,
-		NumEntries: 10,
+		NumEntries: 100,
 	}
 
 	return ser


### PR DESCRIPTION
1. Device API URL missing from agbot agreement status in exchange. Fixed that in gov when finalized state is set.
2. Gov cancelled agreement while it was being formed. Fixed that so that it only scans for db records with formed agreements.
3. Data verification should have been checking for specific agreement ids with the backdoor prefix, not any agreement id with a backdoor prefix.