### PR TITLE
find by api spec URL

### DIFF
--- a/policy/api_spec_list.go
+++ b/policy/api_spec_list.go
@@ -94,3 +94,13 @@ func (self *APISpecList) Add_API_Spec(new_ele *APISpecification) error {
 	(*self) = append(*self, *new_ele)
 	return nil
 }
+
+// This function return true if an api spec list contains the input spec ref url
+func (self APISpecList) ContainsSpecRef(url string) bool {
+	for _, ele := range self {
+		if ele.SpecRef == url {
+			return true
+		}
+	}
+	return false
+}

--- a/policy/api_spec_list_test.go
+++ b/policy/api_spec_list_test.go
@@ -175,3 +175,81 @@ func Test_APISpecification_subset_not_found(t *testing.T) {
 	}
 
 }
+
+// Third, some positive tests for the API Spec search
+func Test_APISpecification_contains_specref(t *testing.T) {
+	var as1 *APISpecList
+	asString := `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"arch":"arm"}]`
+
+	searchURL := "http://mycompany.com/dm/gps"
+	if as1 = create_APISpecification(asString, t); as1 != nil {
+		if !(*as1).ContainsSpecRef(searchURL) {
+			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
+		}
+	}
+
+	asString = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"arch":"arm"},
+				{"specRef": "http://mycompany.com/dm/cpu","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"arch":"arm"},
+				{"specRef": "http://mycompany.com/dm/net","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"arch":"arm"}]`
+
+	searchURL = "http://mycompany.com/dm/net"
+	if as1 = create_APISpecification(asString, t); as1 != nil {
+		if !(*as1).ContainsSpecRef(searchURL) {
+			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
+		}
+	}
+
+	searchURL = "http://mycompany.com/dm/gps"
+	if as1 = create_APISpecification(asString, t); as1 != nil {
+		if !(*as1).ContainsSpecRef(searchURL) {
+			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
+		}
+	}
+
+	searchURL = "http://mycompany.com/dm/cpu"
+	if as1 = create_APISpecification(asString, t); as1 != nil {
+		if !(*as1).ContainsSpecRef(searchURL) {
+			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
+		}
+	}
+}
+
+// Fourth, some negative tests for the API Spec search
+func Test_APISpecification_not_contains_specref(t *testing.T) {
+	var as1 *APISpecList
+	asString := `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"arch":"arm"}]`
+
+	searchURL := "http://mycompany.com/dm/net"
+	if as1 = create_APISpecification(asString, t); as1 != nil {
+		if (*as1).ContainsSpecRef(searchURL) {
+			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
+		}
+	}
+
+	asString = `[{"specRef": "http://mycompany.com/dm/gps","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"arch":"arm"},
+				{"specRef": "http://mycompany.com/dm/cpu","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"arch":"arm"},
+				{"specRef": "http://mycompany.com/dm/net","version": "[1.0.0,2.0.0)","exclusiveAccess": false,"arch":"arm"}]`
+
+	searchURL = "http://mycompany.com/dm/nit"
+	if as1 = create_APISpecification(asString, t); as1 != nil {
+		if (*as1).ContainsSpecRef(searchURL) {
+			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
+		}
+	}
+
+	searchURL = ""
+	if as1 = create_APISpecification(asString, t); as1 != nil {
+		if (*as1).ContainsSpecRef(searchURL) {
+			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
+		}
+	}
+
+	asString = `[]`
+
+	searchURL = "http://mycompany.com/dm/nit"
+	if as1 = create_APISpecification(asString, t); as1 != nil {
+		if (*as1).ContainsSpecRef(searchURL) {
+			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
+		}
+	}
+}

--- a/policy/policy_manager.go
+++ b/policy/policy_manager.go
@@ -325,6 +325,35 @@ func (self *PolicyManager) GetPolicy(name string) *Policy {
 	return nil
 }
 
+// This function returns the set of policy objects that contains contain the input device URL.
+func (self *PolicyManager) GetPolicyByURL(url string) []Policy {
+
+	res := make([]Policy, 0, 10)
+	self.PolicyLock.Lock()
+	defer self.PolicyLock.Unlock()
+	for _, pol := range self.Policies {
+		if pol.APISpecs.ContainsSpecRef(url) {
+			res = append(res, *pol)
+		}
+	}
+	return res
+}
+
+// This function deletes a policy by URL
+func (self *PolicyManager) DeletePolicyByURL(url string) error {
+
+	self.PolicyLock.Lock()
+	defer self.PolicyLock.Unlock()
+	for _, pol := range self.Policies {
+		if pol.APISpecs.ContainsSpecRef(url) {
+			// save the policy name
+			// Delete this policy - compress the array
+			// Remove the agreement counts by policy name
+		}
+	}
+	return errors.New("Not implemented yet")
+}
+
 func (self *PolicyManager) GetAllAgreementProtocols() map[string]bool {
 	protocols := make(map[string]bool)
 	self.PolicyLock.Lock()

--- a/policy/policy_manager_test.go
+++ b/policy/policy_manager_test.go
@@ -181,3 +181,28 @@ func Test_contractCounter_failure1(t *testing.T) {
 		}
 	}
 }
+
+func Test_find_by_apispec1(t *testing.T) {
+
+	if pm, err := Initialize("./test/pfcompat1/"); err != nil {
+		t.Error(err)
+	} else {
+		searchURL := "http://mycompany.com/dm/gps"
+		pols := pm.GetPolicyByURL(searchURL)
+		if len(pols) != 1 {
+			t.Errorf("Expected to find 1 policy, found %v", len(pols))
+		}
+
+		searchURL = "http://mycompany.com/dm/cpu_temp"
+		pols = pm.GetPolicyByURL(searchURL)
+		if len(pols) != 2 {
+			t.Errorf("Expected to find 2 policies, found %v", len(pols))
+		}
+
+		searchURL = ""
+		pols = pm.GetPolicyByURL(searchURL)
+		if len(pols) != 0 {
+			t.Errorf("Expected to find 0 policies, found %v", len(pols))
+		}
+	}
+}


### PR DESCRIPTION
1. Find policy by API Spec URL, complete and tested.
2. Delete policy by Spec URL, created but returns "not implemented" error. Will take a lot more work complete.