### PR TITLE
exploit new seconds stale on search

### DIFF
--- a/agreement/agreement.go
+++ b/agreement/agreement.go
@@ -44,6 +44,11 @@ func NewAgreementWorker(config *config.HorizonConfig, db *bolt.DB, pm *policy.Po
 
 	id, _ := device.Id()
 
+	token := ""
+	if dev, _ := persistence.FindExchangeDevice(db); dev != nil {
+		token = dev.Token
+	}
+
 	worker := &AgreementWorker{
 		Worker: worker.Worker{
 			Manager: worker.Manager{
@@ -60,9 +65,7 @@ func NewAgreementWorker(config *config.HorizonConfig, db *bolt.DB, pm *policy.Po
 		pm:         pm,
 		bcClientInitialized: false,
 		deviceId:   id,
-
-		// TODO: this needs to be read from the db and "token_valid" set to false (using persistence.InvalidateExchangeDeviceToken)
-		deviceToken: "", // set by incoming event or read from database directly
+		deviceToken: token,
 	}
 
 	glog.Info("Starting Agreement worker")

--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -394,6 +394,7 @@ func (w *AgreementBotWorker) searchExchange(pol *policy.Policy) (*[]exchange.Dev
 	}
 
 	ser := exchange.CreateSearchRequest()
+	ser.SecondsStale = w.Config.AgreementBot.ActiveDeviceTimeoutS
 	ser.DesiredMicroservices = append(ms, *newMS)
 
 	var resp interface{}

--- a/agreementbot/build/Makefile
+++ b/agreementbot/build/Makefile
@@ -2,7 +2,7 @@ SHELL = /bin/bash -e
 
 ARCH = $(shell ./tools/arch-tag)
 DOCKER_REGISTRY ?= summit.hovitos.engineering
-DOCKER_TAG ?= v2.0.1
+DOCKER_TAG ?= v2.0.2
 DOCKER_OPTS ?= --no-cache
 COMPILE_CLEAN ?= clean
 

--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,7 @@ type AGConfig struct {
 	ExchangeId                   string // The id of the agbot, not the userid of the exchange user
 	ExchangeToken                string // The agbot's authentication token
 	DVPrefix                     string // When looking for agreement ids in the data verification API response, look for agreement ids with this prefix.
+	ActiveDeviceTimeoutS         int    // The amount of time a device can go without heartbeating and still be considered active for the purposes of search
 
 }
 

--- a/exchange/rpc.go
+++ b/exchange/rpc.go
@@ -46,14 +46,14 @@ func (m Microservice) ShortString() string {
 
 type SearchExchangeRequest struct {
 	DesiredMicroservices []Microservice `json:"desiredMicroservices"`
-	DaysStale            int            `json:"daysStale"`
+	SecondsStale         int            `json:"secondsStale"`
 	PropertiesToReturn   []string       `json:"propertiesToReturn"`
 	StartIndex           int            `json:"startIndex"`
 	NumEntries           int            `json:"numEntries"`
 }
 
 func (a SearchExchangeRequest) String() string {
-	return fmt.Sprintf("Microservices: %v, DaysStale: %v, PropertiesToReturn: %v, StartIndex: %v, NumEntries: %v", a.DesiredMicroservices, a.DaysStale, a.PropertiesToReturn, a.StartIndex, a.NumEntries)
+	return fmt.Sprintf("Microservices: %v, SecondsStale: %v, PropertiesToReturn: %v, StartIndex: %v, NumEntries: %v", a.DesiredMicroservices, a.SecondsStale, a.PropertiesToReturn, a.StartIndex, a.NumEntries)
 }
 
 type Device struct {
@@ -170,7 +170,6 @@ func (p PutDeviceRequest) ShortString() string {
 func CreateSearchRequest() *SearchExchangeRequest {
 
 	ser := &SearchExchangeRequest{
-		DaysStale:  1,
 		StartIndex:  0,
 		NumEntries: 100,
 	}

--- a/governance/governance.go
+++ b/governance/governance.go
@@ -55,6 +55,11 @@ func NewGovernanceWorker(config *config.HorizonConfig, db *bolt.DB, pm *policy.P
 
 	id, _ := device.Id()
 
+	token := ""
+	if dev, _ := persistence.FindExchangeDevice(db); dev != nil {
+		token = dev.Token
+	}
+
 	worker := &GovernanceWorker{
 
 		Worker: worker.Worker{
@@ -69,8 +74,7 @@ func NewGovernanceWorker(config *config.HorizonConfig, db *bolt.DB, pm *policy.P
 		db:              db,
 		pm:              pm,
 		deviceId: id,
-		// TODO: this needs to be read from the db and "token_valid" set to false (using persistence.InvalidateExchangeDeviceToken)
-		deviceToken: "", // set by incoming event or read from database directly
+		deviceToken: token,
 		bcWritesEnabled: false,
 	}
 


### PR DESCRIPTION
1. Updated agbot to exploit secondsStale filter on device search API
2. Found and fixed a bug where anax doesnt pick up its device token from it's db when it restarts.