### PR TITLE
workload password hash passed to workload

### DIFF
--- a/agreement/agreement.go
+++ b/agreement/agreement.go
@@ -270,7 +270,8 @@ func (w *AgreementWorker) RecordReply(proposal *citizenscientist.Proposal, reply
 				}
 				envAdds[config.ENVVAR_PREFIX+"AGREEMENTID"] = proposal.AgreementId
 				envAdds[config.ENVVAR_PREFIX+"CONTRACT"] = w.Config.Edge.DVPrefix + proposal.AgreementId
-				envAdds[config.ENVVAR_PREFIX+"CONFIGURE_NONCE"] = proposal.AgreementId
+				envAdds[config.ENVVAR_PREFIX+"CONFIGURE_NONCE"] = tcPolicy.Workloads[0].WorkloadPassword
+				envAdds["HZN_HASH"] = tcPolicy.Workloads[0].WorkloadPassword
 				// For workload compatibility, the DEVICE_ID env var is passed with and without the prefix. We would like to drop
 				// the env var without prefix once all the workloads have ben updated.
 				envAdds["DEVICE_ID"] = w.deviceId
@@ -418,6 +419,7 @@ func (w *AgreementWorker) advertiseAllPolicies(location string) error {
 			newMS.Url = p.APISpecs[0].SpecRef
 			newMS.NumAgreements = p.MaxAgreements
 
+			p.DataVerify.Obscure()
 			if pBytes, err := json.Marshal(p); err != nil {
 				return errors.New(fmt.Sprintf("AgreementWorker received error marshalling policy: %v", err))
 			} else {

--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -128,7 +128,7 @@ func (a *CSAgreementWorker) start(work chan CSAgreementWork, random *rand.Rand, 
 				glog.Errorf(logString(fmt.Sprintf("error persisting agreement attempt: %v", err)))
 
 				// Initiate the protocol
-			} else if proposal, err := protocolHandler.InitiateAgreement(agreementId, &wi.ProducerPolicy, &wi.ConsumerPolicy, &wi.Device, myAddress, a.agbotId); err != nil {
+			} else if proposal, err := protocolHandler.InitiateAgreement(agreementIdString, &wi.ProducerPolicy, &wi.ConsumerPolicy, &wi.Device, myAddress, a.agbotId); err != nil {
 				glog.Errorf(logString(fmt.Sprintf("error initiating agreement: %v", err)))
 
 				// Remove pending agreement from database
@@ -143,7 +143,7 @@ func (a *CSAgreementWorker) start(work chan CSAgreementWork, random *rand.Rand, 
 				glog.Errorf(logString(fmt.Sprintf("error marshalling policy for storage %v, error: %v", wi.ConsumerPolicy, err)))
 			} else if pBytes, err := json.Marshal(proposal); err != nil {
 				glog.Errorf(logString(fmt.Sprintf("error marshalling proposal for storage %v, error: %v", *proposal, err)))
-			} else if _, err := AgreementUpdate(a.db, agreementIdString, string(pBytes), string(polBytes), wi.ConsumerPolicy.DataVerify.URL, !wi.ConsumerPolicy.Get_DataVerification_enabled(), citizenscientist.PROTOCOL_NAME); err != nil {
+			} else if _, err := AgreementUpdate(a.db, agreementIdString, string(pBytes), string(polBytes), wi.ConsumerPolicy.DataVerify.URL, wi.ConsumerPolicy.DataVerify.URLUser, wi.ConsumerPolicy.DataVerify.URLPassword, !wi.ConsumerPolicy.Get_DataVerification_enabled(), citizenscientist.PROTOCOL_NAME); err != nil {
 				glog.Errorf(logString(fmt.Sprintf("error updating agreement with proposal %v in DB, error: %v", *proposal, err)))
 
 				// Record that the agreement was initiated, in the exchange

--- a/agreementbot/persistence.go
+++ b/agreementbot/persistence.go
@@ -25,12 +25,14 @@ type Agreement struct {
 	PolicyName                    string `json:"policy_name"`                      // The name of the policy for this agreement, policy names are unique
 	CounterPartyAddress           string `json:"counter_party_address"`            // The blockchain address of the counterparty in the agreement
 	DataVerificationURL           string `json:"data_verification_URL"`            // The URL to use to ensure that this agreement is sending data.
+	DataVerificationUser          string `json:"data_verification_user"`           // The user to use with the DataVerificationURL
+	DataVerificationPW            string `json:"data_verification_pw"`             // The pw of the data verification user
 	DisableDataVerificationChecks bool   `json:"disable_data_verification_checks"` // disable data verification checks, assume data is being sent.
 	DataVerifiedTime              uint64 `json:"data_verification_time"`           // The last time that data verification was successful
 }
 
 func (a Agreement) String() string {
-	return fmt.Sprintf("CurrentAgreementId: %v, DeviceId: %v, AgreementInceptionTime: %v, AgreementCreationTime: %v, AgreementFinalizedTime: %v, AgreementTimedout: %v, ProposalSig: %v, Policy Name: %v, CounterPartyAddress: %v, DataVerificationURL: %v, DisableDataVerification: %v, DataVerifiedTime: %v", a.CurrentAgreementId, a.DeviceId, a.AgreementInceptionTime, a.AgreementCreationTime, a.AgreementFinalizedTime, a.AgreementTimedout, a.ProposalSig, a.PolicyName, a.CounterPartyAddress, a.DataVerificationURL, a.DisableDataVerificationChecks, a.DataVerifiedTime)
+	return fmt.Sprintf("CurrentAgreementId: %v, DeviceId: %v, AgreementInceptionTime: %v, AgreementCreationTime: %v, AgreementFinalizedTime: %v, AgreementTimedout: %v, ProposalSig: %v, Policy Name: %v, CounterPartyAddress: %v, DataVerificationURL: %v, DataVerificationUser: %v, DisableDataVerification: %v, DataVerifiedTime: %v", a.CurrentAgreementId, a.DeviceId, a.AgreementInceptionTime, a.AgreementCreationTime, a.AgreementFinalizedTime, a.AgreementTimedout, a.ProposalSig, a.PolicyName, a.CounterPartyAddress, a.DataVerificationURL, a.DataVerificationUser, a.DisableDataVerificationChecks, a.DataVerifiedTime)
 }
 
 // private factory method for agreement w/out persistence safety:
@@ -52,6 +54,8 @@ func agreement(agreementid string, deviceid string, policyName string, agreement
 			PolicyName:                    policyName,
 			CounterPartyAddress:           "",
 			DataVerificationURL:           "",
+			DataVerificationUser:          "",
+			DataVerificationPW:            "",
 			DisableDataVerificationChecks: false,
 			DataVerifiedTime:              0,
 		}, nil
@@ -68,12 +72,14 @@ func AgreementAttempt(db *bolt.DB, agreementid string, deviceid string, policyNa
 	}
 }
 
-func AgreementUpdate(db *bolt.DB, agreementid string, proposal string, policy string, url string, checks bool, protocol string) (*Agreement, error) {
+func AgreementUpdate(db *bolt.DB, agreementid string, proposal string, policy string, url string, user string, pw string, checks bool, protocol string) (*Agreement, error) {
 	if agreement, err := singleAgreementUpdate(db, agreementid, protocol, func(a Agreement) *Agreement {
 		a.AgreementCreationTime = uint64(time.Now().Unix())
 		a.Proposal = proposal
 		a.Policy = policy
 		a.DataVerificationURL = url
+		a.DataVerificationUser = user
+		a.DataVerificationPW = pw
 		a.DisableDataVerificationChecks = checks
 		a.DataVerifiedTime = uint64(time.Now().Unix())
 		return &a
@@ -182,6 +188,8 @@ func persistUpdatedAgreement(db *bolt.DB, agreementid string, protocol string, u
 				mod.PolicyName = update.PolicyName
 				mod.ProposalSig = update.ProposalSig
 				mod.DataVerificationURL = update.DataVerificationURL
+				mod.DataVerificationUser = update.DataVerificationUser
+				mod.DataVerificationPW = update.DataVerificationPW
 				mod.DisableDataVerificationChecks = update.DisableDataVerificationChecks
 				mod.DataVerifiedTime = update.DataVerifiedTime
 

--- a/citizenscientist/protocol.go
+++ b/citizenscientist/protocol.go
@@ -93,9 +93,9 @@ func NewProtocolHandler(gethURL string, pm *policy.PolicyManager) *ProtocolHandl
 	}
 }
 
-func (p *ProtocolHandler) InitiateAgreement(agreementId []byte, producerPolicy *policy.Policy, consumerPolicy *policy.Policy, device *exchange.Device, myAddress string, myId string) (*Proposal, error) {
+func (p *ProtocolHandler) InitiateAgreement(agreementId string, producerPolicy *policy.Policy, consumerPolicy *policy.Policy, device *exchange.Device, myAddress string, myId string) (*Proposal, error) {
 
-	if TCPolicy, err := policy.Create_Terms_And_Conditions(producerPolicy, consumerPolicy); err != nil {
+	if TCPolicy, err := policy.Create_Terms_And_Conditions(producerPolicy, consumerPolicy, agreementId); err != nil {
 		return nil, errors.New(fmt.Sprintf("CS Protocol initiation received error trying to merge policy %v and %v, error: %v", producerPolicy, consumerPolicy, err))
 	} else {
 		glog.V(5).Infof("Merged Policy %v", *TCPolicy)
@@ -109,7 +109,7 @@ func (p *ProtocolHandler) InitiateAgreement(agreementId []byte, producerPolicy *
 			newProposal.Type = MsgTypeProposal
 			newProposal.TsAndCs = string(tcBytes)
 			newProposal.ProducerPolicy = string(prodBytes)
-			newProposal.AgreementId = hex.EncodeToString(agreementId)
+			newProposal.AgreementId = agreementId
 			newProposal.Address = myAddress
 			newProposal.ConsumerId = myId
 

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,8 @@ type AGConfig struct {
 	AgreementTimeoutS            uint64 // Number of seconds to wait before declaring agreement not finalized in blockchain
 	NoDataIntervalS              uint64 // default should be 15 mins == 15*60 == 900. Ignored if the policy has data verification disabled.
 	ActiveAgreementsURL          string // This field is used when policy files indicate they want data verification but they dont specify a URL
+	ActiveAgreementsUser         string // This is the userid the agbot uses to authenticate to the data verifivcation API
+	ActiveAgreementsPW           string // This is the password for the ActiveAgreementsUser
 	PolicyPath                   string // The directory where policy files are kept, default /etc/provider-tremor/policy/
 	NewContractIntervalS         uint64 // default should be 1
 	ProcessGovernanceIntervalS   uint64 // How long the gov sleeps before general gov checks (new payloads, interval payments, etc).

--- a/policy/data_verification.go
+++ b/policy/data_verification.go
@@ -1,0 +1,29 @@
+package policy
+
+import (
+	"fmt"
+)
+
+type DataVerification struct {
+	Enabled          bool   `json:"enabled"`          // Whether or not data verification is enabled
+	URL              string `json:"URL"`              // The URL to be used for data receipt verification
+	URLUser          string `json:"URLUser"`          // The user id to use when calling the verification URL
+	URLPassword      string `json:"URLPassword"`      // The password to use when calling the verification URL
+	Interval         int    `json:"interval"`         // The number of seconds between data receipt checks
+}
+
+
+// Two sections are identical if the field values are the same.
+func (d DataVerification) IsSame(compare DataVerification) bool {
+	return d.Enabled == compare.Enabled && d.URL == compare.URL && d.URLUser == compare.URLUser && d.Interval == compare.Interval
+}
+
+func (d DataVerification) String() string {
+	return fmt.Sprintf("Enabled: %v, URL: %v, URL User: %v, Interval: %v", d.Enabled, d.URL, d.URLUser, d.Interval)
+}
+
+func (d *DataVerification) Obscure() {
+	if d.URLPassword != "" {
+		d.URLPassword = "********"
+	}
+}

--- a/policy/data_verification_test.go
+++ b/policy/data_verification_test.go
@@ -1,0 +1,66 @@
+package policy
+
+import (
+    "encoding/json"
+	"testing"
+)
+
+func Test_data_verification_section_success(t *testing.T) {
+
+    dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","Interval":0}`
+    dv2 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","Interval":0}`
+    if dva := create_DataVerification(dv1, t); dva != nil {
+        if dvb := create_DataVerification(dv2, t); dvb != nil {
+            if !dva.IsSame(*dvb) {
+                t.Errorf("DV section %v is the same as %v\n", dva, dvb)
+            }
+        }
+    }
+
+}
+
+func Test_data_verification_section_failure(t *testing.T) {
+
+    dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","Interval":0}`
+    dv2 := `{"enabled":true,"URL":"http://othercompany.com/verify","URLUser":"me","URLPassword":"mysecret","Interval":0}`
+    if dva := create_DataVerification(dv1, t); dva != nil {
+        if dvb := create_DataVerification(dv2, t); dvb != nil {
+            if dva.IsSame(*dvb) {
+                t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
+            }
+        }
+    }
+
+}
+
+func Test_data_verification_obscure(t *testing.T) {
+
+    dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","Interval":0}`
+    dv2 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","Interval":0}`
+    if dva := create_DataVerification(dv1, t); dva != nil {
+        upb4 := dva.URLPassword
+        dva.Obscure()
+        if dva.URLPassword == upb4 || dva.URLPassword != "********" {
+            t.Errorf("DV section %v was not obscured correctly\n", dva)
+        } else if dvb := create_DataVerification(dv2, t); dvb != nil {
+            if dva.IsSame(*dvb) {
+                t.Errorf("DV section %v is the same as %v\n", dva, dvb)
+            }
+        }
+    }
+
+}
+
+// Create an Data Verification section from a JSON serialization. The JSON serialization
+// does not have to be a valid DataVerification serialization, just has to be a valid
+// JSON serialization.
+func create_DataVerification(jsonString string, t *testing.T) *DataVerification {
+	dv := new(DataVerification)
+
+	if err := json.Unmarshal([]byte(jsonString), &dv); err != nil {
+		t.Errorf("Error unmarshalling DataVerification json string: %v error:%v\n", jsonString, err)
+		return nil
+	} else {
+		return dv
+	}
+}

--- a/policy/policy_file_test.go
+++ b/policy/policy_file_test.go
@@ -243,7 +243,7 @@ func Test_Policy_Merge(t *testing.T) {
 		t.Error(err)
 	} else if pf_con, err := ReadPolicyFile("./test/pfmerge1/agbot.policy"); err != nil {
 		t.Error(err)
-	} else if pf_merged, err := Create_Terms_And_Conditions(pf_prod, pf_con); err != nil {
+	} else if pf_merged, err := Create_Terms_And_Conditions(pf_prod, pf_con, "12345"); err != nil {
 		t.Error(err)
 	} else if err := WritePolicyFile(pf_merged, "./test/pfmerge1/merged.policy"); err != nil {
 		t.Error(err)
@@ -343,49 +343,20 @@ func Test_Policy_Creation(t *testing.T) {
 
 }
 
-// func Test_convertAccount_succeeds1(t *testing.T) {
+// Now let's make sure we are obscuring the workload password
+func Test_Policy_Workload_obscure(t *testing.T) {
+	if pf_prod1, err := ReadPolicyFile("./test/pftest/test1.policy"); err != nil {
+		t.Error(err)
+	} else {
+		pf_prod1.Workloads[0].WorkloadPassword = "abcdefg"
+		if err := pf_prod1.ObscureWorkloadPWs("123456"); err != nil {
+			t.Error(err)
+		} else if pf_prod1.Workloads[0].WorkloadPassword == "abcdefg" {
+			t.Errorf("Password was not obscured in %v", pf_prod1.Workloads[0])
+		}
+	}
+}
 
-//     bigIntForm := big.NewInt(0)
-//     bigIntForm, _ = bigIntForm.SetString("1234567890abcdef1234567890abcdef12345678", 16)
-//     expected := bigIntForm.Bytes()
-
-//     if pf, err := ReadPolicyFile("./test/pfaccttest/acct1.policy"); err != nil {
-//         t.Error(err)
-//     } else {
-//         switch pf.Properties[0].Value.(type) {
-//             case []byte:
-//                 if bytes.Compare(pf.Properties[0].Value.([]byte), expected) != 0 {
-//                     t.Errorf("Expected byte array %v, received: %v", expected, pf.Properties[0].Value)
-//                 }
-//             default:
-//                 t.Errorf("Value should be a byte array, but is %T", pf.Properties[0].Value)
-//         }
-
-//         expectedString := "1234567890abcdef1234567890abcdef12345678"
-//         if err := pf.ConvertEthereumAccount(false); err != nil {
-//             t.Errorf("Error converting account to string: %v", err)
-//         } else {
-//             switch pf.Properties[0].Value.(type) {
-//                 case string:
-//                     if pf.Properties[0].Value.(string) != expectedString {
-//                         t.Errorf("Expected string %v, received: %v", expected, pf.Properties[0].Value)
-//                     }
-//                 default:
-//                     t.Errorf("Value should be a byte array")
-//             }
-//         }
-//     }
-// }
-
-// func Test_convertAccount_fails1(t *testing.T) {
-
-//     if _, err := ReadPolicyFile("./test/pfaccttest/acct2.policy"); err == nil {
-//         t.Errorf("Should be an error converting account to binary.")
-//     } else if !strings.Contains(err.Error(), "Unable to convert") {
-//         t.Errorf("Wrong error returned, expected 'Unable to convert', received %v", err)
-//     }
-
-// }
 
 // ================================================================================================================
 // Helper functions

--- a/policy/test/pfcompat2/expecting.policy
+++ b/policy/test/pfcompat2/expecting.policy
@@ -40,6 +40,8 @@
     "dataVerification": {
         "enabled": true,
         "URL": "http://data.receipt.system.com",
+        "URLUser": "",
+        "URLPassword": "",
         "interval": 300
     },
     "proposalRejection": {

--- a/policy/test/pfcompat2/merged.policy
+++ b/policy/test/pfcompat2/merged.policy
@@ -40,6 +40,8 @@
     "dataVerification": {
         "enabled": true,
         "URL": "http://data.receipt.system.com",
+        "URLUser": "",
+        "URLPassword": "",
         "interval": 300
     },
     "proposalRejection": {

--- a/policy/test/pfcreate/created.policy
+++ b/policy/test/pfcreate/created.policy
@@ -40,6 +40,8 @@
     "dataVerification": {
         "enabled": false,
         "URL": "",
+        "URLUser": "",
+        "URLPassword": "",
         "interval": 0
     },
     "proposalRejection": {

--- a/policy/test/pfcreate/expecting.policy
+++ b/policy/test/pfcreate/expecting.policy
@@ -40,6 +40,8 @@
     "dataVerification": {
         "enabled": false,
         "URL": "",
+        "URLUser": "",
+        "URLPassword": "",
         "interval": 0
     },
     "proposalRejection": {

--- a/policy/test/pfmerge1/expecting.policy
+++ b/policy/test/pfmerge1/expecting.policy
@@ -29,7 +29,8 @@
                         "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                     }
                 ]
-            }
+            },
+            "workload_password": ""
         }
     ],
     "valueExchange": {
@@ -47,6 +48,8 @@
     "dataVerification": {
         "enabled": true,
         "URL": "http://data.receipt.system.com",
+        "URLUser": "",
+        "URLPassword": "",
         "interval": 300
     },
     "proposalRejection": {

--- a/policy/test/pfmerge1/merged.policy
+++ b/policy/test/pfmerge1/merged.policy
@@ -29,7 +29,8 @@
                         "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                     }
                 ]
-            }
+            },
+            "workload_password": ""
         }
     ],
     "valueExchange": {
@@ -47,6 +48,8 @@
     "dataVerification": {
         "enabled": true,
         "URL": "http://data.receipt.system.com",
+        "URLUser": "",
+        "URLPassword": "",
         "interval": 300
     },
     "proposalRejection": {

--- a/policy/test/pftest/echo.policy
+++ b/policy/test/pftest/echo.policy
@@ -29,7 +29,8 @@
                         "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                     }
                 ]
-            }
+            },
+            "workload_password": ""
         }
     ],
     "deviceType": "12345-54321-abcdef-fedcba",
@@ -48,6 +49,8 @@
     "dataVerification": {
         "enabled": true,
         "URL": "http://data.receipt.system.com",
+        "URLUser": "",
+        "URLPassword": "",
         "interval": 300
     },
     "proposalRejection": {

--- a/policy/test/pftest/test1.policy
+++ b/policy/test/pftest/test1.policy
@@ -29,7 +29,8 @@
                         "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                     }
                 ]
-            }
+            },
+            "workload_password": ""
         }
     ],
     "deviceType": "12345-54321-abcdef-fedcba",
@@ -48,6 +49,8 @@
     "dataVerification": {
         "enabled": true,
         "URL": "http://data.receipt.system.com",
+        "URLUser": "",
+        "URLPassword": "",
         "interval": 300
     },
     "proposalRejection": {

--- a/policy/workload.go
+++ b/policy/workload.go
@@ -1,0 +1,65 @@
+package policy
+
+import (
+    "golang.org/x/crypto/bcrypt"
+)
+
+type Image struct {
+    File      string `json:"file"`
+    Signature string `json:"signature"`
+}
+
+func (i Image) IsSame(compare Image) bool {
+    return i.File == compare.File && i.Signature == compare.Signature
+}
+
+type Torrent struct {
+    Url    string  `json:"url"`
+    Images []Image `json:"images"`
+}
+
+func (t Torrent) IsSame(compare Torrent) bool {
+    if t.Url != compare.Url {
+        return false
+    } else {
+        for _, i := range t.Images {
+            found := false
+            for _, compareI := range compare.Images {
+                if i.IsSame(compareI) {
+                    found = true
+                    break
+                }
+            }
+            if !found {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+type Workload struct {
+    Deployment          string  `json:"deployment"`
+    DeploymentSignature string  `json:"deployment_signature"`
+    DeploymentUserInfo  string  `json:"deployment_user_info"`
+    Torrent             Torrent `json:"torrent"`
+    WorkloadPassword    string  `json:"workload_password"` // The password used to create the bcrypt hash that is passed to the workload so that the workload can verify the caller
+}
+
+func (wl Workload) IsSame(compare Workload) bool {
+    return wl.Deployment == compare.Deployment && wl.DeploymentSignature == compare.DeploymentSignature && wl.DeploymentUserInfo == compare.DeploymentUserInfo && wl.Torrent.IsSame(compare.Torrent) && wl.WorkloadPassword == compare.WorkloadPassword
+}
+
+func (w *Workload) Obscure(agreementId string) error {
+    if w.WorkloadPassword == "" {
+        return nil
+    }
+
+    // Convert the workload password into a hash by first concatenating the agreement id onto the end of the password
+    if hash, err := bcrypt.GenerateFromPassword([]byte(w.WorkloadPassword + agreementId), bcrypt.DefaultCost); err != nil {
+        return err
+    } else {
+        w.WorkloadPassword = string(hash)
+        return nil
+    }
+}

--- a/policy/workload_test.go
+++ b/policy/workload_test.go
@@ -1,0 +1,103 @@
+package policy
+
+import (
+    "bytes"
+    "encoding/json"
+    "golang.org/x/crypto/bcrypt"
+    "math/rand"
+    "testing"
+    "time"
+)
+
+func Test_workload_pw_hash(t *testing.T) {
+
+    random := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+
+    rpw := func (random *rand.Rand) string {
+        var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+        b := make([]rune, 20)
+        for i := range b {
+            b[i] = letters[random.Intn(len(letters))]
+        }
+        return string(b)
+    }
+
+    rHash := func(random *rand.Rand) []byte {
+        b := make([]byte, 32, 32)
+        for i := range b {
+            b[i] = byte(random.Intn(256))
+        }
+        return b
+    }
+
+    for i := 0; i < 10; i++ {
+        password := rpw(random)
+        // Perform the hash twice
+        if hash1, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); err != nil {
+            t.Error(err)
+        } else if hash2, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); err != nil {
+            t.Error(err)
+        } else if bytes.Compare(hash1, hash2) == 0 {
+            t.Errorf("2 calls to generate hash for %v result in equivalent hashes %v, but should not", password, hash1)
+        } else if err := bcrypt.CompareHashAndPassword(hash1, []byte(password)); err != nil {
+            t.Error(err)
+        } else if err := bcrypt.CompareHashAndPassword(hash2, []byte(password)); err != nil {
+            t.Error(err)
+        }
+    }
+
+    password := rpw(random)
+    rh := rHash(random)
+    if err := bcrypt.CompareHashAndPassword(rh, []byte(password)); err == nil {
+        t.Errorf("Random hash %v should not verify %v", rh, password)
+    }
+
+}
+
+func Test_workload_pw_hash_error(t *testing.T) {
+
+    pw := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+    if hash1, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost); err != nil {
+        t.Error(err)
+    } else if len(hash1) == 0 {
+        t.Errorf("bcrypt returned zero length hash\n")
+    } else if err := bcrypt.CompareHashAndPassword(hash1, []byte(pw[:71])); err == nil {
+        t.Errorf("Password was shortened and should not validate, but it did.")
+    }
+
+}
+
+
+func Test_workload_obscure(t *testing.T) {
+
+    wl1 := `{"deployment":"deploymentabcdefg","deployment_signature":"123456","deployment_user_info":"duiabcdefg","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+    wl2 := `{"deployment":"deploymentabcdefg","deployment_signature":"123456","deployment_user_info":"duiabcdefg","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+    if wla := create_Workload(wl1, t); wla != nil {
+        wpb4 := wla.WorkloadPassword
+        wla.Obscure("01020304")
+        if wla.WorkloadPassword == wpb4 {
+            t.Errorf("Workload section %v was not obscured correctly\n", wla)
+        } else if wlb := create_Workload(wl2, t); wlb != nil {
+            if wla.IsSame(*wlb) {
+                t.Errorf("Workload section %v is the same as %v\n", wla, wlb)
+            }
+        }
+    }
+
+}
+
+// Create a Workload section from a JSON serialization. The JSON serialization
+// does not have to be a valid Workload serialization, just has to be a valid
+// JSON serialization.
+func create_Workload(jsonString string, t *testing.T) *Workload {
+    wl := new(Workload)
+
+    if err := json.Unmarshal([]byte(jsonString), &wl); err != nil {
+        t.Errorf("Error unmarshalling Workload json string: %v error:%v\n", jsonString, err)
+        return nil
+    } else {
+        return wl
+    }
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -595,6 +595,18 @@
 			"revisionTime": "2016-02-25T14:53:07Z"
 		},
 		{
+			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",
+			"path": "golang.org/x/crypto/bcrypt",
+			"revision": "9477e0b78b9ac3d0b03822fd95422e2fe07627cd",
+			"revisionTime": "2016-10-31T15:37:30Z"
+		},
+		{
+			"checksumSHA1": "JsJdKXhz87gWenMwBeejTOeNE7k=",
+			"path": "golang.org/x/crypto/blowfish",
+			"revision": "9477e0b78b9ac3d0b03822fd95422e2fe07627cd",
+			"revisionTime": "2016-10-31T15:37:30Z"
+		},
+		{
 			"checksumSHA1": "DDHnuGCrmkKSXdNzc8pmn6P5O28=",
 			"path": "golang.org/x/crypto/sha3",
 			"revision": "3c0d69f1777220f1a1d2ec373cb94a282f03eb42",


### PR DESCRIPTION
See US 431 for a description of changes:
https://projects.hovitos.engineering/project/rmlinden-mtn-edgenet-v2/us/431
Briefly, this support allows a workload deployer to specify a password (in the policy file) that the workload uses at runtime to authenticate with its cloud ingest when the workload is running.