### PR TITLE
also fixed a policy comparison bug

### DIFF
--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -436,7 +436,7 @@ func (w *AgreementBotWorker) syncOnInit() error {
 					}
 					w.pwcommands <- NewAgreementTimeoutCommand(ag.CurrentAgreementId, ag.AgreementProtocol, CANCEL_POLICY_CHANGED)
 				} else if err := w.pm.MatchesMine(pol); err != nil {
-					glog.Errorf(AWlogString(fmt.Sprintf("agreement %v has a policy %v that has changed.", ag.CurrentAgreementId, pol.Header.Name)))
+					glog.Errorf(AWlogString(fmt.Sprintf("agreement %v has a policy %v that has changed: %v", ag.CurrentAgreementId, pol.Header.Name, err)))
 					// Update state in exchange
 					if err := DeleteConsumerAgreement(w.Config.AgreementBot.ExchangeURL, w.agbotId, w.token, ag.CurrentAgreementId); err != nil {
 						glog.Errorf(logString(fmt.Sprintf("error deleting agreement %v in exchange: %v", ag.CurrentAgreementId, err)))

--- a/agreementbot/governance.go
+++ b/agreementbot/governance.go
@@ -86,7 +86,7 @@ func (w *AgreementBotWorker) GovernAgreements() {
 					// We are waiting for a reply
 					glog.V(5).Infof("AgreementBot Governance waiting for reply to %v.", ag.CurrentAgreementId)
 					now := uint64(time.Now().Unix())
-					if ag.AgreementCreationTime + w.Worker.Manager.Config.AgreementBot.AgreementTimeoutS < now {
+					if ag.AgreementCreationTime + w.Worker.Manager.Config.AgreementBot.ProtocolTimeoutS < now {
 						w.TerminateAgreement(&ag, CANCEL_NO_REPLY)
 					}
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type AGConfig struct {
 	AgreementWorkers             int
 	DBPath                       string
 	GethURL                      string
+	ProtocolTimeoutS             uint64 // Number of seconds to wait before declaring proposal response is lost
 	AgreementTimeoutS            uint64 // Number of seconds to wait before declaring agreement not finalized in blockchain
 	NoDataIntervalS              uint64 // default should be 15 mins == 15*60 == 900. Ignored if the policy has data verification disabled.
 	ActiveAgreementsURL          string // This field is used when policy files indicate they want data verification but they dont specify a URL

--- a/policy/data_verification_test.go
+++ b/policy/data_verification_test.go
@@ -43,8 +43,8 @@ func Test_data_verification_obscure(t *testing.T) {
         if dva.URLPassword == upb4 || dva.URLPassword != "********" {
             t.Errorf("DV section %v was not obscured correctly\n", dva)
         } else if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dva.IsSame(*dvb) {
-                t.Errorf("DV section %v is the same as %v\n", dva, dvb)
+            if !dva.IsSame(*dvb) {
+                t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
             }
         }
     }

--- a/policy/policy_file.go
+++ b/policy/policy_file.go
@@ -202,10 +202,10 @@ func Create_Terms_And_Conditions(producer_policy *Policy, consumer_policy *Polic
 		merged_pol := new(Policy)
 		merged_pol.Header.Name = producer_policy.Header.Name + " merged with " + consumer_policy.Header.Name
 		merged_pol.Header.Version = CurrentVersion
-		merged_pol.APISpecs = consumer_policy.APISpecs
+		merged_pol.APISpecs = append(merged_pol.APISpecs, consumer_policy.APISpecs...)
 		intersecting_agreement_protocols, _ := (&producer_policy.AgreementProtocols).Intersects_With(&consumer_policy.AgreementProtocols)
 		merged_pol.AgreementProtocols = *intersecting_agreement_protocols.Single_Element()
-		merged_pol.Workloads = consumer_policy.Workloads
+		merged_pol.Workloads = append(merged_pol.Workloads, consumer_policy.Workloads...)
 		if err := merged_pol.ObscureWorkloadPWs(agreementId); err != nil {
 			return nil, errors.New(fmt.Sprintf("Error merging policies, error: %v", err))
 		}

--- a/policy/policy_manager.go
+++ b/policy/policy_manager.go
@@ -135,6 +135,9 @@ func (self *PolicyManager) hasPolicy(matchPolicy *Policy) (bool, error) {
 
 	errString := ""
 	for _, pol := range self.Policies {
+		if errString != "" {
+			glog.V(3).Infof("Policy Manager: Previous search loop returned: %v", errString)
+		}
 		if !pol.Header.IsSame(matchPolicy.Header) {
 			errString = fmt.Sprintf("Header %v mismatch with %v", pol.Header, matchPolicy.Header)
 			continue


### PR DESCRIPTION
1. In agbot split the protocol message timeout from the blockchain timeout.
2. Also fixed a bug (found while testing the timeout split) that occurs during agbot restart where false policy differences are detected causing all agreements to be killed and recreated.