### PR TITLE
always pass token in PUT device body

### DIFF
--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -178,8 +178,8 @@ func (w *AgreementBotWorker) start() {
 		w.ready = true
 
 		// Begin heartbeating with the exchange.
-		targetURL := w.Manager.Config.AgreementBot.ExchangeURL + "agbots/" + w.agbotId + "/heartbeat?token=" + w.token
-		go exchange.Heartbeat(&http.Client{}, targetURL, w.Worker.Manager.Config.AgreementBot.ExchangeHeartbeat)
+		targetURL := w.Manager.Config.AgreementBot.ExchangeURL + "agbots/" + w.agbotId + "/heartbeat"
+		go exchange.Heartbeat(&http.Client{}, targetURL, w.agbotId, w.token, w.Worker.Manager.Config.AgreementBot.ExchangeHeartbeat)
 
 		// Start the governance routine.
 		go w.GovernAgreements()
@@ -398,9 +398,9 @@ func (w *AgreementBotWorker) searchExchange(pol *policy.Policy) (*[]exchange.Dev
 
 	var resp interface{}
 	resp = new(exchange.SearchExchangeResponse)
-	targetURL := w.Worker.Manager.Config.AgreementBot.ExchangeURL + "search/devices?id=" + w.agbotId + "&token=" + w.token
+	targetURL := w.Worker.Manager.Config.AgreementBot.ExchangeURL + "search/devices"
 	for {
-		if err, tpErr := exchange.InvokeExchange(w.httpClient, "POST", targetURL, ser, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(w.httpClient, "POST", targetURL, w.agbotId, w.token, ser, &resp); err != nil {
 			return nil, err
 		} else if tpErr != nil {
 			glog.V(5).Infof(err.Error())
@@ -453,9 +453,9 @@ func (w *AgreementBotWorker) syncOnInit() error {
 					var exchangeAgreement map[string]exchange.AgbotAgreement
 					var resp interface{}
 					resp = new(exchange.AllAgbotAgreementsResponse)
-					targetURL := w.Worker.Manager.Config.AgreementBot.ExchangeURL + "agbots/" + w.agbotId + "/agreements/" + ag.CurrentAgreementId + "?token=" + w.token
+					targetURL := w.Worker.Manager.Config.AgreementBot.ExchangeURL + "agbots/" + w.agbotId + "/agreements/" + ag.CurrentAgreementId
 					for {
-						if err, tpErr := exchange.InvokeExchange(w.httpClient, "GET", targetURL, nil, &resp); err != nil {
+						if err, tpErr := exchange.InvokeExchange(w.httpClient, "GET", targetURL, w.agbotId, w.token, nil, &resp); err != nil {
 							return err
 						} else if tpErr != nil {
 							glog.V(5).Infof(err.Error())
@@ -515,9 +515,9 @@ func (w *AgreementBotWorker) recordConsumerAgreementState(agreementId string, wo
 	as.State = state
 	var resp interface{}
 	resp = new(exchange.PostDeviceResponse)
-	targetURL := w.Config.AgreementBot.ExchangeURL + "agbots/" + w.agbotId + "/agreements/" + agreementId + "?token=" + w.token
+	targetURL := w.Config.AgreementBot.ExchangeURL + "agbots/" + w.agbotId + "/agreements/" + agreementId
 	for {
-		if err, tpErr := exchange.InvokeExchange(w.httpClient, "PUT", targetURL, &as, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(w.httpClient, "PUT", targetURL, w.agbotId, w.token, &as, &resp); err != nil {
 			glog.Errorf(err.Error())
 			return err
 		} else if tpErr != nil {

--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -260,9 +260,9 @@ func (a *CSAgreementWorker) recordConsumerAgreementState(agreementId string, wor
 	as.State = state
 	var resp interface{}
 	resp = new(exchange.PostDeviceResponse)
-	targetURL := a.config.AgreementBot.ExchangeURL + "agbots/" + a.agbotId + "/agreements/" + agreementId + "?token=" + a.token
+	targetURL := a.config.AgreementBot.ExchangeURL + "agbots/" + a.agbotId + "/agreements/" + agreementId
 	for {
-		if err, tpErr := exchange.InvokeExchange(a.httpClient, "PUT", targetURL, &as, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(a.httpClient, "PUT", targetURL, a.agbotId, a.token, &as, &resp); err != nil {
 			glog.Errorf(err.Error())
 			return err
 		} else if tpErr != nil {

--- a/agreementbot/governance.go
+++ b/agreementbot/governance.go
@@ -132,9 +132,9 @@ func recordConsumerAgreementState(url string, agbotId string, token string, agre
 	as.State = state
 	var resp interface{}
 	resp = new(exchange.PostDeviceResponse)
-	targetURL := url + "agbots/" + agbotId + "/agreements/" + agreementId + "?token=" + token
+	targetURL := url + "agbots/" + agbotId + "/agreements/" + agreementId
 	for {
-		if err, tpErr := exchange.InvokeExchange(&http.Client{}, "PUT", targetURL, &as, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(&http.Client{}, "PUT", targetURL, agbotId, token, &as, &resp); err != nil {
 			glog.Errorf(logString(fmt.Sprintf(err.Error())))
 			return err
 		} else if tpErr != nil {
@@ -159,9 +159,9 @@ func DeleteConsumerAgreement(url string, agbotId string, token string, agreement
 
 	var resp interface{}
 	resp = new(exchange.PostDeviceResponse)
-	targetURL := url + "agbots/" + agbotId + "/agreements/" + agreementId + "?token=" + token
+	targetURL := url + "agbots/" + agbotId + "/agreements/" + agreementId
 	for {
-		if err, tpErr := exchange.InvokeExchange(&http.Client{}, "DELETE", targetURL, nil, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(&http.Client{}, "DELETE", targetURL, agbotId, token, nil, &resp); err != nil {
 			glog.Errorf(logString(fmt.Sprintf(err.Error())))
 			return err
 		} else if tpErr != nil {

--- a/governance/governance.go
+++ b/governance/governance.go
@@ -419,9 +419,9 @@ func recordProducerAgreementState(url string, deviceId string, token string, agr
 	as.State = state
 	var resp interface{}
 	resp = new(exchange.PostDeviceResponse)
-	targetURL := url + "devices/" + deviceId + "/agreements/" + agreementId + "?token=" + token
+	targetURL := url + "devices/" + deviceId + "/agreements/" + agreementId
 	for {
-		if err, tpErr := exchange.InvokeExchange(&http.Client{}, "PUT", targetURL, &as, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(&http.Client{}, "PUT", targetURL, deviceId, token, &as, &resp); err != nil {
 			glog.Errorf(logString(fmt.Sprintf(err.Error())))
 			return err
 		} else if tpErr != nil {
@@ -442,9 +442,9 @@ func deleteProducerAgreement(url string, deviceId string, token string, agreemen
 
 	var resp interface{}
 	resp = new(exchange.PostDeviceResponse)
-	targetURL := url + "devices/" + deviceId + "/agreements/" + agreementId + "?token=" + token
+	targetURL := url + "devices/" + deviceId + "/agreements/" + agreementId
 	for {
-		if err, tpErr := exchange.InvokeExchange(&http.Client{}, "DELETE", targetURL, nil, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(&http.Client{}, "DELETE", targetURL, deviceId, token, nil, &resp); err != nil {
 			glog.Errorf(logString(fmt.Sprintf(err.Error())))
 			return err
 		} else if tpErr != nil {


### PR DESCRIPTION
When persistence was added to the exchange, they had to change the interface to PUT /devices/{id} such that we could no longer pass a blank token in the body to indicate that we didnt want it to be updated.

While we were in this area of the code, we noticed that device token could be passed in the HTTP basic auth header instead of as a URL parameter, so we made that change as well.