### PR TITLE
propagate agbot reason code to device

### DIFF
--- a/agreement/agreement.go
+++ b/agreement/agreement.go
@@ -11,7 +11,6 @@ import (
 	"github.com/open-horizon/anax/device"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/exchange"
-	"github.com/open-horizon/anax/governance"
 	"github.com/open-horizon/anax/persistence"
 	"github.com/open-horizon/anax/policy"
 	"github.com/open-horizon/anax/worker"
@@ -103,8 +102,8 @@ func (w *AgreementWorker) NewEvent(incoming events.Message) {
 		agCmd := NewReceivedProposalCommand(*msg)
 		w.Commands <- agCmd
 
-	case *events.BlockchainClientInitilizedMessage:
-		msg, _ := incoming.(*events.BlockchainClientInitilizedMessage)
+	case *events.BlockchainClientInitializedMessage:
+		msg, _ := incoming.(*events.BlockchainClientInitializedMessage)
 		switch msg.Event().Id {
 		case events.BC_CLIENT_INITIALIZED:
 			w.bcClientInitialized = true
@@ -376,11 +375,11 @@ func (w *AgreementWorker) syncOnInit() error {
 					glog.Errorf(logString(fmt.Sprintf("unable to demarshal policy for agreement %v, error %v", ag.CurrentAgreementId, err)))
 				} else if existingPol := w.pm.GetPolicy(pol.Header.Name); existingPol == nil {
 					glog.Errorf(logString(fmt.Sprintf("agreement %v has a policy %v that doesn't exist anymore", ag.CurrentAgreementId, pol.Header.Name)))
-					w.Messages() <- events.NewInitAgreementCancelationMessage(events.AGREEMENT_ENDED, governance.CANCEL_POLICY_CHANGED, citizenscientist.PROTOCOL_NAME, ag.CurrentAgreementId, ag.CurrentDeployment)
+					w.Messages() <- events.NewInitAgreementCancelationMessage(events.AGREEMENT_ENDED, citizenscientist.CANCEL_POLICY_CHANGED, citizenscientist.PROTOCOL_NAME, ag.CurrentAgreementId, ag.CurrentDeployment)
 
 				} else if err := w.pm.MatchesMine(pol); err != nil {
 					glog.Errorf(logString(fmt.Sprintf("agreement %v has a policy %v that has changed.", ag.CurrentAgreementId, pol.Header.Name)))
-					w.Messages() <- events.NewInitAgreementCancelationMessage(events.AGREEMENT_ENDED, governance.CANCEL_POLICY_CHANGED, citizenscientist.PROTOCOL_NAME, ag.CurrentAgreementId, ag.CurrentDeployment)
+					w.Messages() <- events.NewInitAgreementCancelationMessage(events.AGREEMENT_ENDED, citizenscientist.CANCEL_POLICY_CHANGED, citizenscientist.PROTOCOL_NAME, ag.CurrentAgreementId, ag.CurrentDeployment)
 
 				} else if err := w.pm.AttemptingAgreement(existingPol, ag.CurrentAgreementId); err != nil {
 					glog.Errorf(logString(fmt.Sprintf("cannot update agreement count for %v, error: %v", ag.CurrentAgreementId, err)))

--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -434,14 +434,14 @@ func (w *AgreementBotWorker) syncOnInit() error {
 					if err := DeleteConsumerAgreement(w.Config.AgreementBot.ExchangeURL, w.agbotId, w.token, ag.CurrentAgreementId); err != nil {
 						glog.Errorf(logString(fmt.Sprintf("error deleting agreement %v in exchange: %v", ag.CurrentAgreementId, err)))
 					}
-					w.pwcommands <- NewAgreementTimeoutCommand(ag.CurrentAgreementId, ag.AgreementProtocol, CANCEL_POLICY_CHANGED)
+					w.pwcommands <- NewAgreementTimeoutCommand(ag.CurrentAgreementId, ag.AgreementProtocol, citizenscientist.AB_CANCEL_POLICY_CHANGED)
 				} else if err := w.pm.MatchesMine(pol); err != nil {
 					glog.Errorf(AWlogString(fmt.Sprintf("agreement %v has a policy %v that has changed: %v", ag.CurrentAgreementId, pol.Header.Name, err)))
 					// Update state in exchange
 					if err := DeleteConsumerAgreement(w.Config.AgreementBot.ExchangeURL, w.agbotId, w.token, ag.CurrentAgreementId); err != nil {
 						glog.Errorf(logString(fmt.Sprintf("error deleting agreement %v in exchange: %v", ag.CurrentAgreementId, err)))
 					}
-					w.pwcommands <- NewAgreementTimeoutCommand(ag.CurrentAgreementId, ag.AgreementProtocol, CANCEL_POLICY_CHANGED)
+					w.pwcommands <- NewAgreementTimeoutCommand(ag.CurrentAgreementId, ag.AgreementProtocol, citizenscientist.AB_CANCEL_POLICY_CHANGED)
 				} else if err := w.pm.AttemptingAgreement(existingPol, ag.CurrentAgreementId); err != nil {
 					glog.Errorf(AWlogString(fmt.Sprintf("cannot update agreement count for %v, error: %v", ag.CurrentAgreementId, err)))
 				} else if err := w.pm.FinalAgreement(existingPol, ag.CurrentAgreementId); err != nil {

--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -91,13 +91,6 @@ func (c CSCancelAgreement) Type() string {
 	return c.workType
 }
 
-// These constants represent agreement cancellation reason codes
-const CANCEL_NOT_FINALIZED_TIMEOUT = 200
-const CANCEL_NO_REPLY = 201
-const CANCEL_NEGATIVE_REPLY = 202
-const CANCEL_NO_DATA_RECEIVED = 203
-const CANCEL_POLICY_CHANGED = 204
-const CANCEL_DISCOVERED = 205
 
 // This function receives an event to "make a new agreement" from the Process function, and then synchronously calls a function
 // to actually work through the agreement protocol.
@@ -202,7 +195,7 @@ func (a *CSAgreementWorker) start(work chan CSAgreementWork, random *rand.Rand, 
 					glog.Errorf(logString(fmt.Sprintf("no database entry for agreement %v, can't cleanup after rejection.", reply.AgreementId())))
 				} else if pol, err := policy.DemarshalPolicy(ag.Policy); err != nil {
 					glog.Errorf(logString(fmt.Sprintf("unable to demarshal policy for agreement %v while trying to cleanup after rejection, error %v", reply.AgreementId(), err)))
-				} else if err := protocolHandler.TerminateAgreement(pol, ag.CounterPartyAddress, ag.CurrentAgreementId, CANCEL_NEGATIVE_REPLY, bc.Agreements); err != nil {
+				} else if err := protocolHandler.TerminateAgreement(pol, ag.CounterPartyAddress, ag.CurrentAgreementId, citizenscientist.AB_CANCEL_NEGATIVE_REPLY, bc.Agreements); err != nil {
 					glog.Errorf(logString(fmt.Sprintf("error terminating agreement %v on the blockchain: %v", reply.AgreementId(), err)))
 				}
 

--- a/agreementbot/governance.go
+++ b/agreementbot/governance.go
@@ -52,7 +52,7 @@ func (w *AgreementBotWorker) GovernAgreements() {
 						now := uint64(time.Now().Unix())
 						if ag.AgreementCreationTime+w.Worker.Manager.Config.AgreementBot.AgreementTimeoutS < now {
 							// Start timing out the agreement
-							w.TerminateAgreement(&ag, CANCEL_NOT_FINALIZED_TIMEOUT)
+							w.TerminateAgreement(&ag, citizenscientist.AB_CANCEL_NOT_FINALIZED_TIMEOUT)
 						}
 					}
 
@@ -64,11 +64,11 @@ func (w *AgreementBotWorker) GovernAgreements() {
 					} else if !recorded {
 						// The agreement is not on the blockchain, update state in exchange
 						glog.V(3).Infof(logString(fmt.Sprintf("discovered terminated agreement %v, cleaning up.", ag.CurrentAgreementId)))
-						w.TerminateAgreement(&ag, CANCEL_DISCOVERED)
+						w.TerminateAgreement(&ag, citizenscientist.AB_CANCEL_DISCOVERED)
 					} else if now - ag.DataVerifiedTime >= w.Worker.Manager.Config.AgreementBot.NoDataIntervalS {
 						// No data is being received, terminate the agreement
 						glog.V(3).Infof(logString(fmt.Sprintf("cancelling agreement %v due to lack of data", ag.CurrentAgreementId)))
-						w.TerminateAgreement(&ag, CANCEL_NO_DATA_RECEIVED)
+						w.TerminateAgreement(&ag, citizenscientist.AB_CANCEL_NO_DATA_RECEIVED)
 					} else if activeDataVerification {
 						// And make sure the device is still sending data
 						if activeAgreements, err := GetActiveAgreements(allActiveAgreements, ag, &w.Worker.Manager.Config.AgreementBot); err != nil {
@@ -87,7 +87,7 @@ func (w *AgreementBotWorker) GovernAgreements() {
 					glog.V(5).Infof("AgreementBot Governance waiting for reply to %v.", ag.CurrentAgreementId)
 					now := uint64(time.Now().Unix())
 					if ag.AgreementCreationTime + w.Worker.Manager.Config.AgreementBot.ProtocolTimeoutS < now {
-						w.TerminateAgreement(&ag, CANCEL_NO_REPLY)
+						w.TerminateAgreement(&ag, citizenscientist.AB_CANCEL_NO_REPLY)
 					}
 				}
 			}

--- a/ethblockchain/blockchainworker.go
+++ b/ethblockchain/blockchainworker.go
@@ -1,6 +1,7 @@
 package ethblockchain
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/config"
@@ -8,7 +9,9 @@ import (
 	"github.com/open-horizon/anax/policy"
 	"github.com/open-horizon/anax/worker"
 	"net/http"
+	"os"
 	"runtime"
+	"strconv"
 	"time"
 )
 
@@ -17,10 +20,12 @@ type EthBlockchainWorker struct {
 	worker.Worker // embedded field
 	httpClient    *http.Client
 	gethURL       string
-	bc            *policy.EthereumBlockchain
+	bcMetadata    *policy.EthereumBlockchain
+	bc            *BaseContracts
+	el            *Event_Log
 }
 
-func NewEthBlockchainWorker(config *config.HorizonConfig, gethURL string, bc *policy.EthereumBlockchain) *EthBlockchainWorker {
+func NewEthBlockchainWorker(config *config.HorizonConfig, gethURL string, bcMetadata *policy.EthereumBlockchain) *EthBlockchainWorker {
 	messages := make(chan events.Message)      // The channel for outbound messages to the anax wide bus
 	commands := make(chan worker.Command, 100) // The channel for commands into the agreement bot worker
 
@@ -36,6 +41,7 @@ func NewEthBlockchainWorker(config *config.HorizonConfig, gethURL string, bc *po
 
 		httpClient: &http.Client{},
 		gethURL:    gethURL,
+		bcMetadata: bcMetadata,
 	}
 
 	glog.Info(logString("starting worker"))
@@ -81,21 +87,33 @@ func (w *EthBlockchainWorker) start() {
 					if !notifiedBCReady {
 						// geth initilzed
 						notifiedBCReady = true
-						glog.V(3).Infof(logString(fmt.Sprintf("sending blockchian client initilzed event")))
-						w.Messages() <- events.NewBlockchainClientInitilizedMessage(events.BC_CLIENT_INITIALIZED)
+						glog.V(3).Infof(logString(fmt.Sprintf("sending blockchian client initialized event")))
+						w.initBlockchainEventListener()
+						w.Messages() <- events.NewBlockchainClientInitializedMessage(events.BC_CLIENT_INITIALIZED)
 					}
 
 					if !funded {
 						glog.V(3).Infof(logString(fmt.Sprintf("account %v not funded yet", acct)))
 					} else if funded && !notifiedFunded {
 						notifiedFunded = true
-						nonBlockDuration = 300
+						nonBlockDuration = 60
 						glog.V(3).Infof(logString(fmt.Sprintf("sending acct %v funded event", acct)))
 						w.Messages() <- events.NewAccountFundedMessage(events.ACCOUNT_FUNDED, acct)
 					} else if funded {
 						glog.V(3).Infof(logString(fmt.Sprintf("%v still funded", acct)))
 					}
 				}
+
+				// Get new blockchain events and publish them to the rest of anax.
+				if w.el != nil {
+					if events, _, err := w.el.Get_Next_Raw_Event_Batch(getFilter(), 0); err != nil {
+						glog.Errorf(logString(fmt.Sprintf("unable to get event batch, error %v", err)))
+						return
+					} else {
+						w.handleEvents(events)
+					}
+				}
+
 			}
 
 			runtime.Gosched()
@@ -104,6 +122,81 @@ func (w *EthBlockchainWorker) start() {
 	}()
 
 	glog.Info(logString("ready for commands."))
+}
+
+// This function sets up the blockchain event listener
+func (w *EthBlockchainWorker) initBlockchainEventListener() {
+
+	// Establish the go objects that are used to interact with the ethereum blockchain.
+	acct, _ := AccountId()
+	dir, _ := DirectoryAddress()
+	gethURL := w.Worker.Manager.Config.Edge.GethURL
+	if gethURL == "" {
+		gethURL = w.Worker.Manager.Config.AgreementBot.GethURL
+	}
+
+	if bc, err := InitBaseContracts(acct, gethURL, dir); err != nil {
+		glog.Errorf(logString(fmt.Sprintf("unable to initialize platform contracts, error: %v", err)))
+		return
+	} else {
+		w.bc = bc
+	}
+
+	// Establish the event logger that will be used to listen for blockchain events
+	if conn := RPC_Connection_Factory("", 0, gethURL); conn == nil {
+		glog.Errorf(logString(fmt.Sprintf("unable to create connection")))
+		return
+	} else if rpc := RPC_Client_Factory(conn); rpc == nil {
+		glog.Errorf(logString(fmt.Sprintf("unable to create RPC client")))
+		return
+	} else if el := Event_Log_Factory(rpc, w.bc.Agreements.Get_contract_address()); el == nil {
+		glog.Errorf(logString(fmt.Sprintf("unable to create blockchain event log")))
+		return
+	} else {
+		w.el = el
+
+		// Set the starting block for the event logger. We will ignore events before this block.
+		// Assume that anax will sync it's state with the blockchain by calling methods on the
+		// relevant smart contracts, not depending on this logger to publish events from the past.
+		block_read_delay := 0
+		if rd, err := strconv.Atoi(os.Getenv("mtn_soliditycontract_block_read_delay")); err == nil {
+			block_read_delay = rd
+		}
+		if block, err := rpc.Get_block_number(); err != nil {
+			glog.Errorf(logString(fmt.Sprintf("unable to get current block, error %v", err)))
+			return
+		} else if err := os.Setenv("bh_event_log_start", strconv.FormatUint(block - uint64(block_read_delay), 10)); err != nil {
+			glog.Errorf(logString(fmt.Sprintf("unable to set starting block, error %v", err)))
+			return
+		}
+
+		// Grab the first bunch of events and process them. Put no limit on the batch size.
+		if events, err := w.el.Get_Raw_Event_Batch(getFilter(), 0); err != nil {
+			glog.Errorf(logString(fmt.Sprintf("unable to get initial event batch, error %v", err)))
+			return
+		} else {
+			w.handleEvents(events)
+		}
+
+	}
+}
+
+// Process each event in the list
+func (w *EthBlockchainWorker) handleEvents(newEvents []Raw_Event) {
+	for _, ev := range newEvents {
+		if evBytes, err := json.Marshal(ev); err != nil {
+			glog.Errorf(logString(fmt.Sprintf("unable to marshal event %v, error %v", ev, err)))
+		} else {
+			rawEvent := string(evBytes)
+			glog.V(5).Info(logString(fmt.Sprintf("found event: %v", rawEvent)))
+			w.Messages() <- events.NewEthBlockchainEventMessage(events.BC_EVENT, rawEvent, policy.CitizenScientist)
+		}
+	}
+}
+
+func getFilter() []interface{} {
+	filter := []interface{}{}
+	return filter
 }
 
 // ==========================================================================================================

--- a/ethblockchain/connection.go
+++ b/ethblockchain/connection.go
@@ -1,0 +1,84 @@
+package ethblockchain
+
+import (
+    "github.com/golang/glog"
+    "net/url"
+    "regexp"
+    "strconv"
+    "strings"
+)
+
+type RPC_Connection struct {
+    host                  string
+    port                  int
+    fullURL               string
+}
+
+func RPC_Connection_Factory(host string, port int, fullURL string) *RPC_Connection {
+    if len(fullURL) != 0 {
+        if parsed_url,err := url.Parse(fullURL); err != nil {
+            glog.Errorf("Input URL %v is not parseable: %v", fullURL, err)
+            return nil
+        } else if len(parsed_url.Host) == 0 || len(parsed_url.Scheme) == 0 {
+            glog.Errorf("Input URL %v is not parseable, host or scheme is empty", fullURL)
+            return nil
+        } else if parsed_url.Scheme != "http" {
+            glog.Errorf("Input URL %v is not parseable, scheme is not http", fullURL)
+            return nil
+        } else {
+
+            err := error(nil)
+            parsed_host := parsed_url.Host
+            parsed_port := 0
+            if strings.Contains(parsed_host, ":") {
+                parsed_host = parsed_url.Host[:strings.Index(parsed_url.Host,":")]
+                if parsed_port,err = strconv.Atoi(parsed_url.Host[strings.Index(parsed_url.Host,":")+1:]); err != nil {
+                    glog.Errorf("Unable to convert port in input URL %v to an integer: %v", fullURL, err)
+                    return nil
+                }
+            }
+
+            if !validHostName(parsed_host) {
+                glog.Errorf("Input URL %v is not parseable, host name is not valid", fullURL)
+                return nil
+            }
+            return &RPC_Connection{
+                        host: parsed_host,
+                        port: parsed_port,
+                        fullURL: fullURL,
+                    }
+        }
+
+    } else if len(host) == 0 || port == 0 {
+        glog.Errorf("Input host %v is empty or port %v is zero.", host, port)
+        return nil
+    } else if !validHostName(host) {
+        glog.Errorf("Input host %v is not parseable, host name is not valid", host)
+        return nil
+    } else {
+        construct_URL := "http://"+host+":"+strconv.Itoa(port)
+        return &RPC_Connection{
+                        host: host,
+                        port: port,
+                        fullURL: construct_URL,
+                    }
+    }
+}
+
+func (self *RPC_Connection) Get_fullURL() string {
+    return self.fullURL
+}
+
+
+// ================ Utility functions =======================================================
+
+func validHostName(host string) bool {
+    host_regex := `^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`
+    if rx,err := regexp.Compile(host_regex); err != nil {
+        glog.Errorf("Unable to compile hostname regex: %v", err)
+        return false
+    } else {
+        return rx.Match([]byte(host))
+    }
+}
+

--- a/ethblockchain/connection_test.go
+++ b/ethblockchain/connection_test.go
@@ -1,0 +1,46 @@
+package ethblockchain
+
+import (
+    // "fmt"
+    "testing"
+    )
+
+func TestConstructor(t *testing.T) {
+    if c := RPC_Connection_Factory("localhost",8545,""); c == nil {
+        t.Errorf("Factory returned nil, but should not.\n")
+    } else if c.Get_fullURL() != "http://localhost:8545" {
+        t.Errorf("Factory did not correctly construct URL, returned %v\n",c.Get_fullURL())
+    } else if c := RPC_Connection_Factory("",0,"http://localhost:8545"); c == nil {
+        t.Errorf("Factory returned nil, but should not.\n")
+    } else if c.Get_fullURL() != "http://localhost:8545" {
+        t.Errorf("Factory did not correctly construct URL, returned %v\n",c.Get_fullURL())
+    }
+}
+
+func TestBadURLConstructor(t *testing.T) {
+    if c := RPC_Connection_Factory("",0,"blah blah"); c != nil {
+        t.Errorf("Factory should have returned nil, but did not.\n")
+    } else if c := RPC_Connection_Factory("",0,"other://host:1234"); c != nil {
+        t.Errorf("Factory should have returned nil, but did not.\n")
+    } else if c := RPC_Connection_Factory("",0,"host:1234"); c != nil {
+        t.Errorf("Factory should have returned nil, but did not.\n")
+    } else if c := RPC_Connection_Factory("",0,"://host:1234"); c != nil {
+        t.Errorf("Factory should have returned nil, but did not.\n")
+    } else if c := RPC_Connection_Factory("",0,"//host:1234"); c != nil {
+        t.Errorf("Factory should have returned nil, but did not.\n")
+    } else if c := RPC_Connection_Factory("",0,"http://local_host:1234"); c != nil {
+        t.Errorf("Factory should have returned nil, but did not.\n")
+    } else if c := RPC_Connection_Factory("",0,"http://host:host"); c != nil {
+        t.Errorf("Factory should have returned nil, but did not.\n")
+    }
+}
+
+func TestBadConstructor(t *testing.T) {
+    if c := RPC_Connection_Factory("",0,""); c != nil {
+        t.Errorf("Factory should have returned nil, but did not.\n")
+    } else if c := RPC_Connection_Factory("local_host",0,""); c != nil {
+        t.Errorf("Factory should have returned nil, but did not.\n")
+    } else if c := RPC_Connection_Factory("local_host",1,""); c != nil {
+        t.Errorf("Factory should have returned nil, but did not.\n")
+    }
+}

--- a/ethblockchain/event_log.go
+++ b/ethblockchain/event_log.go
@@ -1,0 +1,317 @@
+package ethblockchain
+
+import (
+    "encoding/json"
+    "errors"
+    "fmt"
+    "github.com/golang/glog"
+    "os"
+    "reflect"
+    "strconv"
+    "strings"
+    "sync"
+    "time"
+)
+
+type Event_Log struct {
+    client              *RPC_Client
+    filterId            string
+    contractAddress     string
+    formatter           func(*Raw_Event)string
+    processor           func(*Event_Log, *Raw_Event, interface{})
+    processorContext    interface{}
+    batchStart          uint64
+    batchEnd            uint64
+    batchSize           uint64
+    anyEvents           bool
+}
+
+type Raw_Event struct {
+    LogIndex         string   `json:"logIndex"`
+    TransactionHash  string   `json:"transactionHash"`
+    TransactionIndex string   `json:"transactionIndex"`
+    BlockNumber      string   `json:"blockNumber"`
+    BlockHash        string   `json:"blockHash"`
+    Address          string   `json:"address"`
+    Data             string   `json:"data"`
+    Topics           []string `json:"topics"`
+}
+
+// === global state used to detect when we havent seen a block in a while ===
+type blockSync struct {
+    lastBlockTime  int64    // The unix time in seconds when blockNumber was last updated
+    blockNumber    string   // The last block that was seen, top of the chain
+    blockStable    uint64   // The last block that can be read from
+}
+
+var global_block_state_lock sync.Mutex
+var global_block_state blockSync
+var no_recent_blocks int
+var block_read_delay int
+var block_update_delay int
+
+func update_block(blockNumber uint64) {
+    global_block_state_lock.Lock()
+    defer global_block_state_lock.Unlock()
+
+    newBlock := fmt.Sprintf("0x%x", blockNumber)
+    if global_block_state.blockNumber == "" || newBlock != global_block_state.blockNumber {
+        global_block_state.lastBlockTime = time.Now().Unix()
+        global_block_state.blockNumber = newBlock
+        global_block_state.blockStable = blockNumber - uint64(block_read_delay)
+    }
+}
+
+func (self *Event_Log) get_stable_block() uint64 {
+    delta := time.Now().Unix()-global_block_state.lastBlockTime
+    if int(delta) >= block_update_delay {
+        if block, err := self.client.Get_block_number(); err != nil {
+            glog.Errorf("Error getting current block: %v", err)
+        } else {
+            update_block(block)
+        }
+    }
+
+    return global_block_state.blockStable
+}
+
+func (self *Event_Log) Get_current_stable_block() string {
+    global_block_state_lock.Lock()
+    defer global_block_state_lock.Unlock()
+    res := fmt.Sprintf("0x%x", global_block_state.blockStable)
+    return res
+}
+
+// A factory function used to create Event_Log instances
+func Event_Log_Factory(rpcClient *RPC_Client, contractAddress string) *Event_Log {
+
+    var err error
+
+    if block_read_delay, err = strconv.Atoi(os.Getenv("mtn_soliditycontract_block_read_delay")); err != nil {
+        block_read_delay = 0
+    }
+
+    if block_update_delay, err = strconv.Atoi(os.Getenv("mtn_soliditycontract_block_update_delay")); err != nil {
+        block_update_delay = 10
+    }
+
+    rpcc := rpcClient
+    if rpcc == nil {
+        if rpcc = getRPCClient(); rpcc == nil {
+            return nil
+        }
+    }
+
+    if len(contractAddress) == 0 {
+        glog.Errorf("Input contract address is empty")
+        return nil
+    } else {
+        el := &Event_Log{
+                    client:          rpcc,
+                    filterId:        "",
+                    contractAddress: contractAddress,
+                }
+        return el
+    }
+}
+
+func (self *Event_Log) Set_formatter(f func(*Raw_Event) string) {
+    self.formatter = f
+}
+
+func (self *Event_Log) Set_processor(p func(*Event_Log, *Raw_Event, interface{}), c interface{}) {
+    self.processor = p
+    self.processorContext = c
+}
+
+
+func (self *Event_Log) Get_Raw_Event_Batch(topics []interface{}, size uint64) ([]Raw_Event, error) {
+
+    self.batchStart = 1
+    if bs, err := strconv.Atoi(os.Getenv("bh_event_log_start")); err == nil {
+        self.batchStart = uint64(bs)
+    }
+    self.batchSize = size
+
+    lastBlock := self.get_stable_block()
+
+    if size == 0 {
+        self.batchEnd = lastBlock
+    } else if lastBlock < (self.batchStart + size - 1) {
+        self.batchEnd = lastBlock
+    } else {
+        self.batchEnd = self.batchStart + size -1
+    }
+
+    if self.batchEnd < self.batchStart {
+        self.batchEnd = self.batchStart
+    }
+
+    return self.get_raw_events_in_range(topics, self.batchStart, self.batchEnd)
+}
+
+func (self *Event_Log) Get_Next_Raw_Event_Batch(topics []interface{}, size uint64) ([]Raw_Event, bool, error) {
+    reachedEnd := false
+
+    events := make([]Raw_Event,0,10)
+    if self.batchEnd == 0 {
+        glog.Warningf("For %v previous batch included the latest blocks.", self.contractAddress)
+        return events, true, nil
+    }
+
+    if err := self.remove_Filter(); err != nil {
+        glog.Errorf("For %v could not remove filter: %v", self.contractAddress, err)
+    }
+
+    lastBlock := self.get_stable_block()
+
+    start := self.batchEnd + 1
+    end := start + size - 1
+    if lastBlock <= start {
+        return events, true, nil
+    } else if size == 0 {
+        end = lastBlock
+        reachedEnd = true
+    } else if lastBlock < (start + size - 1) {
+        end = lastBlock
+        reachedEnd = true
+    }
+
+    if end < start {
+        end = start
+        reachedEnd = true
+    }
+
+    if events, err := self.get_raw_events_in_range(topics, start, end); err != nil {
+        return events, true, err
+    } else {
+        self.batchStart = start
+        self.batchSize = size
+        self.batchEnd = end
+        return events, reachedEnd, nil
+    }
+
+}
+
+func (self *Event_Log) get_raw_events_in_range(topics []interface{}, start uint64, end uint64) ([]Raw_Event, error) {
+    events := make([]Raw_Event,0,10)
+
+    if err := self.establish_Filter(start, end, topics); err != nil {
+        glog.Errorf("For %v could not establish filter: %v", self.contractAddress, err)
+        return events, err
+    }
+
+    rpcEventResp := rpcGetEventsResponse{}
+
+    glog.V(5).Infof("Filter %v for %v using client %v ", self.filterId, self.contractAddress, self.client)
+    if out, err := self.client.Invoke("eth_getFilterLogs", self.filterId); err != nil {
+        glog.Errorf("Error occurred getting events for contract %v, error: %v", self.contractAddress , err)
+        return events, errors.New(err.Msg)
+    } else if err := json.Unmarshal([]byte(out), &rpcEventResp); err != nil {
+        glog.Errorf("Error occurred umarshalling getFilterLogs for %v, response: %v", self.contractAddress, err)
+        return events, err
+    } else if rpcEventResp.Error.Message != "" {
+        glog.Errorf("For %v eth_getFilterLogs returned an error: %v", self.contractAddress, rpcEventResp.Error.Message)
+        return events, err
+    } else {
+        events = rpcEventResp.Result
+        if len(events) != 0 {
+            self.anyEvents = true
+        }
+    }
+
+    return events, nil
+}
+
+func (self *Event_Log) clear_Filter() {
+    self.filterId = ""
+}
+
+func (self *Event_Log) establish_Filter(startBlock uint64, endBlock uint64, topics []interface{}) error {
+    if self.filterId == "" {
+        rpcResp := RPC_Response{}
+        params := make(map[string]interface{})
+        params["address"] = self.contractAddress
+        params["fromBlock"] = fmt.Sprintf("0x%x", startBlock)
+        if endBlock != 0 {
+            params["toBlock"] = fmt.Sprintf("0x%x", endBlock)
+        } else {
+            params["toBlock"] = "latest"
+        }
+        theTopics := topics
+
+        for ix, val := range theTopics {
+            switch val.(type) {
+                case string:
+                    v := val.(string)
+                    if len(v) < 66 && !strings.HasPrefix(v, "0x") {
+                        v = "0x" + v
+                    }
+                    if len(v) < 66 {
+                        v = v[:2] + strings.Repeat("0", 66-len(v)) + v[2:]
+                    }
+                    theTopics[ix] = v
+                case nil:
+                default:
+                    return errors.New(fmt.Sprintf("Cannot establish filter, topics must be string or nil, type was %v", reflect.TypeOf(val).String()))
+            }
+        }
+        params["topics"] = theTopics
+        glog.V(5).Infof("For %v creating event filter with params: %v", self.contractAddress, params)
+
+        if out,err := self.client.Invoke("eth_newFilter",params); err != nil {
+            return errors.New(err.Msg)
+        } else if err := json.Unmarshal([]byte(out), &rpcResp); err != nil {
+            return err
+        } else if rpcResp.Error.Message != "" {
+            return errors.New(fmt.Sprintf("Creating event filter returned an error: %v.", rpcResp.Error.Message))
+        } else {
+            self.filterId = rpcResp.Result.(string)
+        }
+    }
+    return nil
+}
+
+func (self *Event_Log) remove_Filter() error {
+    if self.filterId != "" {
+        rpcResp := RPC_Response{}
+        if out,err := self.client.Invoke("eth_uninstallFilter", self.filterId); err != nil {
+            return errors.New(err.Msg)
+        } else if err := json.Unmarshal([]byte(out), &rpcResp); err != nil {
+            return err
+        } else if rpcResp.Error.Message != "" {
+            return errors.New(fmt.Sprintf("Removing event filter returned an error: %v.", rpcResp.Error.Message))
+        } else {
+            self.clear_Filter()
+            return nil
+        }
+    } else {
+        return nil
+    }
+}
+
+func getRPCClient() *RPC_Client {
+    var rpcc *RPC_Client
+
+    if con := RPC_Connection_Factory("", 0, "http://localhost:8545"); con == nil {
+        glog.Errorf("RPC Connection not created")
+        return nil
+    } else if rpcc = RPC_Client_Factory(con); rpcc == nil {
+        glog.Errorf("RPC Client not created")
+        return nil
+    }
+    return rpcc
+}
+
+
+type rpcGetEventsResponse struct {
+    Id      string             `json:"id"`
+    Version string             `json:"jsonrpc"`
+    Result  []Raw_Event        `json:"result"`
+    Error   struct {
+        Code    int    `json:"code"`
+        Message string `json:"message"`
+    } `json:"error"`
+}
+
+

--- a/ethblockchain/event_log_test.go
+++ b/ethblockchain/event_log_test.go
@@ -1,0 +1,12 @@
+package ethblockchain
+
+import (
+	"testing"
+)
+
+func TestClientConstructor(t *testing.T) {
+    if event_log := Event_Log_Factory(nil,"0x0123456789012345678901234567890123456789"); event_log == nil {
+        t.Errorf("Factory returned nil, but should not.\n")
+    }
+}
+

--- a/ethblockchain/rpc.go
+++ b/ethblockchain/rpc.go
@@ -1,0 +1,181 @@
+package ethblockchain
+
+import (
+    "bytes"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "github.com/golang/glog"
+    "io/ioutil"
+    "math/big"
+    "net/http"
+    "os"
+    "strconv"
+    "time"
+)
+
+type RPC_Client struct {
+    connection *RPC_Connection
+    body       map[string]interface{}
+    httpClient * http.Client
+}
+
+func RPC_Client_Factory(connection *RPC_Connection) *RPC_Client {
+    if connection == nil {
+        glog.Errorf("Input connection is nil")
+        return nil
+    } else {
+        rpcc := &RPC_Client{
+                    connection: connection,
+                    body:       make(map[string]interface{}),
+                }
+        rpcc.body["jsonrpc"] = "2.0"
+        rpcc.body["id"] = "1"
+
+        var rpc_timeout time.Duration
+        if rpc_t, err := strconv.Atoi(os.Getenv("bh_rpc_timeout")); err != nil || rpc_t == 0 {
+            rpc_timeout = time.Duration(60 * time.Second)
+        } else {
+            rpc_timeout = time.Duration(rpc_t)
+        }
+
+        rpcc.httpClient = &http.Client{
+            Timeout: time.Duration(rpc_timeout * time.Second),
+        }
+        return rpcc
+    }
+}
+
+func (self *RPC_Client) Get_connection() *RPC_Connection {
+    return self.connection
+}
+
+func (self *RPC_Client) Get_block_number() (uint64,error) {
+
+    if out,err := self.Invoke("eth_blockNumber",nil); err != nil {
+        return 0, errors.New(err.Msg)
+    } else if rpcResp, err := self.decodeResponse([]byte(out)); err != nil {
+        return 0, err
+    } else if block,err := strconv.ParseUint(rpcResp.Result.(string)[2:], 16, 64); err != nil {
+        return 0, err
+    } else {
+        return block, nil
+    }
+
+    return 0, nil
+}
+
+func (self *RPC_Client) Get_balance(address string) (*big.Int,error) {
+
+    bal := big.NewInt(0)
+    p := make([]interface{},0,2)
+    p = append(p,address)
+    p = append(p,"latest")
+
+    if out,err := self.Invoke("eth_getBalance",p); err != nil {
+        return bal, errors.New(err.Msg)
+    } else if rpcResp, err := self.decodeResponse([]byte(out)); err != nil {
+        return bal, err
+    } else {
+        bal_hex_str := rpcResp.Result.(string)
+        // the math/big library doesn't like leading "0x" on hex strings
+        bal.SetString(bal_hex_str[2:],16)
+    }
+
+    return bal,nil
+}
+
+func (self *RPC_Client) Get_first_account() (string,error) {
+
+    if out,err := self.Invoke("eth_accounts",nil); err != nil {
+        return "", errors.New(err.Msg)
+    } else if rpcResp, err := self.decodeResponse([]byte(out)); err != nil {
+        return "", err
+    } else {
+        var resp []interface{}
+        resp = rpcResp.Result.([]interface{})
+        if len(resp) == 0 {
+            return "", errors.New("No accounts returned")
+        } else {
+            acct := resp[0].(string)
+            return acct, nil
+        }
+    }
+}
+
+func (self *RPC_Client) Invoke(method string, params interface{}) (string,*RPCError) {
+
+    out := ""
+    var err *RPCError
+
+    if len(method) == 0 {
+        err = &RPCError{fmt.Sprintf("RPC method name must be non-empty")}
+        glog.Errorf("Error: %v", err.Msg)
+        return out,err
+    }
+
+    self.body["method"] = method
+
+    switch params.(type) {
+    case []interface{}:
+        self.body["params"] = params
+    default:
+        the_params := make([]interface{}, 0, 5)
+        self.body["params"] = append(the_params,params)
+    }
+    
+    glog.V(5).Infof("Invoking %v with %v", method, self.body)
+
+    if jsonBytes, e := json.Marshal(self.body); e != nil {
+        err = &RPCError{fmt.Sprintf("RPC invocation of %v failed creating JSON body %v, error: %v", method, self.body, e.Error())}
+    } else if req, e := http.NewRequest("POST", self.connection.Get_fullURL(), bytes.NewBuffer(jsonBytes)); e != nil {
+        err = &RPCError{fmt.Sprintf("RPC invocation of %v failed creating http request, error: %v", method, e.Error())}
+    } else {
+        req.Close = true            // work around to ensure that Go doesn't get connections confused. Supposed to be fixed in Go 1.6.
+        if resp, e := self.httpClient.Do(req); e != nil {
+            err = &RPCError{fmt.Sprintf("RPC http invocation of %v with %v returned error: %v", method, self.body, e.Error())}
+        } else {
+            defer resp.Body.Close()
+            if outBytes, e := ioutil.ReadAll(resp.Body); e != nil {
+                err = &RPCError{fmt.Sprintf("RPC invocation of %v failed reading response message, error: %v", method, outBytes, e.Error())}
+            } else {
+                out = string(outBytes)
+                glog.V(5).Infof("Response to %v is %v", self.body, out)
+            }
+        }
+    }
+
+    if err != nil {
+        glog.Errorf("Error: %v", err.Msg)
+    }
+
+    return out, err
+}
+
+func (self *RPC_Client) decodeResponse(out []byte) (*RPC_Response,error) {
+    rpcResp := RPC_Response{}
+    if err := json.Unmarshal(out, &rpcResp); err != nil {
+        return nil, err
+    } else if rpcResp.Error.Message != "" {
+        return nil, errors.New(rpcResp.Error.Message)
+    } else {
+        return &rpcResp, nil
+    }
+} 
+
+
+
+type RPC_Response struct {
+    Id      string      `json:"id"`
+    Version string      `json:"jsonrpc"`
+    Result  interface{} `json:"result"`
+    Error   struct {
+        Code    int    `json:"code"`
+        Message string `json:"message"`
+    } `json:"error"`
+}
+
+type RPCError struct {
+    Msg string
+}
+

--- a/ethblockchain/rpc_test.go
+++ b/ethblockchain/rpc_test.go
@@ -1,0 +1,21 @@
+package ethblockchain
+
+import (
+    // "fmt"
+    "testing"
+    )
+
+func TestClient_Constructor(t *testing.T) {
+    rpc_client := RPC_Connection_Factory("localhost",8545,"")
+    if c := RPC_Client_Factory(rpc_client); c == nil {
+        t.Errorf("Factory returned nil, but should not.\n")
+    } else if c.Get_connection().Get_fullURL() != "http://localhost:8545" {
+        t.Errorf("Factory returned a client that does not point to the right connection URL: %v\n", c.Get_connection().Get_fullURL())
+    }
+}
+
+func TestBadClientConstructor(t *testing.T) {
+    if c := RPC_Client_Factory(nil); c != nil {
+        t.Errorf("Factory did not return nil, but should have.\n")
+    }
+}

--- a/events/events.go
+++ b/events/events.go
@@ -23,6 +23,7 @@ const (
 	AGREEMENT_REGISTERED  EventId = "AGREEMENT_REGISTERED"
 	ACCOUNT_FUNDED        EventId = "ACCOUNT_FUNDED"
 	BC_CLIENT_INITIALIZED EventId = "BC_CLIENT_INITIALIZED"
+	BC_EVENT              EventId = "BC_EVENT"
 
 	// whisper related
 	RECEIVED_MSG EventId = "RECEIVED_MSG"
@@ -471,28 +472,63 @@ func NewAccountFundedMessage(id EventId, acct string) *AccountFundedMessage {
 }
 
 // Blockchain client initialized message
-type BlockchainClientInitilizedMessage struct {
+type BlockchainClientInitializedMessage struct {
 	event Event
 	Time  uint64
 }
 
-func (m *BlockchainClientInitilizedMessage) Event() Event {
+func (m *BlockchainClientInitializedMessage) Event() Event {
 	return m.event
 }
 
-func (m BlockchainClientInitilizedMessage) String() string {
+func (m BlockchainClientInitializedMessage) String() string {
 	return fmt.Sprintf("Event: %v, Time: %v", m.Event, m.Time)
 }
 
-func (m BlockchainClientInitilizedMessage) ShortString() string {
+func (m BlockchainClientInitializedMessage) ShortString() string {
 	return m.String()
 }
 
-func NewBlockchainClientInitilizedMessage(id EventId) *BlockchainClientInitilizedMessage {
-	return &BlockchainClientInitilizedMessage{
+func NewBlockchainClientInitializedMessage(id EventId) *BlockchainClientInitializedMessage {
+	return &BlockchainClientInitializedMessage{
 		event: Event{
 			Id: id,
 		},
+		Time: uint64(time.Now().Unix()),
+	}
+}
+
+// Blockchain event occurred
+type EthBlockchainEventMessage struct {
+	event    Event
+	rawEvent string
+	protocol string
+	Time     uint64
+}
+
+func (m *EthBlockchainEventMessage) Event() Event {
+	return m.event
+}
+
+func (m *EthBlockchainEventMessage) RawEvent() string {
+	return m.rawEvent
+}
+
+func (m EthBlockchainEventMessage) String() string {
+	return fmt.Sprintf("Event: %v, Protocol: %v, Raw Event: %v, Time: %v", m.Event, m.rawEvent, m.protocol, m.Time)
+}
+
+func (m EthBlockchainEventMessage) ShortString() string {
+	return fmt.Sprintf("Event: %v, Protocol: %v, Time: %v", m.Event, m.protocol, m.Time)
+}
+
+func NewEthBlockchainEventMessage(id EventId, ev string, protocol string) *EthBlockchainEventMessage {
+	return &EthBlockchainEventMessage{
+		event: Event{
+			Id: id,
+		},
+		rawEvent: ev,
+		protocol: protocol,
 		Time: uint64(time.Now().Unix()),
 	}
 }


### PR DESCRIPTION
The only way to get the agbot reason code is to consume events from the blockchain transactions. That's what the event_log is for. This is the same code that runs at the heart of the smart contract monitor.