### PR TITLE
fixed anax panic when exchange goes down

### DIFF
--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -259,7 +259,7 @@ func (a *CSAgreementWorker) recordConsumerAgreementState(agreementId string, wor
 			glog.Errorf(err.Error())
 			return err
 		} else if tpErr != nil {
-			glog.Warningf(err.Error())
+			glog.Warningf(tpErr.Error())
 			time.Sleep(10 * time.Second)
 			continue
 		} else {

--- a/agreementbot/governance.go
+++ b/agreementbot/governance.go
@@ -138,7 +138,7 @@ func recordConsumerAgreementState(url string, agbotId string, token string, agre
 			glog.Errorf(logString(fmt.Sprintf(err.Error())))
 			return err
 		} else if tpErr != nil {
-			glog.Warningf(err.Error())
+			glog.Warningf(tpErr.Error())
 			time.Sleep(10 * time.Second)
 			continue
 		} else {
@@ -165,7 +165,7 @@ func DeleteConsumerAgreement(url string, agbotId string, token string, agreement
 			glog.Errorf(logString(fmt.Sprintf(err.Error())))
 			return err
 		} else if tpErr != nil {
-			glog.Warningf(err.Error())
+			glog.Warningf(tpErr.Error())
 			time.Sleep(10 * time.Second)
 			continue
 		} else {

--- a/governance/governance.go
+++ b/governance/governance.go
@@ -463,7 +463,7 @@ func recordProducerAgreementState(url string, deviceId string, token string, agr
 			glog.Errorf(logString(fmt.Sprintf(err.Error())))
 			return err
 		} else if tpErr != nil {
-			glog.Warningf(err.Error())
+			glog.Warningf(tpErr.Error())
 			time.Sleep(10 * time.Second)
 			continue
 		} else {
@@ -486,7 +486,7 @@ func deleteProducerAgreement(url string, deviceId string, token string, agreemen
 			glog.Errorf(logString(fmt.Sprintf(err.Error())))
 			return err
 		} else if tpErr != nil {
-			glog.Warningf(err.Error())
+			glog.Warningf(tpErr.Error())
 			time.Sleep(10 * time.Second)
 			continue
 		} else {


### PR DESCRIPTION
1) When the exchange goes down, retry logic logs the wrong variable causing a panic in go.
2) Changed the syncOnInit logic in device and agbot such that it doesnt hold up init when the exchange is down.