### PR TITLE
Feature/reply ack

### DIFF
--- a/agreement/commands.go
+++ b/agreement/commands.go
@@ -37,12 +37,12 @@ func NewAdvertisePolicyCommand(fileName string) *AdvertisePolicyCommand {
 	}
 }
 
-type ReceivedProposalCommand struct {
+type WhisperMessageCommand struct {
 	Msg events.WhisperReceivedMessage
 }
 
-func NewReceivedProposalCommand(msg events.WhisperReceivedMessage) *ReceivedProposalCommand {
-	return &ReceivedProposalCommand{
+func NewWhisperMessageCommand(msg events.WhisperReceivedMessage) *WhisperMessageCommand {
+	return &WhisperMessageCommand{
 		Msg: msg,
 	}
 }

--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -253,6 +253,7 @@ func (w *AgreementBotWorker) InitiateAgreementProtocolHandler(protocol string) {
 						agreementWork := CSHandleReply{
 							workType: REPLY,
 							Reply:    cmd.Msg.Payload(),
+							From:     cmd.Msg.From(),
 						}
 						work <- agreementWork
 						glog.V(5).Infof("AgreementBot queued possible reply message")

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	ExchangeHeartbeat             int    // Seconds between heartbeats
 	AgreementTimeoutS             uint64 // Number of seconds to wait before declaring agreement not finalized in blockchain
 	DVPrefix                      string // When passing agreement ids into a workload container, add this prefix to the agreement id
+	RegistrationDelayS            uint64 // The number of seconds to wait after blockchain init before registering with the exchange. This is for testing initialization ONLY.
 
 	// these Ids could be provided in config or discovered after startup by the system
 	BlockchainAccountId        string

--- a/ethblockchain/blockchainworker.go
+++ b/ethblockchain/blockchainworker.go
@@ -87,7 +87,7 @@ func (w *EthBlockchainWorker) start() {
 					if !notifiedBCReady {
 						// geth initilzed
 						notifiedBCReady = true
-						glog.V(3).Infof(logString(fmt.Sprintf("sending blockchian client initialized event")))
+						glog.V(3).Infof(logString(fmt.Sprintf("sending blockchain client initialized event")))
 						w.initBlockchainEventListener()
 						w.Messages() <- events.NewBlockchainClientInitializedMessage(events.BC_CLIENT_INITIALIZED)
 					}


### PR DESCRIPTION
1) Add an ack (positive or negative) to the agreement protocol. The ack flows from the agbot to the device, confirming (or not) that the agbot received the device's reply and that the agbot is still pursuing the agreement (or not). The ack can be lost, and that's ok because:
2) If the device doesnt get the ack but does see the agreement get written to the blockchain, then the device will treat the blockchain write as if it received a positive ack to its reply message.
3) By design, the device doesn't write its agreement state to the exchange and doesnt start workloads until AFTER it receives a positive ack (or blockchain agreement write) from the agbot. If a negative ack arrives, then the device will simply delete it's database record instead of archiving it because there was never an agreement and therefore it would be confusing to see an archived DB record for an agreement that never happened.
4) Added a small change for Bruce: HZN_EXCHANGE_URL is now passed to workloads.
5) Added a small change for Egan, anax will delay registering with the exchange for some number of seconds after Eth is up. The config parameter is RegistrationDelayS and should NEVER be set anywhere except when running anax device in a test where this delay might be useful.
6) Because this represents a protocol change, the agbots need to be upgraded with this fix BEFORE the devices. Failure to do so will result in agreement flapping until the agbots are upgraded.