### PR TITLE
Feature/api config add

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -271,8 +271,8 @@ func (a *API) horizonDevice(w http.ResponseWriter, r *http.Request) {
 			return nil, true
 		}
 
-		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(successStatusCode)
+		w.Header().Set("Content-Type", "application/json")
 
 		if _, err := w.Write(serial); err != nil {
 			glog.Error(err)
@@ -311,9 +311,6 @@ func (a *API) horizonDevice(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if bail := checkInputString(w, "device.account.email", device.Account.Email); bail {
-			return
-		}
-		if bail := checkInputString(w, "device.id", device.Id); bail {
 			return
 		}
 		if bail := checkInputString(w, "device.name", device.Name); bail {
@@ -719,7 +716,6 @@ func (a *API) serviceAttribute(w http.ResponseWriter, r *http.Request) {
 		}
 
 		body, _ := ioutil.ReadAll(r.Body)
-
 		decoder := json.NewDecoder(bytes.NewReader(body))
 		decoder.UseNumber()
 
@@ -753,6 +749,7 @@ func (a *API) serviceAttribute(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
+		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
 
 		if _, err := w.Write(serial); err != nil {
@@ -760,8 +757,6 @@ func (a *API) serviceAttribute(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
-
-		w.WriteHeader(http.StatusCreated)
 
 	case "OPTIONS":
 		w.Header().Set("Allow", "GET, POST, OPTIONS")
@@ -788,7 +783,6 @@ func (a *API) status(w http.ResponseWriter, r *http.Request) {
 			glog.Errorf("Failed to serialize status object: %v", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 		} else {
-			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
 
 			if _, err := w.Write(serial); err != nil {
@@ -830,8 +824,6 @@ func tokenRandom(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
-
-		w.WriteHeader(http.StatusOK)
 
 	case "OPTIONS":
 		w.Header().Set("Allow", "GET, OPTIONS")
@@ -892,8 +884,8 @@ func writeInputErr(writer http.ResponseWriter, status int, inputErr *APIUserInpu
 		glog.Infof("Error serializing agreement output: %v", err)
 		http.Error(writer, "Internal server error", http.StatusInternalServerError)
 	} else {
-		writer.Header().Set("Content-Type", "application/json")
 		writer.WriteHeader(status)
+		writer.Header().Set("Content-Type", "application/json")
 		if _, err := writer.Write(serial); err != nil {
 			glog.Infof("Error writing response: %v", err)
 			http.Error(writer, "Internal server error", http.StatusInternalServerError)

--- a/api/api.go
+++ b/api/api.go
@@ -774,7 +774,7 @@ func (a *API) serviceAttribute(w http.ResponseWriter, r *http.Request) {
 func (a *API) status(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
-		info := NewInfo(false)
+		info := NewInfo(a.Config)
 
 		if err := WriteGethStatus(a.Config.Edge.GethURL, info.Geth); err != nil {
 			glog.Errorf("Unable to determine geth service facts: %v", err)

--- a/api/status.go
+++ b/api/status.go
@@ -9,29 +9,29 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/open-horizon/anax/config"
 )
 
-type Firmware struct {
-	Definition   string `json:"definition"`
-	FlashVersion string `json:"flash_version"`
+type Configuration struct {
+	ExchangeAPI string `json:"exchange_api"`
 }
 
 type Info struct {
-	Geth         *Geth           `json:"geth"`
-	Firmware     *Firmware       `json:"firmware"`
-	Connectivity map[string]bool `json:"connectivity"`
+	Geth          *Geth           `json:"geth"`
+	Configuration *Configuration  `json:"configuration"`
+	Connectivity  map[string]bool `json:"connectivity"`
 }
 
-func NewInfo(gethRunning bool) *Info {
+func NewInfo(config *config.HorizonConfig) *Info {
 	return &Info{
 		Geth: &Geth{
 			NetPeerCount:   -1,
 			EthSyncing:     false,
 			EthBlockNumber: -1,
+			EthAccounts:    []string{},
 		},
-		Firmware: &Firmware{
-			Definition:   "",
-			FlashVersion: "",
+		Configuration: &Configuration{
+			ExchangeAPI: config.Edge.ExchangeURL,
 		},
 		Connectivity: map[string]bool{},
 	}

--- a/api/status.go
+++ b/api/status.go
@@ -29,6 +29,7 @@ func NewInfo(config *config.HorizonConfig) *Info {
 			EthSyncing:     false,
 			EthBlockNumber: -1,
 			EthAccounts:    []string{},
+			EthBalance:     "",
 		},
 		Configuration: &Configuration{
 			ExchangeAPI: config.Edge.ExchangeURL,
@@ -43,6 +44,7 @@ type Geth struct {
 	EthSyncing     bool     `json:"eth_syncing"`
 	EthBlockNumber int64    `json:"eth_block_number"`
 	EthAccounts    []string `json:"eth_accounts"`
+	EthBalance     string   `json:"eth_balance"` // a string b/c this is a huge number
 }
 
 func WriteGethStatus(gethURL string, geth *Geth) error {
@@ -109,6 +111,8 @@ func WriteGethStatus(gethURL string, geth *Geth) error {
 		geth.NetPeerCount = peers
 	}
 
+	geth.EthBalance = singleResult("eth_getBalance").(string)
+
 	// get the account
 	if account := singleResult("eth_accounts"); account != nil {
 		switch account.(type) {
@@ -119,7 +123,7 @@ func WriteGethStatus(gethURL string, geth *Geth) error {
 				geth.EthAccounts[i] = a1[i].(string)
 			}
 		default:
-			geth.EthAccounts = nil
+			geth.EthAccounts = []string{}
 		}
 	}
 	return nil


### PR DESCRIPTION
Old /status call:

`{
  "geth": {
    "net_peer_count": -1,
    "eth_syncing": true,
    "eth_block_number": -1,
    "eth_accounts": null
  },
  "connectivity": {
    "firmware.bluehorizon.network": true,
    "images.bluehorizon.network": true
  }
}`

New /status call:

`{
  "geth": {
    "net_peer_count": -1,
    "eth_syncing": true,
    "eth_block_number": -1,
    "eth_accounts": [],
    "eth_balance": ""
  },
  "configuration": {
    "exchange_api": "https://exchange.bluehorizon.network/api/v1/"
  },
  "connectivity": {
    "firmware.bluehorizon.network": true,
    "images.bluehorizon.network": true
  }
}`