### PR TITLE
replaced string concat for path building with path.Join() so config param needn't include a trailing slash

### DIFF
--- a/agreement/agreement.go
+++ b/agreement/agreement.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-horizon/anax/worker"
 	gwhisper "github.com/open-horizon/go-whisper"
 	"net/http"
+	"path"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -56,13 +57,13 @@ func NewAgreementWorker(config *config.HorizonConfig, db *bolt.DB, pm *policy.Po
 			Commands: commands,
 		},
 
-		db:         db,
-		httpClient: &http.Client{},
-		protocols:  make(map[string]bool),
-		pm:         pm,
+		db:                  db,
+		httpClient:          &http.Client{},
+		protocols:           make(map[string]bool),
+		pm:                  pm,
 		bcClientInitialized: false,
-		deviceId:   id,
-		deviceToken: token,
+		deviceId:            id,
+		deviceToken:         token,
 	}
 
 	glog.Info("Starting Agreement worker")
@@ -139,7 +140,7 @@ func (w *AgreementWorker) start() {
 
 			// If the device is registered, start heartbeating. If the device isn't registered yet, then we will
 			// start heartbeating when the registration event comes in.
-			targetURL := w.Manager.Config.Edge.ExchangeURL + "devices/" + w.deviceId + "/heartbeat"
+			targetURL := path.Join(w.Manager.Config.Edge.ExchangeURL, "devices", w.deviceId, "heartbeat")
 			go exchange.Heartbeat(w.httpClient, targetURL, w.deviceId, w.deviceToken, w.Worker.Manager.Config.Edge.ExchangeHeartbeat)
 		}
 
@@ -207,7 +208,7 @@ func (w *AgreementWorker) start() {
 				// on agreement worker threads at the same time.
 				if proposal, err := protocolHandler.ValidateProposal(cmd.Msg.Payload()); err != nil {
 					glog.Warningf(logString(fmt.Sprintf("Proposal handler ignoring non-proposal message: %v due to %v", cmd.Msg.Payload(), err)))
-				} else if agAlreadyExists, err := persistence.FindEstablishedAgreements(w.db, citizenscientist.PROTOCOL_NAME, []persistence.EAFilter{persistence.UnarchivedEAFilter(),persistence.IdEAFilter(proposal.AgreementId)}); err != nil {
+				} else if agAlreadyExists, err := persistence.FindEstablishedAgreements(w.db, citizenscientist.PROTOCOL_NAME, []persistence.EAFilter{persistence.UnarchivedEAFilter(), persistence.IdEAFilter(proposal.AgreementId)}); err != nil {
 					glog.Errorf(logString(fmt.Sprintf("unable to retrieve agreements from database, error %v", err)))
 				} else if len(agAlreadyExists) != 0 {
 					glog.Errorf(logString(fmt.Sprintf("agreement %v already exists, ignoring proposal: %v", proposal.AgreementId, proposal.ShortString())))
@@ -239,7 +240,7 @@ func (w *AgreementWorker) maintainWhisperId() {
 
 	getWhisperId := func() string {
 		if wId, err := gwhisper.AccountId(w.Config.Edge.GethURL); err != nil {
-			glog.Errorf(logStringww(fmt.Sprintf("encountered error reading whisper id, error %v",err)))
+			glog.Errorf(logStringww(fmt.Sprintf("encountered error reading whisper id, error %v", err)))
 			return ""
 		} else {
 			return wId
@@ -253,7 +254,7 @@ func (w *AgreementWorker) maintainWhisperId() {
 		if newId != "" {
 			var resp interface{}
 			resp = new(exchange.GetDevicesResponse)
-			targetURL := w.Worker.Manager.Config.Edge.ExchangeURL + "devices/" + w.deviceId
+			targetURL := path.Join(w.Worker.Manager.Config.Edge.ExchangeURL, "devices", w.deviceId)
 			if err, tpErr := exchange.InvokeExchange(w.httpClient, "GET", targetURL, w.deviceId, w.deviceToken, nil, &resp); err != nil || tpErr != nil {
 				glog.Errorf(logStringww(fmt.Sprintf("encountered error getting device info from exchange, error %v, transport error %v", err, tpErr)))
 			} else if dev, there := resp.(*exchange.GetDevicesResponse).Devices[w.deviceId]; there {
@@ -277,13 +278,12 @@ func (w *AgreementWorker) maintainWhisperId() {
 
 }
 
-
 func (w *AgreementWorker) handleDeviceRegistered(cmd *DeviceRegisteredCommand) {
 
 	w.deviceToken = cmd.Token
 
 	// Start the go thread that heartbeats to the exchange
-	targetURL := w.Manager.Config.Edge.ExchangeURL + "devices/" + w.deviceId + "/heartbeat"
+	targetURL := path.Join(w.Manager.Config.Edge.ExchangeURL, "devices", w.deviceId, "/heartbeat")
 	go exchange.Heartbeat(w.httpClient, targetURL, w.deviceId, w.deviceToken, w.Worker.Manager.Config.Edge.ExchangeHeartbeat)
 
 }
@@ -321,13 +321,13 @@ func (w *AgreementWorker) syncOnInit() error {
 			} else if err := w.pm.FinalAgreement(existingPol, ag.CurrentAgreementId); err != nil {
 				glog.Errorf(logString(fmt.Sprintf("cannot update agreement count for %v, error: %v", ag.CurrentAgreementId, err)))
 
-			// There is a small window where an agreement might not have been recorded in the exchange. Let's just make sure.
+				// There is a small window where an agreement might not have been recorded in the exchange. Let's just make sure.
 			} else if ag.AgreementAcceptedTime != 0 {
 
 				var exchangeAgreement map[string]exchange.DeviceAgreement
 				var resp interface{}
 				resp = new(exchange.AllDeviceAgreementsResponse)
-				targetURL := w.Worker.Manager.Config.Edge.ExchangeURL + "devices/" + w.deviceId + "/agreements/" + ag.CurrentAgreementId
+				targetURL := path.Join(w.Worker.Manager.Config.Edge.ExchangeURL, "devices", w.deviceId, "agreements", ag.CurrentAgreementId)
 
 				if err, tpErr := exchange.InvokeExchange(w.httpClient, "GET", targetURL, w.deviceId, w.deviceToken, nil, &resp); err != nil || tpErr != nil {
 					glog.Errorf(logStringww(fmt.Sprintf("encountered error getting device info from exchange, error %v, transport error %v", err, tpErr)))
@@ -442,7 +442,7 @@ func (w *AgreementWorker) advertiseAllPolicies(location string) error {
 		pdr.RegisteredMicroservices = ms
 		var resp interface{}
 		resp = new(exchange.PutDeviceResponse)
-		targetURL := w.Manager.Config.Edge.ExchangeURL + "devices/" + w.deviceId
+		targetURL := path.Join(w.Manager.Config.Edge.ExchangeURL, "devices", w.deviceId)
 
 		glog.V(3).Infof("AgreementWorker Registering microservices: %v at %v", pdr.ShortString(), targetURL)
 
@@ -472,7 +472,7 @@ func (w *AgreementWorker) recordAgreementState(agreementId string, microservice 
 	as.State = state
 	var resp interface{}
 	resp = new(exchange.PostDeviceResponse)
-	targetURL := w.Manager.Config.Edge.ExchangeURL + "devices/" + w.deviceId + "/agreements/" + agreementId
+	targetURL := path.Join(w.Manager.Config.Edge.ExchangeURL, "devices", w.deviceId, "agreements", agreementId)
 	for {
 		if err, tpErr := exchange.InvokeExchange(w.httpClient, "PUT", targetURL, w.deviceId, w.deviceToken, as, &resp); err != nil {
 			glog.Errorf(err.Error())

--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/satori/go.uuid"
 	"math/rand"
 	"net/http"
+	"path"
 	"runtime"
 	"time"
 )
@@ -54,8 +55,8 @@ type CSAgreementWork interface {
 
 type CSInitiateAgreement struct {
 	workType       string
-	ProducerPolicy policy.Policy   // the producer policy received from the exchange
-	ConsumerPolicy policy.Policy   // the consumer policy we're matched up with
+	ProducerPolicy policy.Policy               // the producer policy received from the exchange
+	ConsumerPolicy policy.Policy               // the consumer policy we're matched up with
 	Device         exchange.SearchResultDevice // the device entry in the exchange
 }
 
@@ -102,7 +103,6 @@ type CSCancelAgreement struct {
 func (c CSCancelAgreement) Type() string {
 	return c.workType
 }
-
 
 // This function receives an event to "make a new agreement" from the Process function, and then synchronously calls a function
 // to actually work through the agreement protocol.
@@ -173,7 +173,7 @@ func (a *CSAgreementWorker) start(work chan CSAgreementWork, random *rand.Rand, 
 				} else if agreement.CounterPartyAddress != "" {
 					glog.V(5).Infof(logString(fmt.Sprintf("discarding reply, agreement id %v already received a reply", agreement.CurrentAgreementId)))
 
-				// Now we need to write the info to the exchange and the database
+					// Now we need to write the info to the exchange and the database
 				} else if proposal, err := protocolHandler.DemarshalProposal(agreement.Proposal); err != nil {
 					glog.Errorf(logString(fmt.Sprintf("error validating proposal from pending agreement %v, error: %v", reply.AgreementId(), err)))
 				} else if pol, err := policy.DemarshalPolicy(proposal.TsAndCs); err != nil {
@@ -185,7 +185,7 @@ func (a *CSAgreementWorker) start(work chan CSAgreementWork, random *rand.Rand, 
 				} else if err := a.recordConsumerAgreementState(reply.AgreementId(), pol.APISpecs[0].SpecRef, "Producer agreed"); err != nil {
 					glog.Errorf(logString(fmt.Sprintf("error setting agreement state for %v", reply.AgreementId())))
 
-				// We need to send a reply ack and write the info to the blockchain
+					// We need to send a reply ack and write the info to the blockchain
 				} else if consumerPolicy, err := policy.DemarshalPolicy(agreement.Policy); err != nil {
 					glog.Errorf(logString(fmt.Sprintf("unable to demarshal policy for agreement %v, error %v", reply.AgreementId(), err)))
 				} else {
@@ -294,7 +294,7 @@ func (a *CSAgreementWorker) recordConsumerAgreementState(agreementId string, wor
 	as.State = state
 	var resp interface{}
 	resp = new(exchange.PostDeviceResponse)
-	targetURL := a.config.AgreementBot.ExchangeURL + "agbots/" + a.agbotId + "/agreements/" + agreementId
+	targetURL := path.Join(a.config.AgreementBot.ExchangeURL, "agbots", a.agbotId, "agreements", agreementId)
 	for {
 		if err, tpErr := exchange.InvokeExchange(a.httpClient, "PUT", targetURL, a.agbotId, a.token, &as, &resp); err != nil {
 			glog.Errorf(err.Error())


### PR DESCRIPTION
This change makes use of the configured URL less brittle, esp. b/n the UI and Anax.

Diffs also include go fmt changes to edited files.