### PR TITLE
Feature/hagroup

### DIFF
--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -497,6 +497,8 @@ func (w *AgreementBotWorker) InitiateAgreementProtocolHandler(protocol string) {
 										// Check to see if the device's policy is compatible
 									} else if err := policy.Are_Compatible(producerPolicy, &consumerPolicy); err != nil {
 										glog.Errorf("AgreementBot received error comparing %v and %v, error: %v", *producerPolicy, consumerPolicy, err)
+									} else if err := w.incompleteHAGroup(dev, producerPolicy); err != nil {
+										glog.Warningf("AgreementBot received error checking HA group %v completeness for device %v, error: %v", producerPolicy.HAGroup, dev.Id, err)
 									} else {
 										agreementWork := CSInitiateAgreement{
 											workType:       INITIATE,
@@ -602,14 +604,33 @@ func (w *AgreementBotWorker) syncOnInit() error {
 					if err := DeleteConsumerAgreement(w.Config.AgreementBot.ExchangeURL, w.agbotId, w.token, ag.CurrentAgreementId); err != nil {
 						glog.Errorf(AWlogString(fmt.Sprintf("error deleting agreement %v in exchange: %v", ag.CurrentAgreementId, err)))
 					}
-					w.pwcommands <- NewAgreementTimeoutCommand(ag.CurrentAgreementId, ag.AgreementProtocol, citizenscientist.AB_CANCEL_POLICY_CHANGED)
-				} else if err := w.pm.MatchesMine(pol); err != nil {
-					glog.Errorf(AWlogString(fmt.Sprintf("agreement %v has a policy %v that has changed: %v", ag.CurrentAgreementId, pol.Header.Name, err)))
-					// Update state in exchange
-					if err := DeleteConsumerAgreement(w.Config.AgreementBot.ExchangeURL, w.agbotId, w.token, ag.CurrentAgreementId); err != nil {
-						glog.Errorf(AWlogString(fmt.Sprintf("error deleting agreement %v in exchange: %v", ag.CurrentAgreementId, err)))
+					// Remove any workload usage records so that a new agreement will be made starting from the highest priority workload
+					if err := DeleteWorkloadUsage(w.db, ag.DeviceId, ag.PolicyName); err != nil {
+						glog.Warningf(AWlogString(fmt.Sprintf("error deleting workload usage for %v using policy %v, error: %v", ag.DeviceId, ag.PolicyName, err)))
 					}
 					w.pwcommands <- NewAgreementTimeoutCommand(ag.CurrentAgreementId, ag.AgreementProtocol, citizenscientist.AB_CANCEL_POLICY_CHANGED)
+				} else if err := w.pm.MatchesMine(pol); err != nil {
+					glog.Warningf(AWlogString(fmt.Sprintf("agreement %v has a policy %v that has changed: %v", ag.CurrentAgreementId, pol.Header.Name, err)))
+
+					// Remove any workload usage records (non-HA) or mark for pending upgrade (HA). There might not be a workload usage record
+					// if the consumer policy does not specify the workload priority section.
+					if wlUsage, err := FindSingleWorkloadUsageByDeviceAndPolicyName(w.db, ag.DeviceId, ag.PolicyName); err != nil {
+						glog.Warningf(AWlogString(fmt.Sprintf("error retreiving workload usage for %v using policy %v, error: %v", ag.DeviceId, ag.PolicyName, err)))
+					} else if wlUsage != nil && len(wlUsage.HAPartners) != 0 && wlUsage.PendingUpgradeTime != 0 {
+						// Skip this agreement, it is part of an HA group where another member is upgrading
+						continue
+					} else if wlUsage != nil && len(wlUsage.HAPartners) != 0 && wlUsage.PendingUpgradeTime == 0 {
+						for _, partnerId := range wlUsage.HAPartners {
+							if _, err := UpdatePendingUpgrade(w.db, partnerId, ag.PolicyName); err != nil {
+								glog.Warningf(AWlogString(fmt.Sprintf("could not update pending workload upgrade for %v using policy %v, error: %v", partnerId, ag.PolicyName, err)))
+							}
+						}
+						// Choose this device's agreement within the HA group to start upgrading
+						w.cleanupAgreement(&ag)
+					} else {
+						// Non-HA device or agrement without workload priority in the policy, re-make the agreement
+						w.cleanupAgreement(&ag)
+					}
 				} else if err := w.pm.AttemptingAgreement(existingPol, ag.CurrentAgreementId); err != nil {
 					glog.Errorf(AWlogString(fmt.Sprintf("cannot update agreement count for %v, error: %v", ag.CurrentAgreementId, err)))
 				} else if err := w.pm.FinalAgreement(existingPol, ag.CurrentAgreementId); err != nil {
@@ -651,7 +672,7 @@ func (w *AgreementBotWorker) syncOnInit() error {
 				// This state should never occur, but could if there was an error along the way. It means that a DB record
 				// was created for this agreement but the record was never updated with the creation time, which is supposed to occur
 				// immediately following creation of the record. Further, if this were to occur, then the exchange should not have been
-				// updated, so there is no reason to try to clean that up.
+				// updated, so there is no reason to try to clean that up. Same is true for the workload usage records.
 			} else if ag.AgreementInceptionTime != 0 && ag.AgreementCreationTime == 0 {
 				if err := DeleteAgreement(w.db, ag.CurrentAgreementId, citizenscientist.PROTOCOL_NAME); err != nil {
 					glog.Errorf(AWlogString(fmt.Sprintf("error deleting partially created agreement: %v, error: %v", ag.CurrentAgreementId, err)))
@@ -665,6 +686,20 @@ func (w *AgreementBotWorker) syncOnInit() error {
 
 	glog.V(3).Infof(AWlogString("sync up completed normally."))
 	return nil
+}
+
+func (w *AgreementBotWorker) cleanupAgreement(ag *Agreement) {
+	// Update state in exchange
+	if err := DeleteConsumerAgreement(w.Config.AgreementBot.ExchangeURL, w.agbotId, w.token, ag.CurrentAgreementId); err != nil {
+		glog.Errorf(AWlogString(fmt.Sprintf("error deleting agreement %v in exchange: %v", ag.CurrentAgreementId, err)))
+	}
+
+	// Delete this workload usage record so that a new agreement will be made starting from the highest priority workload
+	if err := DeleteWorkloadUsage(w.db, ag.DeviceId, ag.PolicyName); err != nil {
+		glog.Warningf(AWlogString(fmt.Sprintf("error deleting workload usage for %v using policy %v, error: %v", ag.DeviceId, ag.PolicyName, err)))
+	}
+
+	w.pwcommands <- NewAgreementTimeoutCommand(ag.CurrentAgreementId, ag.AgreementProtocol, citizenscientist.AB_CANCEL_POLICY_CHANGED)
 }
 
 func (w *AgreementBotWorker) recordConsumerAgreementState(agreementId string, workloadID string, state string) error {
@@ -688,6 +723,58 @@ func (w *AgreementBotWorker) recordConsumerAgreementState(agreementId string, wo
 		} else {
 			glog.V(5).Infof(AWlogString(fmt.Sprintf("set agreement %v to state %v", agreementId, state)))
 			return nil
+		}
+	}
+
+}
+
+// This function checks the Exchange for every declared HA partner to verify that the partner is registered in the
+// exchange. As long as all partners are registered, agreements can be made. The partners dont have to be up and heart
+// beating, they just have to be registered. If not all partners are registered then no agreements will be attempted
+// with any of the registered partners.
+func (w *AgreementBotWorker) incompleteHAGroup(dev exchange.SearchResultDevice, producerPolicy *policy.Policy) error {
+
+	// If the HA group specification is empty, there is nothing to check.
+	if len(producerPolicy.HAGroup.Partners) == 0  {
+		return nil
+	} else {
+
+		// Make sure all partners are in the exchange
+		for _, partnerId := range producerPolicy.HAGroup.Partners {
+
+			if _, err := getTheDevice(partnerId, w.Config.AgreementBot.ExchangeURL, w.agbotId, w.token); err != nil {
+				glog.Warningf(AWlogString(fmt.Sprintf("could not obtain device %v from the exchange: %v", partnerId, err)))
+				return err
+			}
+		}
+		return nil
+
+	}
+}
+
+func getTheDevice(deviceId string, url string, agbotId string, token string) (*exchange.Device, error) {
+
+	glog.V(5).Infof(AWlogString(fmt.Sprintf("retrieving device %v from exchange", deviceId)))
+
+	var resp interface{}
+	resp = new(exchange.GetDevicesResponse)
+	targetURL := url + "devices/" + deviceId
+	for {
+		if err, tpErr := exchange.InvokeExchange(&http.Client{}, "GET", targetURL, agbotId, token, nil, &resp); err != nil {
+			glog.Errorf(AWlogString(fmt.Sprintf(err.Error())))
+			return nil, err
+		} else if tpErr != nil {
+			glog.Warningf(tpErr.Error())
+			time.Sleep(10 * time.Second)
+			continue
+		} else {
+			devs := resp.(*exchange.GetDevicesResponse).Devices
+			if dev, there := devs[deviceId]; !there {
+				return nil, errors.New(fmt.Sprintf("device %v not in GET response %v as expected", deviceId, devs))
+			} else {
+				glog.V(5).Infof(AWlogString(fmt.Sprintf("retrieved device %v from exchange %v", deviceId, dev)))
+				return &dev, nil
+			}
 		}
 	}
 

--- a/agreementbot/wl_persistence.go
+++ b/agreementbot/wl_persistence.go
@@ -1,0 +1,326 @@
+package agreementbot
+
+import (
+    "encoding/json"
+    "errors"
+    "fmt"
+    "github.com/boltdb/bolt"
+    "github.com/golang/glog"
+    "strconv"
+    "time"
+)
+
+const WORKLOAD_USAGE = "workload_usage"
+
+type WorkloadUsage struct {
+    Id                 uint64   `json:"record_id"`             // unique primary key for records
+    DeviceId           string   `json:"device_id"`             // the device id we are working with, immutable after construction
+    HAPartners         []string `json:"ha_partners"`           // list of deviceis which are partners to this device
+    PendingUpgradeTime uint64   `json:"pending_upgrade_time"`  // time when this usage was marked for pending upgrade
+    Policy             string   `json:"policy"`                // the policy containing the workloads we're managing
+    PolicyName         string   `json:"policy_name"`           // the name of the policy containing the workloads we're managing
+    Priority           int      `json:"priority"`              // the workload priority that we're working with 
+    RetryCount         int      `json:"retry_count"`           // The number of retries attempted so far
+    RetryDurationS     int      `json:"retry_durations"`       // The number of seconds in which the specified number of retries must occur in order for the next priority workload to be attempted.
+    CurrentAgreementId string   `json:"current_agreement_id"`  // the agreement id currently in use
+    FirstTryTime       uint64   `json:"first_try_time"`        // time when first agrement attempt was made, used to count retries per time
+    LatestRetryTime    uint64   `json:"latest_retry_time"`     // time when the newest retry has occurred
+}
+
+func (w WorkloadUsage) String() string {
+    return fmt.Sprintf("Id: %v, " +
+        "DeviceId: %v, " +
+        "HA Partners: %v, " +
+        "Pending Upgrade Time: %v, " +
+        "PolicyName: %v, " +
+        "Priority: %v, " +
+        "RetryCount: %v, " +
+        "RetryDurationS: %v, " +
+        "CurrentAgreementId: %v, " +
+        "FirstTryTime: %v, " +
+        "LatestRetryTime: %v, " +
+        "Policy: %v",
+        w.Id, w.DeviceId, w.HAPartners, w.PendingUpgradeTime, w.PolicyName, w.Priority, w.RetryCount,
+        w.RetryDurationS, w.CurrentAgreementId, w.FirstTryTime, w.LatestRetryTime, w.Policy)
+}
+
+// private factory method for workloadusage w/out persistence safety:
+func workloadUsage(deviceid string, hapartners []string, policy string, policyName string, priority int, retryDurationS int, agid string) (*WorkloadUsage, error) {
+
+    if deviceid == "" || policy == "" || policyName == "" || priority == 0 || retryDurationS == 0 || agid == "" {
+        return nil, errors.New("Illegal input: one of deviceid, policy, policyName, priority, retryDurationS, retryLimit or agreement id is empty")
+    } else {
+        return &WorkloadUsage{
+            DeviceId:           deviceid,
+            HAPartners:         hapartners,
+            PendingUpgradeTime: 0,
+            Policy:             policy,
+            PolicyName:         policyName,
+            Priority:           priority,
+            RetryCount:         0,
+            RetryDurationS:     retryDurationS,
+            CurrentAgreementId: agid,
+            FirstTryTime:       uint64(time.Now().Unix()),
+            LatestRetryTime:    0,
+        }, nil
+    }
+}
+
+func NewWorkloadUsage(db *bolt.DB, deviceid string, hapartners []string, policy string, policyName string, priority int, retryDurationS int, agid string) error {
+    if wlUsage, err := workloadUsage(deviceid, hapartners, policy, policyName, priority, retryDurationS, agid); err != nil {
+        return err
+    } else if existing, err := FindSingleWorkloadUsageByDeviceAndPolicyName(db, deviceid, policyName); err != nil {
+        return err
+    } else if existing != nil {
+        return fmt.Errorf("Workload usage record with device id %v and policy name %v already exists.", deviceid, policyName)
+    } else if err := WUPersistNew(db, wuBucketName(), wlUsage); err != nil {
+        return err
+    } else {
+        return nil
+    }
+}
+
+func UpdateRetryCount(db *bolt.DB, deviceid string, policyName string, retryCount int, agid string) (*WorkloadUsage, error) {
+    if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
+        w.CurrentAgreementId = agid
+        w.RetryCount = retryCount
+        // Reset the retry interval time. There is a big assumption here, which is that the caller has already made sure
+        // that it's not time to switch the workload usage to a different priority, and therefore the reason for updating
+        // the retry count is because the caller thinks they want to stay with the current workload. Since we know it's ok
+        // to stay with the current workload priority, then we can safely start a new retry interval. It's important to have
+        // an accurate current workload interval in case the workload starts misbehaving.
+        now := uint64(time.Now().Unix())
+        w.LatestRetryTime = now
+        if w.FirstTryTime + uint64(w.RetryDurationS) < now {
+            w.FirstTryTime = uint64(time.Now().Unix())
+            w.RetryCount = 1       // We used one retry simply because we are here updating retry counts.
+        }
+        return &w
+    }); err != nil {
+        return nil, err
+    } else {
+        return wlUsage, nil
+    }
+}
+
+func UpdatePriority(db *bolt.DB, deviceid string, policyName string, priority int, retryDurationS int, agid string) (*WorkloadUsage, error) {
+    if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
+        w.CurrentAgreementId = agid
+        w.Priority = priority
+        w.RetryCount = 0
+        w.RetryDurationS = retryDurationS
+        w.FirstTryTime = uint64(time.Now().Unix())
+        return &w
+    }); err != nil {
+        return nil, err
+    } else {
+        return wlUsage, nil
+    }
+}
+
+func UpdatePendingUpgrade(db *bolt.DB, deviceid string, policyName string) (*WorkloadUsage, error) {
+    if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
+        w.PendingUpgradeTime = uint64(time.Now().Unix())
+        return &w
+    }); err != nil {
+        return nil, err
+    } else {
+        return wlUsage, nil
+    }
+}
+
+func UpdateWUAgreementId(db *bolt.DB, deviceid string, policyName string, agid string) (*WorkloadUsage, error) {
+    if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
+        w.CurrentAgreementId = agid
+        return &w
+    }); err != nil {
+        return nil, err
+    } else {
+        return wlUsage, nil
+    }
+}
+
+func FindSingleWorkloadUsageByDeviceAndPolicyName(db *bolt.DB, deviceid string, policyName string) (*WorkloadUsage, error) {
+    filters := make([]WUFilter, 0)
+    filters = append(filters, DaPWUFilter(deviceid, policyName))
+
+    if wlUsages, err := FindWorkloadUsages(db, filters); err != nil {
+        return nil, err
+    } else if len(wlUsages) > 1 {
+        return nil, fmt.Errorf("Expected only one record for device: %v and policy: %v, but retrieved: %v", deviceid, policyName, wlUsages)
+    } else if len(wlUsages) == 0 {
+        return nil, nil
+    } else {
+        return &wlUsages[0], nil
+    }
+}
+
+func singleWorkloadUsageUpdate(db *bolt.DB, deviceid string, policyName string, fn func(WorkloadUsage) *WorkloadUsage) (*WorkloadUsage, error) {
+    if wlUsage, err := FindSingleWorkloadUsageByDeviceAndPolicyName(db, deviceid, policyName); err != nil {
+        return nil, err
+    } else if wlUsage == nil {
+        return nil, fmt.Errorf("Unable to locate workload usage for device: %v, and policy: %v", deviceid, policyName)
+    } else {
+        updated := fn(*wlUsage)
+        return updated, persistUpdatedWorkloadUsage(db, wlUsage.Id, updated)
+    }
+}
+
+// does whole-member replacements of values that are legal to change during the course of a workload usage
+func persistUpdatedWorkloadUsage(db *bolt.DB, id uint64, update *WorkloadUsage) error {
+    return db.Update(func(tx *bolt.Tx) error {
+        if b, err := tx.CreateBucketIfNotExists([]byte(wuBucketName())); err != nil {
+            return err
+        } else {
+            pKey := strconv.FormatUint(id, 10)
+            current := b.Get([]byte(pKey))
+            var mod WorkloadUsage
+
+            if current == nil {
+                return fmt.Errorf("No workload usage with id %v available to update", pKey)
+            } else if err := json.Unmarshal(current, &mod); err != nil {
+                return fmt.Errorf("Failed to unmarshal workload usage DB data: %v", string(current))
+            } else {
+
+                // write updates only to the fields we expect should be updateable
+                mod.Priority = update.Priority
+                mod.RetryCount = update.RetryCount
+                mod.RetryDurationS = update.RetryDurationS
+                mod.CurrentAgreementId = update.CurrentAgreementId
+                mod.FirstTryTime = update.FirstTryTime
+                mod.PendingUpgradeTime = update.PendingUpgradeTime
+                mod.LatestRetryTime = update.LatestRetryTime
+
+                if serialized, err := json.Marshal(mod); err != nil {
+                    return fmt.Errorf("Failed to serialize workload usage record: %v", mod)
+                } else if err := b.Put([]byte(pKey), serialized); err != nil {
+                    return fmt.Errorf("Failed to write workload usage record with key: %v", pKey)
+                } else {
+                    glog.V(2).Infof("Succeeded updating workload usage record to %v", mod)
+                }
+            }
+        }
+        return nil
+    })
+}
+
+func DeleteWorkloadUsage(db *bolt.DB, deviceid string, policyName string) error {
+    if deviceid == "" || policyName == "" {
+        return fmt.Errorf("Missing required arg deviceid or policyName")
+    } else {
+
+        if wlUsage, err := FindSingleWorkloadUsageByDeviceAndPolicyName(db, deviceid, policyName); err != nil {
+            return err
+        } else if wlUsage == nil {
+            return fmt.Errorf("Unable to locate workload usage for device: %v, and policy: %v", deviceid, policyName)
+        } else {
+
+            pk := wlUsage.Id
+            return db.Update(func(tx *bolt.Tx) error {
+                b := tx.Bucket([]byte(wuBucketName()))
+                if b == nil {
+                    return fmt.Errorf("Unknown bucket: %v", wuBucketName())
+                } else if existing := b.Get([]byte(strconv.FormatUint(pk, 10))); existing == nil {
+                    glog.Errorf("Warning: record deletion requested, but record does not exist: %v", pk)
+                    return nil // handle already-deleted workload usage as success
+                } else {
+                    var record WorkloadUsage
+
+                    if err := json.Unmarshal(existing, &record); err != nil {
+                        glog.Errorf("Error deserializing workload usage: %v. This is a pre-deletion warning message function so deletion will still proceed", record)
+                    }
+                }
+
+                glog.V(3).Infof("Deleting workload usage record for %v with policy %v", deviceid, policyName)
+                return b.Delete([]byte(strconv.FormatUint(pk, 10)))
+            })
+        }
+    }
+}
+
+func DaPWUFilter(deviceid string, policyName string) WUFilter {
+    return func(a WorkloadUsage) bool { return a.DeviceId == deviceid && a.PolicyName == policyName }
+}
+
+func DWUFilter(deviceid string) WUFilter {
+    return func(a WorkloadUsage) bool { return a.DeviceId == deviceid }
+}
+
+func PWUFilter(policyName string) WUFilter {
+    return func(a WorkloadUsage) bool { return a.PolicyName == policyName }
+}
+
+type WUFilter func(WorkloadUsage) bool
+
+func FindWorkloadUsages(db *bolt.DB, filters []WUFilter) ([]WorkloadUsage, error) {
+    wlUsages := make([]WorkloadUsage, 0)
+
+    readErr := db.View(func(tx *bolt.Tx) error {
+
+        if b := tx.Bucket([]byte(wuBucketName())); b != nil {
+            b.ForEach(func(k, v []byte) error {
+
+                var a WorkloadUsage
+
+                if err := json.Unmarshal(v, &a); err != nil {
+                    glog.Errorf("Unable to deserialize db record: %v", v)
+                } else {
+                    glog.V(5).Infof("Demarshalled workload usage in DB: %v", a)
+                    exclude := false
+                    for _, filterFn := range filters {
+                        if !filterFn(a) {
+                            exclude = true
+                        }
+                    }
+                    if !exclude {
+                        wlUsages = append(wlUsages, a)
+                    }
+                }
+                return nil
+            })
+        }
+
+        return nil // end the transaction
+    })
+
+    if readErr != nil {
+        return nil, readErr
+    } else {
+        return wlUsages, nil
+    }
+}
+
+// This function allocates the record's primary key from the DB's internal sequence counter. The record
+// being created is updated with this key right before it is written. This function assumes that duplicate
+// record checks have already occurred before it is called.
+func WUPersistNew(db *bolt.DB, bucket string, record *WorkloadUsage) error {
+    if bucket == "" {
+        return fmt.Errorf("Missing required arg bucket")
+    } else {
+        writeErr := db.Update(func(tx *bolt.Tx) error {
+
+            if b, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
+                return err
+            } else if nextKey, err := b.NextSequence(); err != nil {
+                return fmt.Errorf("Unable to get sequence key for new record %v. Error: %v", record, err)
+            } else {
+                strKey := strconv.FormatUint(nextKey, 10)
+                record.Id = nextKey
+                if bytes, err := json.Marshal(record); err != nil {
+                    return fmt.Errorf("Unable to serialize record %v. Error: %v", record, err)
+                } else if err := b.Put([]byte(strKey), bytes); err != nil {
+                    return fmt.Errorf("Unable to write record to bucket %v. Primary key of record: %v", bucket, strKey)
+                } else {
+                    glog.V(2).Infof("Succeeded writing workload usage record identified by key %v, record %v in %v", strKey, *record, bucket)
+                    return nil
+                }
+            }
+        })
+
+        return writeErr
+    }
+}
+
+func wuBucketName() string {
+    return WORKLOAD_USAGE
+}

--- a/agreementbot/wl_persistence_int_test.go
+++ b/agreementbot/wl_persistence_int_test.go
@@ -1,0 +1,78 @@
+// +build integration
+
+package agreementbot
+
+import (
+    "github.com/boltdb/bolt"
+    "io/ioutil"
+    "os"
+    "testing"
+    "time"
+)
+
+var testDb *bolt.DB
+
+func TestMain(m *testing.M) {
+    testDbFile, err := ioutil.TempFile("", "agreementbot_test.db")
+    if err != nil {
+        panic(err)
+    }
+    defer os.Remove(testDbFile.Name())
+
+    var dbErr error
+    testDb, dbErr = bolt.Open(testDbFile.Name(), 0600, &bolt.Options{Timeout: 10 * time.Second})
+    if dbErr != nil {
+        panic(err)
+    }
+
+    m.Run()
+}
+
+func Test_SaveNewRecord1(t *testing.T) {
+
+    deviceid := "an12345"
+    pName := "test policy"
+
+    if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 1, 30, "AG1"); err != nil {
+        t.Errorf("Received error creating new workload usage: %v", err)
+    } else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
+        t.Errorf("Received error finding new record: %v", err)
+    } else if wlu.Priority != 1 {
+        t.Errorf("Record received on read does not have the right priority, expecting 1, was %v", wlu.Priority)
+    }
+
+    if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 1, 30, "AG1"); err == nil {
+        t.Errorf("Should have received error creating duplicate record")
+    }
+
+    deviceid = "an54321"
+    if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
+        t.Errorf("Received error finding non-existent record: %v", err)
+    } else if wlu != nil {
+        t.Errorf("Received record %v that should not have been returned.", wlu)
+    }
+
+}
+
+func Test_SaveNewRecord2(t *testing.T) {
+
+    deviceid := "an67890"
+    pName := "test policy"
+
+    if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 2, 30, "AG1"); err != nil {
+        t.Errorf("Received error creating new workload usage: %v", err)
+    } else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
+        t.Errorf("Received error finding new record: %v", err)
+    } else if wlu.Priority != 2 {
+        t.Errorf("Record received on read does not have the right priority, expecting 1, was %v", wlu.Priority)
+    }
+
+    if err := DeleteWorkloadUsage(testDb, deviceid, pName); err != nil {
+        t.Errorf("Received error deleting workload usage: %v", err)
+    } else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
+        t.Errorf("Received error finding new record: %v", err)
+    } else if wlu != nil {
+        t.Errorf("Received record %v that should not have been returned.", wlu)
+    }
+
+}

--- a/citizenscientist/protocol.go
+++ b/citizenscientist/protocol.go
@@ -28,7 +28,7 @@ type Proposal struct {
 	Type           string `json:"type"`
 	Protocol       string `json:"protocol"`
 	Version        int    `json:"version"`
-	TsAndCs        string `json:"tsandcs"`
+	TsAndCs        string `json:"tsandcs"`        // This is a JSON serialized policy file, merged between consumer and producer. It has 1 workload array element.
 	ProducerPolicy string `json:"producerPolicy"`
 	AgreementId    string `json:"agreementId"`
 	Address        string `json:"address"`
@@ -197,9 +197,9 @@ func NewProtocolHandler(gethURL string, pm *policy.PolicyManager) *ProtocolHandl
 	}
 }
 
-func (p *ProtocolHandler) InitiateAgreement(agreementId string, producerPolicy *policy.Policy, consumerPolicy *policy.Policy, myAddress string, myId string, messageTarget interface{}, defaultPW string, sendMessage func(msgTarget interface{}, pay []byte) error) (*Proposal, error) {
+func (p *ProtocolHandler) InitiateAgreement(agreementId string, producerPolicy *policy.Policy, consumerPolicy *policy.Policy, myAddress string, myId string, messageTarget interface{}, workload *policy.Workload, defaultPW string, sendMessage func(msgTarget interface{}, pay []byte) error) (*Proposal, error) {
 
-	if TCPolicy, err := policy.Create_Terms_And_Conditions(producerPolicy, consumerPolicy, agreementId, defaultPW); err != nil {
+	if TCPolicy, err := policy.Create_Terms_And_Conditions(producerPolicy, consumerPolicy, workload, agreementId, defaultPW); err != nil {
 		return nil, errors.New(fmt.Sprintf("CS Protocol initiation received error trying to merge policy %v and %v, error: %v", producerPolicy, consumerPolicy, err))
 	} else {
 		glog.V(5).Infof("Merged Policy %v", *TCPolicy)

--- a/doc/api.md
+++ b/doc/api.md
@@ -79,6 +79,7 @@ body:
 | name | string | the user readable name for the device  |
 | token_valid | bool| whether the device token is valid or not |
 | token_last_valid_time | uint64 | the time stamp when the device token was last valid. |
+| ha_device | bool | whether the device is part of an HA group or not |
 | account | json | the account information for the user who owns this device. |
 | account.id | string |  the user id on the account.   |
 | account.email | string | the user email on the account. |
@@ -413,7 +414,7 @@ attribute
 | id | string| the id of the attribute. |
 | ---- | ---- | ---------------- |
 | label | string | the user readable name of the attribute |
-| short_type| string | the short type name of the service. This filed is ominted if it is empty. Supported types are: compute, location, architecture and mapped. |
+| short_type| string | the short type name of the service. This filed is omitted if it is empty. Supported types are: compute, location, architecture, ha, and mapped. |
 | sensor_urls | array | an array of sensor url. It applies to all services if it is empty. |
 | publishable| bool | whether the attribute can be made public or not. |
 | mappings | map | a list of key value pairs. |

--- a/persistence/device.go
+++ b/persistence/device.go
@@ -29,6 +29,7 @@ type ExchangeDevice struct {
 	Token              string          `json:"token"`
 	TokenLastValidTime uint64          `json:"token_last_valid_time"`
 	TokenValid         bool            `json:"token_valid"`
+	HADevice           bool            `json:"ha_device"`
 }
 
 func (e ExchangeDevice) String() string {
@@ -43,7 +44,7 @@ func (e ExchangeDevice) String() string {
 }
 
 // TODO: removed check for email set temporarily until the new account mgmt. stuff is released
-func newExchangeDevice(token string, name string, tokenLastValidTime uint64, account *ExchangeAccount) (*ExchangeDevice, error) {
+func newExchangeDevice(token string, name string, tokenLastValidTime uint64, ha bool,  account *ExchangeAccount) (*ExchangeDevice, error) {
 	if token == "" || name == "" || tokenLastValidTime == 0 || account == nil || account.Id == "" {
 		return nil, errors.New("Cannot create exchange account, illegal arguments")
 	}
@@ -56,6 +57,7 @@ func newExchangeDevice(token string, name string, tokenLastValidTime uint64, acc
 		Token:              token,
 		TokenLastValidTime: tokenLastValidTime,
 		TokenValid:         true,
+		HADevice:           ha,
 		Account:            *account,
 	}, nil
 }
@@ -138,7 +140,7 @@ func updateExchangeDeviceToken(db *bolt.DB, accountId string, token string) (*Ex
 }
 
 // always assumed the given token is valid at the time of call
-func SaveNewExchangeDevice(db *bolt.DB, token string, name string, accountId string, accountEmail string) (*ExchangeDevice, error) {
+func SaveNewExchangeDevice(db *bolt.DB, token string, name string, accountId string, accountEmail string, ha bool) (*ExchangeDevice, error) {
 
 	if token == "" || name == "" || accountId == "" {
 		return nil, errors.New("Argument null and must not be")
@@ -162,7 +164,7 @@ func SaveNewExchangeDevice(db *bolt.DB, token string, name string, accountId str
 		return nil, fmt.Errorf("Duplicate record found in devices for %v.", name)
 	}
 
-	exDevice, err := newExchangeDevice(token, name, uint64(time.Now().Unix()), &ExchangeAccount{
+	exDevice, err := newExchangeDevice(token, name, uint64(time.Now().Unix()), ha, &ExchangeAccount{
 		Id:    accountId,
 		Email: accountEmail,
 	})

--- a/policy/ha_group.go
+++ b/policy/ha_group.go
@@ -1,0 +1,18 @@
+package policy
+
+import (
+)
+
+// The purpose of this file is to abstract the operations on the HA Group type.
+
+type HighAvailabilityGroup struct {
+    Partners []string `json:"partners"`
+}
+
+// This function creates HAGroup objects
+func HAGroup_Factory(partners []string) *HighAvailabilityGroup {
+    g := new(HighAvailabilityGroup)
+    g.Partners = partners
+
+    return g
+}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -10,7 +10,7 @@ import (
 )
 
 // This function generates policy files for each sensor on the device.
-func GeneratePolicy(e chan events.Message, sensorName string, arch string, props *map[string]string, filePath string) error {
+func GeneratePolicy(e chan events.Message, sensorName string, arch string, props *map[string]string, haPartners []string, filePath string) error {
 
 	glog.V(5).Infof("Generating policy for %v", sensorName)
 
@@ -23,7 +23,6 @@ func GeneratePolicy(e chan events.Message, sensorName string, arch string, props
 	fileName := strings.ToLower(strings.Split(sensorName, " ")[0])
 	p := Policy_Factory("Policy for " + fileName)
 
-	p.MaxAgreements = 1
 	p.Add_API_Spec(APISpecification_Factory("https://bluehorizon.network/documentation/"+fileName+"-device-api", "1.0.0", arch))
 	p.Add_Agreement_Protocol(AgreementProtocol_Factory(CitizenScientist))
 
@@ -65,6 +64,11 @@ func GeneratePolicy(e chan events.Message, sensorName string, arch string, props
 	// Add properties to the policy
 	for prop, val := range *props {
 		p.Add_Property(Property_Factory(prop, val))
+	}
+
+	// Add HA configuration if there is any
+	if len(haPartners) != 0 {
+		p.Add_HAGroup(HAGroup_Factory(haPartners))
 	}
 
 	// Default the max agreements to 1

--- a/policy/policy_file_test.go
+++ b/policy/policy_file_test.go
@@ -241,7 +241,7 @@ func Test_Policy_Merge(t *testing.T) {
 		t.Error(err)
 	} else if pf_con, err := ReadPolicyFile("./test/pfmerge1/agbot.policy"); err != nil {
 		t.Error(err)
-	} else if pf_merged, err := Create_Terms_And_Conditions(pf_prod, pf_con, "12345", ""); err != nil {
+	} else if pf_merged, err := Create_Terms_And_Conditions(pf_prod, pf_con, &pf_con.Workloads[0], "12345", ""); err != nil {
 		t.Error(err)
 	} else if err := WritePolicyFile(pf_merged, "./test/pfmerge1/merged.policy"); err != nil {
 		t.Error(err)

--- a/policy/policy_manager.go
+++ b/policy/policy_manager.go
@@ -101,7 +101,7 @@ func Initialize(policyPath string) (*PolicyManager, error) {
 	}
 
 	errorNotify := func(fileName string, err error) {
-		glog.Errorf("Policy Watcher detected error consuming policy file %v during initialization.", fileName)
+		glog.Errorf("Policy Watcher detected error consuming policy file %v during initialization, error: %v", fileName, err)
 	}
 
 	// Call the policy file watcher once to load up the initial set of policy files
@@ -328,7 +328,7 @@ func (self *PolicyManager) GetPolicy(name string) *Policy {
 	return nil
 }
 
-// This function returns the set of policy objects that contains contain the input device URL.
+// This function returns the set of policy objects that contain the input API spec URL.
 func (self *PolicyManager) GetPolicyByURL(url string) []Policy {
 
 	res := make([]Policy, 0, 10)

--- a/policy/test/pfcompat2/expecting.policy
+++ b/policy/test/pfcompat2/expecting.policy
@@ -133,5 +133,8 @@
                 ]
             }
         }
-    ]
+    ],
+    "ha_group": {
+        "partners": null
+    }
 }

--- a/policy/test/pfcompat2/merged.policy
+++ b/policy/test/pfcompat2/merged.policy
@@ -133,5 +133,8 @@
                 ]
             }
         }
-    ]
+    ],
+    "ha_group": {
+        "partners": null
+    }
 }

--- a/policy/test/pfcreate/created.policy
+++ b/policy/test/pfcreate/created.policy
@@ -105,5 +105,8 @@
                 ]
             }
         }
-    ]
+    ],
+    "ha_group": {
+        "partners": null
+    }
 }

--- a/policy/test/pfcreate/expecting.policy
+++ b/policy/test/pfcreate/expecting.policy
@@ -105,5 +105,8 @@
                 ]
             }
         }
-    ]
+    ],
+    "ha_group": {
+        "partners": null
+    }
 }

--- a/policy/test/pfduptest/find.policy
+++ b/policy/test/pfduptest/find.policy
@@ -28,45 +28,6 @@
                     }
                 ]
             }
-        },
-        {
-            "deployment": "Deployment 1",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ1",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
-        },
-        {
-            "deployment": "Deployment 2",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ2",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
-        },
-        {
-            "deployment": "Deployment 3",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ3",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
         }
     ],
     "deviceType": "12345-54321-abcdef-fedcba",

--- a/policy/test/pfduptest/find2.policy
+++ b/policy/test/pfduptest/find2.policy
@@ -28,45 +28,6 @@
                     }
                 ]
             }
-        },
-        {
-            "deployment": "Deployment 1",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ1",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
-        },
-        {
-            "deployment": "Deployment 2",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ2",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
-        },
-        {
-            "deployment": "Deployment 3",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ3",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
         }
     ],
     "deviceType": "12345-54321-abcdef-fedcba",

--- a/policy/test/pffindtest/find.policy
+++ b/policy/test/pffindtest/find.policy
@@ -28,32 +28,6 @@
                     }
                 ]
             }
-        },
-        {
-            "deployment": "Deployment 2",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ2",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
-        },
-        {
-            "deployment": "Deployment 3",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ3",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
         }
     ],
     "deviceType": "12345-54321-abcdef-fedcba",

--- a/policy/test/pfmatchtest/find.policy
+++ b/policy/test/pfmatchtest/find.policy
@@ -28,45 +28,6 @@
                     }
                 ]
             }
-        },
-        {
-            "deployment": "Deployment 1",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
-        },
-        {
-            "deployment": "Deployment 2",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
-        },
-        {
-            "deployment": "Deployment 3",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
         }
     ],
     "deviceType": "12345-54321-abcdef-fedcba",

--- a/policy/test/pfmatchtest/find3.policy
+++ b/policy/test/pfmatchtest/find3.policy
@@ -28,19 +28,6 @@
                     }
                 ]
             }
-        },
-        {
-            "deployment": "Deployment b_3",
-            "deployment_signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-            "torrent": {
-                "url": "torrent://the.system.com",
-                "images": [
-                    {
-                        "file": "a_file.tar.gz",
-                        "signature": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    }
-                ]
-            }
         }
     ],
     "deviceType": "12345-54321-abcdef-fedcba",

--- a/policy/test/pfmerge1/expecting.policy
+++ b/policy/test/pfmerge1/expecting.policy
@@ -30,7 +30,12 @@
                     }
                 ]
             },
-            "workload_password": ""
+            "workload_password": "",
+            "priority": {
+                "priority_value": 0,
+                "retries": 0,
+                "retry_durations": 0
+            }
         }
     ],
     "valueExchange": {
@@ -101,5 +106,8 @@
             }
         }
     ],
-    "requiredWorkload": "http://mycompany.com/workload1"
+    "requiredWorkload": "http://mycompany.com/workload1",
+    "ha_group": {
+        "partners": null
+    }
 }

--- a/policy/test/pfmerge1/merged.policy
+++ b/policy/test/pfmerge1/merged.policy
@@ -30,7 +30,12 @@
                     }
                 ]
             },
-            "workload_password": ""
+            "workload_password": "",
+            "priority": {
+                "priority_value": 0,
+                "retries": 0,
+                "retry_durations": 0
+            }
         }
     ],
     "valueExchange": {
@@ -101,5 +106,8 @@
             }
         }
     ],
-    "requiredWorkload": "http://mycompany.com/workload1"
+    "requiredWorkload": "http://mycompany.com/workload1",
+    "ha_group": {
+        "partners": null
+    }
 }

--- a/policy/test/pftest/echo.policy
+++ b/policy/test/pftest/echo.policy
@@ -30,7 +30,12 @@
                     }
                 ]
             },
-            "workload_password": ""
+            "workload_password": "",
+            "priority": {
+                "priority_value": 0,
+                "retries": 0,
+                "retry_durations": 0
+            }
         }
     ],
     "deviceType": "12345-54321-abcdef-fedcba",
@@ -56,5 +61,8 @@
     "proposalRejection": {
         "number": 5,
         "duration": 86400
+    },
+    "ha_group": {
+        "partners": null
     }
 }

--- a/policy/test/pftest/test1.policy
+++ b/policy/test/pftest/test1.policy
@@ -30,7 +30,12 @@
                     }
                 ]
             },
-            "workload_password": ""
+            "workload_password": "",
+            "priority": {
+                "priority_value": 0,
+                "retries": 0,
+                "retry_durations": 0
+            }
         }
     ],
     "deviceType": "12345-54321-abcdef-fedcba",
@@ -56,5 +61,8 @@
     "proposalRejection": {
         "number": 5,
         "duration": 86400
+    },
+    "ha_group": {
+        "partners": null
     }
 }

--- a/policy/workload_test.go
+++ b/policy/workload_test.go
@@ -180,10 +180,10 @@ func Test_workload_signature(t *testing.T) {
 
 // func Test_debug_signature(t *testing.T) {
 
-//     tempKeyFile := "/tmp/e2edev/.colonus/mtn-publicKey.pem"
-//     str := `{"services":{"geth":{"image":"summit.hovitos.engineering/private-eth:v1.5.7","command":["start.sh"]}}}`
+//     tempKeyFile := "/tmp/mtn-publicKey.pem"
+//     str := `{"services":{"culex":{"image":"summit.hovitos.engineering/x86/culex:latest","environment":["MTN_MQTT_TOKEN=ZZbrT4ON5rYzoBi7H1VK3Ak9n0Fwjcod"]},"gps":{"image":"summit.hovitos.engineering/x86/gps:v1.2","privileged":true,"environment":["MTN_MQTT_TOKEN=ZZbrT4ON5rYzoBi7H1VK3Ak9n0Fwjcod","SLEEP_INTERVAL=20"],"devices":["/dev/bus/usb/001/001:/dev/bus/usb/001/001"]},"location":{"image":"summit.hovitos.engineering/x86/location:v1.3","environment":["DEPL_ENV=staging"]}}}`
 //     //str := `{\"services\":{\"geth\":{\"image\":\"summit.hovitos.engineering/private-eth:v1.5.7\",\"command\":[\"start.sh\"]}}}`
-//     sig := `DMFgRyyH8OVcoN97FN//8aPpJSy/vNxIxvzrF2N6PmutQOHe2QQaAVfTNJ29jamK7Dl4QuTf/Qk59iK8dz/MgvPSYF3jUEULItbj3sA9DciV1hqE3y0Rn0HP2VCv6qYO+g9A7Pjv73Tpxu+MaYoG4mVr6GovOnIq9udRTCjPUv/4a0gjaHZe4ePoV/BR5n9jeMNGiH8VVD4jv2uw0nOiVvo0X5NSxOzn5NlqvntQWdDLkWduDa4alFXuhIsVUnnTPWMvmZNOU8hiUbBzAnuG9YGX4XO4NkVdSR7jWC0vi2PyvHmb1GSzph1WvaSvcNPePPQuvmrxjSgdSRzDYfOxwl5EPbE+18nJuUou7HWOm1LcyHup8+8e0BQblFh0OUlXLDKDdQwWiLK4DUUdQbzUzX9UFJPiOKS+BvBorRIV3v2s99yR1bH9/ScCMnzgXzmr8lW03QSCwCIyiPc5AYelFWaBzNBERhy7b6r2fGkzOA+NcmoB25dMpOJAellNS4dSarSA82+nSR4gFeZ3znQhk2IH8VYs5kbdDSUpyk2cvYee4K7tx5CUvNyOCvErlayz9fxD2oTznlG2clqtu5GUTJcUKSDEccMJGZHFwPyXHc0BnMtKFFkv362Ybord1JQVFQg6kV9tDaSGbzuEhwls5P26zy+eeW2pSHxYAogaWag=`
+//     sig := `gB2d3aN9nvE926H0muL02k4JGUzvYF4oiNFelxMhLxyTlb37yyLyqcHIVV/RNbJM4UOPiyXAyha61MXL0O7zluyN6uJQ9In0puHkcPRX9pC+iDfi2v6ygYl/nCR7OYAwX/8P+NoV3cuQJ1OTAPkTJJCaITvk0S1JsF4QOk+EoNFZrcvZ0JYKc7rzulBEXacW9bydzcFPJuQGhk32SwSzMJ0Rf/XCydeI5VsIGNwCCgTNxZn3cuslUS2JvY0Th3910p662OkEmTKY412ozOLyRM99hWPSxaO5OvGzWYZB7vfQ6N0eGbGVQv6GnDSnnJ+plzXR/rFolgJ92ir2fC1biL4AgnTjm0Ckn5EKj6f63kpgzdFtTw/yMt+5VczQNET2541iV3xyRc8nCDR/HqlfVaY9Q1R+W9R5JZTyVULkNG0yLeP4Hs+3O32PvqtCJovzlppKYX9/Orq3pUTOjRQRZ0AcenPpgmQUxuJEAs0UmhK4oKe5+a9CJm/YigwzyLlk8whxZLIZgvTPAWjW29n41zj8JVAwWIb7UF3bpVxh63p12sUUD1I7cFWCQA6stTpL6yF5+RQHom5frWvhTaNnPGfcFP5EwFVYtH/lFNoICWOyZy98pAbMzK46c8FnFzVB/TM1dCMMcTSjfJILhi7SCURh42Rp6hj3EPf/lO444hI=`
 
 //     wl1 := `{"deployment":"","deployment_signature":"","deployment_user_info":"","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
 //     if wla := create_Workload(wl1, t); wla != nil {
@@ -244,6 +244,147 @@ func Test_workload_signature_invalid(t *testing.T) {
 
         }
     }
+}
+
+func Test_nexthighestpriority_workload1(t *testing.T) {
+
+    wl1 := `{"priority":{"priority_value":3,"retries":2,"retry_durations":5},"deployment":"3","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+    wl2 := `{"priority":{"priority_value":2,"retries":2,"retry_durations":5},"deployment":"2","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+    wl3 := `{"priority":{"priority_value":1,"retries":2,"retry_durations":5},"deployment":"1","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+
+    if wla := create_Workload(wl1, t); wla == nil {
+        t.Errorf("Error unmarshalling Workload json string: %v\n", wl1)
+    } else if wlb := create_Workload(wl2, t); wlb == nil {
+        t.Errorf("Error unmarshalling Workload json string: %v\n", wl2)
+    } else if wlc := create_Workload(wl3, t); wlc == nil {
+        t.Errorf("Error unmarshalling Workload json string: %v\n", wl3)
+    } else {
+
+        pf_created := Policy_Factory("test creation")
+        pf_created.Workloads = append(pf_created.Workloads, *wlb)
+
+        // Try with 1 workload
+        if wl := pf_created.NextHighestPriorityWorkload(0, 0, 0); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "2" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Now add multiple workloads
+        pf_created.Workloads = append(pf_created.Workloads, *wla)
+        pf_created.Workloads = append(pf_created.Workloads, *wlc)
+
+        // Find priority 1 workload
+        if wl := pf_created.NextHighestPriorityWorkload(0, 0, 0); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "1" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Find priority 1 again
+        if wl := pf_created.NextHighestPriorityWorkload(1, 1, 1000); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "1" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Move to priority 2 due to retries
+        now := uint64(time.Now().Unix())
+        if wl := pf_created.NextHighestPriorityWorkload(1, 2, now-1); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "2" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Stay with priority 2
+        if wl := pf_created.NextHighestPriorityWorkload(2, 1, now-1); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "2" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Stay with priority 2 - not enough retries in the alloted retry duration
+        if wl := pf_created.NextHighestPriorityWorkload(2, 2, now-6); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "2" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Move to priority 3
+        if wl := pf_created.NextHighestPriorityWorkload(2, 2, now-1); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "3" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Stay with priority 3 - not enough retries yet
+        if wl := pf_created.NextHighestPriorityWorkload(3, 0, now-1); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "3" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Stay with priority 3 - not enough retries yet
+        if wl := pf_created.NextHighestPriorityWorkload(3, 1, now-1); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "3" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Stay with priority 3 - retries exceeded but not in the time limit
+        if wl := pf_created.NextHighestPriorityWorkload(3, 2, now-10); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "3" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Stay with priority 3 - retries exceeded but lowest priority workload
+        if wl := pf_created.NextHighestPriorityWorkload(3, 2, now-1); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "3" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+        // Stay with priority 3 - retries exceeded but lowest priority workload
+        if wl := pf_created.NextHighestPriorityWorkload(3, 3, now-1); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "3" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+    }
+
+}
+
+func Test_nexthighestpriority_workload2(t *testing.T) {
+
+    wl1 := `{"priority":{"priority_value":3,"retries":2,"retry_durations":5},"deployment":"3","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+    wl2 := `{"priority":{"priority_value":2,"retries":0,"retry_durations":5},"deployment":"2","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+    wl3 := `{"priority":{"priority_value":1,"retries":2,"retry_durations":5},"deployment":"1","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+
+    if wla := create_Workload(wl1, t); wla == nil {
+        t.Errorf("Error unmarshalling Workload json string: %v\n", wl1)
+    } else if wlb := create_Workload(wl2, t); wlb == nil {
+        t.Errorf("Error unmarshalling Workload json string: %v\n", wl2)
+    } else if wlc := create_Workload(wl3, t); wlc == nil {
+        t.Errorf("Error unmarshalling Workload json string: %v\n", wl3)
+    } else {
+
+        pf_created := Policy_Factory("test creation")
+        pf_created.Workloads = append(pf_created.Workloads, *wlb)
+        pf_created.Workloads = append(pf_created.Workloads, *wla)
+        pf_created.Workloads = append(pf_created.Workloads, *wlc)
+
+        // Find priority 3 workload
+        now := uint64(time.Now().Unix())
+        if wl := pf_created.NextHighestPriorityWorkload(2, 1, now-1); wl == nil {
+            t.Errorf("Error finding highest priority workload.\n")
+        } else if wl.Deployment != "3" {
+            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+        }
+
+    }
+
 }
 
 // Create a Workload section from a JSON serialization. The JSON serialization


### PR DESCRIPTION
Added support for HA devices, who specify their list of partners as a service attribute.
Added support for agbot policy files that have workload priorities so that we we can rollback to older workload versions if newer versions fail to make agreements.