### PR TITLE
issue164 - dynamic policy in the agbot

### DIFF
--- a/agreementbot/commands.go
+++ b/agreementbot/commands.go
@@ -40,17 +40,32 @@ func NewAgreementTimeoutCommand(agreementId string, protocol string, reason uint
 }
 
 // ==============================================================================================================
-type NewPolicyCommand struct {
-	PolicyFile string
+type PolicyChangedCommand struct {
+	Msg events.PolicyChangedMessage
 }
 
-func (p NewPolicyCommand) ShortString() string {
+func (p PolicyChangedCommand) ShortString() string {
 	return fmt.Sprintf("%v", p)
 }
 
-func NewNewPolicyCommand(fileName string) *NewPolicyCommand {
-	return &NewPolicyCommand{
-		PolicyFile: fileName,
+func NewPolicyChangedCommand(msg events.PolicyChangedMessage) *PolicyChangedCommand {
+	return &PolicyChangedCommand{
+		Msg: msg,
+	}
+}
+
+// ==============================================================================================================
+type PolicyDeletedCommand struct {
+	Msg events.PolicyDeletedMessage
+}
+
+func (p PolicyDeletedCommand) ShortString() string {
+	return fmt.Sprintf("%v", p)
+}
+
+func NewPolicyDeletedCommand(msg events.PolicyDeletedMessage) *PolicyDeletedCommand {
+	return &PolicyDeletedCommand{
+		Msg: msg,
 	}
 }
 

--- a/agreementbot/lock_manager.go
+++ b/agreementbot/lock_manager.go
@@ -1,0 +1,40 @@
+package agreementbot
+
+import (
+    "sync"
+)
+
+type AgreementLockManager struct {
+    MapLock           sync.Mutex              // The lock that protects the map of agreement locks
+    AgreementMapLocks map[string]*sync.Mutex  // A map of locks by agreement id
+}
+
+func NewAgreementLockManager() *AgreementLockManager {
+    lm := new(AgreementLockManager)
+    lm.AgreementMapLocks = make(map[string]*sync.Mutex, 10)
+    return lm
+}
+
+func (self *AgreementLockManager) getAgreementLock(agid string) *sync.Mutex {
+    self.MapLock.Lock()
+    defer self.MapLock.Unlock()
+
+    if _, ok := self.AgreementMapLocks[agid]; !ok {
+        self.AgreementMapLocks[agid] = new(sync.Mutex)
+    }
+
+    return self.AgreementMapLocks[agid]
+
+}
+
+func (self *AgreementLockManager) deleteAgreementLock(agid string) {
+    self.MapLock.Lock()
+    defer self.MapLock.Unlock()
+
+    if _, ok := self.AgreementMapLocks[agid]; !ok {
+        return
+    }
+
+    delete(self.AgreementMapLocks, agid)
+
+}

--- a/agreementbot/lock_manager_test.go
+++ b/agreementbot/lock_manager_test.go
@@ -1,0 +1,91 @@
+package agreementbot
+
+import (
+    "runtime"
+    "testing"
+    "time"
+)
+
+func Test_lock_lifecycle1(t *testing.T) {
+
+    alm := NewAgreementLockManager()
+
+    alock := alm.getAgreementLock("abc")
+
+    if len(alm.AgreementMapLocks) != 1 {
+        t.Errorf("There should be 1 lock in the map")
+    }
+
+    alm.deleteAgreementLock("abc")
+
+    if len(alm.AgreementMapLocks) != 0 {
+        t.Errorf("There should be 0 locks in the map")
+    }
+
+    alock.Lock()
+    alock.Unlock()
+
+}
+
+func Test_lock_lifecycle2(t *testing.T) {
+
+    s1 := -1 
+    s2 := -1
+    alm := NewAgreementLockManager()
+
+    modifySharedState := func(id string, s *int) {
+        for i := 0; i < 100; i ++ {
+            lock := alm.getAgreementLock(id)
+            runtime.Gosched()
+            lock.Lock()
+            runtime.Gosched()
+            *s = i
+            runtime.Gosched()
+            lock.Unlock()
+            runtime.Gosched()
+        }
+    }
+
+    go modifySharedState("abc", &s1)
+    go modifySharedState("abc", &s1)
+    go modifySharedState("def", &s2)
+    go modifySharedState("def", &s2)
+
+    // Give time to finish
+    time.Sleep(3 * time.Second)
+
+    if s1 != 99 && s2 != 99 {
+        t.Errorf("Shared state did not get to correct final values, is %v %v", s1, s2)
+    }
+
+}
+
+func Test_lock_lifecycle3(t *testing.T) {
+
+    alm := NewAgreementLockManager()
+
+    getDelLock := func(id string) {
+        for i := 0; i <100; i++ {
+            runtime.Gosched()
+            alock := alm.getAgreementLock(id)
+            runtime.Gosched()
+            alm.deleteAgreementLock(id)
+            runtime.Gosched()
+            alock.Lock()
+            runtime.Gosched()
+            alock.Unlock()
+            runtime.Gosched()
+        }
+    }
+
+    go getDelLock("abc")
+    go getDelLock("abc")
+    go getDelLock("def")
+    go getDelLock("def")
+    go getDelLock("ghi")
+    go getDelLock("ghi")
+
+    // Give time to finish
+    time.Sleep(3 * time.Second)
+
+}

--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,7 @@ type AGConfig struct {
 	DefaultWorkloadPW            string // The default workload password if none is specified in the policy file
 	APIListen                    string // Host and port for the API to listen on
 	PurgeArchivedAgreementHours  int    // Number of hours to leave an archived agreement in the database before automatically deleting it
+	CheckUpdatedPolicyS          int    // The number of seconds to wait between checks for an updated policy file. Zero means auto checking is turned off.
 }
 
 func Read(file string) (*HorizonConfig, error) {

--- a/events/events.go
+++ b/events/events.go
@@ -49,7 +49,9 @@ const (
 	NEW_ETH_CLIENT     EventId = "NEW_ETH_CONTAINER"
 
 	// policy-related
-	NEW_POLICY EventId = "NEW_POLICY"
+	NEW_POLICY EventId     = "NEW_POLICY"
+	CHANGED_POLICY EventId = "CHANGED_POLICY"
+	DELETED_POLICY EventId = "DELETED_POLICY"
 
 	// exchange-related
 	NEW_DEVICE_REG EventId = "NEW_DEVICE_REG"
@@ -233,6 +235,94 @@ func NewPolicyCreatedMessage(id EventId, policyFileName string) *PolicyCreatedMe
 			Id: id,
 		},
 		fileName: policyFileName,
+	}
+}
+
+// This event indicates that a policy file has changed. It might also be a new policy file in the agbot.
+type PolicyChangedMessage struct {
+	event    Event
+	fileName string
+	name     string
+	policy   string
+}
+
+func (e PolicyChangedMessage) String() string {
+	return fmt.Sprintf("event: %v, file: %v, name: %v, policy: %v", e.event, e.fileName, e.name, e.policy)
+}
+
+func (e PolicyChangedMessage) ShortString() string {
+	return e.String()
+}
+
+func (e *PolicyChangedMessage) Event() Event {
+	return e.event
+}
+
+func (e *PolicyChangedMessage) PolicyFile() string {
+	return e.fileName
+}
+
+func (e *PolicyChangedMessage) PolicyName() string {
+	return e.name
+}
+
+func (e *PolicyChangedMessage) PolicyString() string {
+	return e.policy
+}
+
+func NewPolicyChangedMessage(id EventId, policyFileName string, policyName string, policy string) *PolicyChangedMessage {
+
+	return &PolicyChangedMessage{
+		event: Event{
+			Id: id,
+		},
+		fileName: policyFileName,
+		name:     policyName,
+		policy:   policy,
+	}
+}
+
+// This event indicates that a policy file was deleted.
+type PolicyDeletedMessage struct {
+	event    Event
+	fileName string
+	name     string
+	policy   string
+}
+
+func (e PolicyDeletedMessage) String() string {
+	return fmt.Sprintf("event: %v, file: %v, name: %v, policy: %v", e.event, e.fileName, e.name, e.policy)
+}
+
+func (e PolicyDeletedMessage) ShortString() string {
+	return e.String()
+}
+
+func (e *PolicyDeletedMessage) Event() Event {
+	return e.event
+}
+
+func (e *PolicyDeletedMessage) PolicyFile() string {
+	return e.fileName
+}
+
+func (e *PolicyDeletedMessage) PolicyName() string {
+	return e.name
+}
+
+func (e *PolicyDeletedMessage) PolicyString() string {
+	return e.policy
+}
+
+func NewPolicyDeletedMessage(id EventId, policyFileName string, policyName string, policy string) *PolicyDeletedMessage {
+
+	return &PolicyDeletedMessage{
+		event: Event{
+			Id: id,
+		},
+		fileName: policyFileName,
+		name:     policyName,
+		policy:   policy,
 	}
 }
 

--- a/policy/policy_manager_test.go
+++ b/policy/policy_manager_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"encoding/json"
 	// "runtime"
 	"strings"
 	"testing"
@@ -204,5 +205,86 @@ func Test_find_by_apispec1(t *testing.T) {
 		if len(pols) != 0 {
 			t.Errorf("Expected to find 0 policies, found %v", len(pols))
 		}
+	}
+}
+
+func Test_add_policy(t *testing.T) {
+	if pm, err := Initialize("./test/pffindtest/"); err != nil {
+		t.Error(err)
+	} else {
+
+		// Add a new policy file
+		newPolicyContent := `{"header":{"name":"new policy","version":"1.0"}}`
+		newPolicy := new(Policy)
+		if err := json.Unmarshal([]byte(newPolicyContent), newPolicy); err != nil {
+			t.Errorf("Error demarshalling new policy: %v", err)
+		} else if err := pm.AddPolicy(newPolicy); err != nil {
+			t.Errorf("Error adding new policy: %v", err)
+		} else if err := pm.AddPolicy(newPolicy); err == nil {
+			t.Errorf("Should have been an error adding duplicate policy: %v", err)
+		} else if num := pm.NumberPolicies(); num != 2 {
+			t.Errorf("Expecting 2 policies, have %v", num)
+		}
+
+		// update existing policy
+		newPolicyContent = `{"header":{"name":"new policy","version":"2.0"}}`
+		newPolicy = new(Policy)
+		if err := json.Unmarshal([]byte(newPolicyContent), newPolicy); err != nil {
+			t.Errorf("Error demarshalling new policy: %v", err)
+		} else {
+			pm.UpdatePolicy(newPolicy)
+			if num := pm.NumberPolicies(); num != 2 {
+				t.Errorf("Expecting 2 policies, have %v", num)
+			}
+		}
+
+		// add this policy
+		newPolicyContent = `{"header":{"name":"new 2 policy","version":"1.0"}}`
+		newPolicy = new(Policy)
+		if err := json.Unmarshal([]byte(newPolicyContent), newPolicy); err != nil {
+			t.Errorf("Error demarshalling new policy: %v", err)
+		} else {
+			pm.UpdatePolicy(newPolicy)
+			if num := pm.NumberPolicies(); num != 3 {
+				t.Errorf("Expecting 3 policies, have %v", num)
+			}
+		}
+
+		// nothing to delete
+		newPolicyContent = `{"header":{"name":"new 3 policy","version":"1.0"}}`
+		newPolicy = new(Policy)
+		if err := json.Unmarshal([]byte(newPolicyContent), newPolicy); err != nil {
+			t.Errorf("Error demarshalling new policy: %v", err)
+		} else {
+			pm.DeletePolicy(newPolicy)
+			if num := pm.NumberPolicies(); num != 3 {
+				t.Errorf("Expecting 3 policies, have %v", num)
+			}
+		}
+
+		// delete 1 policy
+		newPolicyContent = `{"header":{"name":"new policy","version":"2.0"}}`
+		newPolicy = new(Policy)
+		if err := json.Unmarshal([]byte(newPolicyContent), newPolicy); err != nil {
+			t.Errorf("Error demarshalling new policy: %v", err)
+		} else {
+			pm.DeletePolicy(newPolicy)
+			if num := pm.NumberPolicies(); num != 2 {
+				t.Errorf("Expecting 2 policies, have %v", num)
+			}
+		}
+
+		// delete the other new policy
+		newPolicyContent = `{"header":{"name":"new 2 policy","version":"1.0"}}`
+		newPolicy = new(Policy)
+		if err := json.Unmarshal([]byte(newPolicyContent), newPolicy); err != nil {
+			t.Errorf("Error demarshalling new policy: %v", err)
+		} else {
+			pm.DeletePolicy(newPolicy)
+			if num := pm.NumberPolicies(); num != 1 {
+				t.Errorf("Expecting 1 policies, have %v", num)
+			}
+		}
+
 	}
 }

--- a/policy/workload.go
+++ b/policy/workload.go
@@ -62,6 +62,12 @@ func (wp WorkloadPriority) String() string {
         wp.PriorityValue, wp.Retries, wp.RetryDurationS)
 }
 
+func (wp WorkloadPriority) IsSame(compare WorkloadPriority) bool {
+    return wp.PriorityValue == compare.PriorityValue &&
+            wp.Retries == compare.Retries &&
+            wp.RetryDurationS == compare.RetryDurationS
+}
+
 type Workload struct {
     Deployment          string           `json:"deployment"`
     DeploymentSignature string           `json:"deployment_signature"`
@@ -89,7 +95,12 @@ func (w Workload) ShortString() string {
 
 // This function specifically omits checking the Priority section of the workload because that section is not relevant to the equivalence between 2 workload definitions.
 func (wl Workload) IsSame(compare Workload) bool {
-    return wl.Deployment == compare.Deployment && wl.DeploymentSignature == compare.DeploymentSignature && wl.DeploymentUserInfo == compare.DeploymentUserInfo && wl.Torrent.IsSame(compare.Torrent) && wl.WorkloadPassword == compare.WorkloadPassword
+    return wl.Deployment == compare.Deployment &&
+            wl.DeploymentSignature == compare.DeploymentSignature &&
+            wl.DeploymentUserInfo == compare.DeploymentUserInfo &&
+            wl.Torrent.IsSame(compare.Torrent) &&
+            wl.WorkloadPassword == compare.WorkloadPassword &&
+            wl.Priority.IsSame(compare.Priority)
 }
 
 func (w *Workload) Obscure(agreementId string, defaultPW string) error {


### PR DESCRIPTION
Fixed issue 202 so that I could test.
Added unarchived filters to database searches in agbot. This was missed in the agbot/api feature.
Added a small bit of code to support multiple agreement protocols in the agbot. This was needed in order to properly react to a new policy with a new agreement protocol in it.
Most of the code is in support of dynamically adding/modifying policies int he agbot.