### PR TITLE
Deb-friendly install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ $(TMPGOPATH)/bin/govendor: gopathlinks
 gopathlinks:
 ifneq ($(GOPATH),$(TMPGOPATH))
 	mkdir -p $(PKGPATH)
-	rm -f $(PKGPATH)/anax
-	ln -s $(CURDIR) $(PKGPATH)/anax
+	-ln -s $(CURDIR) $(PKGPATH)/anax
 endif
 
 CDIR=$(DESTDIR)/go/src/github.com/open-horizon/go-solidity/contracts

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ ifneq ($(GOPATH),$(TMPGOPATH))
 endif
 
 CDIR=$(DESTDIR)/go/src/github.com/open-horizon/go-solidity/contracts
-install: anax
+install:
 	mkdir -p $(DESTDIR)/bin && cp anax $(DESTDIR)/bin
 	mkdir -p $(CDIR) && \
 		cp -apv ./vendor/github.com/open-horizon/go-solidity/contracts/. $(CDIR)/

--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,12 @@ ifneq ($(GOPATH),$(TMPGOPATH))
 	ln -s $(CURDIR) $(PKGPATH)/anax
 endif
 
+CDIR=$(DESTDIR)/go/src/github.com/open-horizon/go-solidity/contracts
 install: anax
-	mkdir -p $(DESTDIR)/{bin,srv}
-	cp anax $(DESTDIR)/bin/anax
-
-  # duplicate smart contracts from vendor dir
-	cp -vfap ./vendor/github.com/open-horizon/go-solidity/contracts $(DESTDIR)
+	mkdir -p $(DESTDIR)/bin && cp anax $(DESTDIR)/bin
+	mkdir -p $(CDIR) && \
+		cp -apv ./vendor/github.com/open-horizon/go-solidity/contracts/. $(CDIR)/
+	find $(CDIR)/ \( -name "Makefile" -or -iname ".git*" \) -exec rm {} \;
 
 lint:
 	-cd api/static && \
@@ -71,7 +71,6 @@ lint:
 	-go vet ./... 2>&1 | grep -vP "exit\ status|vendor/"
 
 pull: deps
-
 
 # only unit tests
 test: deps


### PR DESCRIPTION
This install target is deb friendly: the deb packaging process doesn't create the install directories ahead of time so the `install` make target should. This also improves the target by:

- Removing the dep on building (this is the standard; it's less safe for a user but won't duplicate work in some build processes)
- Deleting git and other metadata from contract repo before publishing