### PR TITLE
enable specific host and port for workloads

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -76,7 +76,7 @@ type DeploymentDescription struct {
 }
 
 var invalidDeploymentOptions = map[string][]string {
-	"workload": []string{"Binds","SpecificPorts"},
+	"workload": []string{"Binds"},
 	"infrastructure": []string{},
 }
 


### PR DESCRIPTION
Enable workloads to specify a specific port to be bound on the host, and the host IP to bind to as well. Previously this capability was only available to infrastructure containers. We need this to get around a problem in a POC.