### PR TITLE
Refactor/consolidate http clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ test-integration: deps
 	cd $(PKGPATH)/anax && \
 		GOPATH=$(TMPGOPATH) go test -v -cover -tags=integration $(PKGS)
 
-check: test test-integration
+check: lint test test-integration
 
 # build sequence diagrams
 diagrams:

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ install:
 		cp -apv ./vendor/github.com/open-horizon/go-solidity/contracts/. $(CDIR)/
 	find $(CDIR)/ \( -name "Makefile" -or -iname ".git*" \) -exec rm {} \;
 
+format:
+	find . -name '*.go' -not -path './vendor/*' -exec gofmt -l -w {} \;
+
 lint:
 	-cd api/static && \
 		jshint -c ./.jshintrc --verbose ./js/
@@ -82,6 +85,8 @@ test-integration: deps
 	cd $(PKGPATH)/anax && \
 		GOPATH=$(TMPGOPATH) go test -v -cover -tags=integration $(PKGS)
 
+check: test test-integration
+
 # build sequence diagrams
 diagrams:
 	java -jar $(plantuml_path)/plantuml.jar ./citizenscientist/diagrams/horizonSequenceDiagram.txt
@@ -91,4 +96,4 @@ diagrams:
 	java -jar $(plantuml_path)/plantuml.jar ./basicprotocol/diagrams/protocolSequenceDiagram.txt
 	java -jar $(plantuml_path)/plantuml.jar ./basicprotocol/diagrams/horizonSequenceDiagram.txt
 
-.PHONY: clean deps gopathlinks install lint pull test test-integration
+.PHONY: check clean deps format gopathlinks install lint pull test test-integration

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ Related Projects:
 
 ### Preconditions
 
-* To execute the lint and other code checkers (`make lint`), you must install: `go vet`, `golint`, and `jshint`
+* To execute the lint and other code checkers (`make lint` or `make check`), you must install: `go vet`, `golint`, and `jshint`
 
 ### Operations
+
+Note that the Makefile silences a lot of its output by default. If you want to see more output from build steps, execute a build like this:
+
+    make mostlyclean check verbose=y
 
 #### Build executable
 
@@ -55,4 +59,4 @@ Related Projects:
 
 #### Development Environment
 
-Note that the Makefile constructs its own `GOPATH` and builds from it; this is a convenience that can sometimes cause problems for development tooling that expects a project to be in a subdirector of `$GOPATH/src`. To use the Makefile to build the project inside your user's `GOPATH`, set the `TMPGOPATH` variable to your `GOPATH` and execute make like this: `make deps TMPGOPATH=$GOPATH`
+Note that this Makefile can construct its own `GOPATH` and build from it; this is a convenience that can sometimes cause problems for development tooling that expects a project to be in a subdirector of `$GOPATH/src`. To get full tool support clone this project as `$GOPATH/src/github.com/open-horizon/anax`.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Related Projects:
 
     make lint
 
+#### Format code
+
+    make format
+
+#### Execute both unit and integration tests
+
+    make check
+
 #### Execute unit tests
 
     make test

--- a/abstractprotocol/cancel.go
+++ b/abstractprotocol/cancel.go
@@ -1,7 +1,7 @@
 package abstractprotocol
 
 import (
-    "fmt"
+	"fmt"
 )
 
 // =======================================================================================================
@@ -10,40 +10,40 @@ import (
 //
 
 type Cancel interface {
-    ProtocolMessage
-    Reason() uint
+	ProtocolMessage
+	Reason() uint
 }
 
 // This struct is the cancel that flows from the consumer to the producer or producer to consumer.
 type BaseCancel struct {
-    *BaseProtocolMessage
-    TheReason uint `json:"reason"`
+	*BaseProtocolMessage
+	TheReason uint `json:"reason"`
 }
 
 func (bc *BaseCancel) IsValid() bool {
-    return bc.BaseProtocolMessage.IsValid() && bc.MsgType == MsgTypeCancel
+	return bc.BaseProtocolMessage.IsValid() && bc.MsgType == MsgTypeCancel
 }
 
 func (bc *BaseCancel) String() string {
-    return bc.BaseProtocolMessage.String() + fmt.Sprintf(", Reason: %v", bc.TheReason)
+	return bc.BaseProtocolMessage.String() + fmt.Sprintf(", Reason: %v", bc.TheReason)
 }
 
 func (bc *BaseCancel) ShortString() string {
-    return bc.BaseProtocolMessage.ShortString() + fmt.Sprintf(", Reason: %v", bc.TheReason)
+	return bc.BaseProtocolMessage.ShortString() + fmt.Sprintf(", Reason: %v", bc.TheReason)
 }
 
 func (bc *BaseCancel) Reason() uint {
-    return bc.TheReason
+	return bc.TheReason
 }
 
 func NewBaseCancel(name string, version int, id string, reason uint) *BaseCancel {
-    return &BaseCancel{
-        BaseProtocolMessage: &BaseProtocolMessage{
-            MsgType:   MsgTypeCancel,
-            AProtocol: name,
-            AVersion:  version,
-            AgreeId:   id,
-        },
-        TheReason:    reason,
-    }
+	return &BaseCancel{
+		BaseProtocolMessage: &BaseProtocolMessage{
+			MsgType:   MsgTypeCancel,
+			AProtocol: name,
+			AVersion:  version,
+			AgreeId:   id,
+		},
+		TheReason: reason,
+	}
 }

--- a/abstractprotocol/protocol.go
+++ b/abstractprotocol/protocol.go
@@ -272,7 +272,7 @@ func DecideOnProposal(p ProtocolHandler,
 	if err != nil {
 		replyErr = errors.New(fmt.Sprintf("Protocol %v decide on proposal received error getting policy list: %v", p.Name(), err))
 
-	// Tell the policy manager that we're going to attempt an agreement
+		// Tell the policy manager that we're going to attempt an agreement
 	} else if err := p.PolicyManager().AttemptingAgreement(policies, proposal.AgreementId()); err != nil {
 		replyErr = errors.New(fmt.Sprintf("Protocol %v decide on proposal received error saving agreement count: %v", p.Name(), err))
 	}
@@ -285,19 +285,19 @@ func DecideOnProposal(p ProtocolHandler,
 		if mergedPolicy, err := p.PolicyManager().MergeAllProducers(&policies, producerPolicy); err != nil {
 			replyErr = errors.New(fmt.Sprintf("Protocol %v unable to merge producer policies, error: %v", p.Name(), err))
 
-		// Now that we successfully merged our policies, make sure that the input producer policy is compatible with
-		// the result of our merge
+			// Now that we successfully merged our policies, make sure that the input producer policy is compatible with
+			// the result of our merge
 		} else if _, err := policy.Are_Compatible_Producers(mergedPolicy, producerPolicy, uint64(producerPolicy.DataVerify.Interval)); err != nil {
 			replyErr = errors.New(fmt.Sprintf("Protocol %v error verifying merged policy %v and %v, error: %v", p.Name(), mergedPolicy, producerPolicy, err))
 
-		// And make sure we havent exceeded the maxAgreements in any of our policies.
+			// And make sure we havent exceeded the maxAgreements in any of our policies.
 		} else if maxedOut, err := p.PolicyManager().ReachedMaxAgreements(policies); maxedOut {
 			replyErr = errors.New(fmt.Sprintf("Protocol %v max agreements reached: %v", p.Name(), p.PolicyManager().AgreementCountString()))
 		} else if err != nil {
 			replyErr = errors.New(fmt.Sprintf("Protocol %v decide on proposal received error getting number of agreements, rejecting proposal: %v", p.Name(), err))
 
-		// Now check to make sure that the merged policy is acceptable. The policy is not acceptable if the terms and conditions are not
-		// compatible with the producer's policy.
+			// Now check to make sure that the merged policy is acceptable. The policy is not acceptable if the terms and conditions are not
+			// compatible with the producer's policy.
 		} else if err := policy.Are_Compatible(producerPolicy, termsAndConditions); err != nil {
 			replyErr = errors.New(fmt.Sprintf("Protocol %v decide on proposal received error, T and C policy is not compatible, rejecting proposal: %v", p.Name(), err))
 		} else if err := p.PolicyManager().FinalAgreement(policies, proposal.AgreementId()); err != nil {
@@ -534,14 +534,14 @@ func ValidateCancel(can string) (Cancel, error) {
 
 func DemarshalProposal(proposal string) (Proposal, error) {
 
-    // attempt deserialization of the proposal
-    prop := new(BaseProposal)
+	// attempt deserialization of the proposal
+	prop := new(BaseProposal)
 
-    if err := json.Unmarshal([]byte(proposal), &prop); err != nil {
-        return nil, errors.New(fmt.Sprintf("Error deserializing proposal: %s, error: %v", proposal, err))
-    } else {
-        return prop, nil
-    }
+	if err := json.Unmarshal([]byte(proposal), &prop); err != nil {
+		return nil, errors.New(fmt.Sprintf("Error deserializing proposal: %s, error: %v", proposal, err))
+	} else {
+		return prop, nil
+	}
 
 }
 

--- a/agreement/agreement.go
+++ b/agreement/agreement.go
@@ -58,13 +58,13 @@ func NewAgreementWorker(cfg *config.HorizonConfig, db *bolt.DB, pm *policy.Polic
 			Commands: commands,
 		},
 
-		db:                  db,
-		httpClient:          &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT*time.Millisecond)},
-		protocols:           make(map[string]bool),
-		pm:                  pm,
-		deviceId:            id,
-		deviceToken:         token,
-		producerPH:          make(map[string]producer.ProducerProtocolHandler),
+		db:          db,
+		httpClient:  &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
+		protocols:   make(map[string]bool),
+		pm:          pm,
+		deviceId:    id,
+		deviceToken: token,
+		producerPH:  make(map[string]producer.ProducerProtocolHandler),
 	}
 
 	glog.Info("Starting Agreement worker")
@@ -190,7 +190,7 @@ func (w *AgreementWorker) start() {
 		if err := w.advertiseAllPolicies(w.Worker.Manager.Config.Edge.PolicyPath); err != nil {
 			glog.Errorf(logString(fmt.Sprintf("unable to advertise policies with exchange, error: %v", err)))
 		}
-		
+
 		// Handle agreement processor commands
 		for {
 			glog.V(2).Infof(logString(fmt.Sprintf("blocking for commands")))
@@ -373,17 +373,17 @@ func (w *AgreementWorker) syncOnInit() error {
 				}
 				w.Messages() <- events.NewInitAgreementCancelationMessage(events.AGREEMENT_ENDED, reason, ag.AgreementProtocol, ag.CurrentAgreementId, ag.CurrentDeployment)
 
-			// If the agreement's protocol requires that it is recorded externally in some way, verify that it is present there (e.g. a blockchain).
-			// Make sure the external state agrees with our local DB state for this agreement. If not, then we might need to cancel the agreement.
-			// Anax could have been down for a long time (or inoperable), and the external state may have changed.
+				// If the agreement's protocol requires that it is recorded externally in some way, verify that it is present there (e.g. a blockchain).
+				// Make sure the external state agrees with our local DB state for this agreement. If not, then we might need to cancel the agreement.
+				// Anax could have been down for a long time (or inoperable), and the external state may have changed.
 			} else if ok, err := w.verifyAgreement(&ag, w.producerPH[ag.AgreementProtocol], bcType, bcName); err != nil {
 				return errors.New(logString(fmt.Sprintf("unable to check for agreement %v in blockchain, error %v", ag.CurrentAgreementId, err)))
 			} else if !ok {
 				w.Messages() <- events.NewInitAgreementCancelationMessage(events.AGREEMENT_ENDED, w.producerPH[ag.AgreementProtocol].GetTerminationCode(producer.TERM_REASON_AGBOT_REQUESTED), ag.AgreementProtocol, ag.CurrentAgreementId, ag.CurrentDeployment)
 
-			// If the agreement has been started then we just need to make sure that the policy manager's agreement counts
-			// are correct. Even for already timedout agreements, the governance process will cleanup old and outdated agreements,
-			// so we don't need to do anything here.
+				// If the agreement has been started then we just need to make sure that the policy manager's agreement counts
+				// are correct. Even for already timedout agreements, the governance process will cleanup old and outdated agreements,
+				// so we don't need to do anything here.
 
 			} else if proposal, err := w.producerPH[ag.AgreementProtocol].AgreementProtocolHandler("", "").DemarshalProposal(ag.Proposal); err != nil {
 				glog.Errorf(logString(fmt.Sprintf("unable to demarshal proposal for agreement %v, error %v", ag.CurrentAgreementId, err)))
@@ -434,7 +434,6 @@ func (w *AgreementWorker) syncOnInit() error {
 				w.Messages() <- events.NewNewBCContainerMessage(events.NEW_BC_CLIENT, typeName, instName, w.Config.Edge.ExchangeURL, w.deviceId, w.deviceToken)
 			}
 		}
-
 
 	} else {
 		return errors.New(logString(fmt.Sprintf("error searching database: %v", err)))
@@ -527,11 +526,11 @@ func (w *AgreementWorker) advertiseAllPolicies(location string) error {
 
 			// The version property needs special handling
 			newProp := &exchange.MSProp{
-						Name:     "version",
-						Value:    p.APISpecs[0].Version,
-						PropType: "version",
-						Op:       "in",
-					}
+				Name:     "version",
+				Value:    p.APISpecs[0].Version,
+				PropType: "version",
+				Op:       "in",
+			}
 			newMS.Properties = append(newMS.Properties, *newProp)
 
 			newMS.NumAgreements = p.MaxAgreements
@@ -642,7 +641,7 @@ func deleteProducerAgreement(url string, deviceId string, token string, agreemen
 	resp = new(exchange.PostDeviceResponse)
 	targetURL := url + "devices/" + deviceId + "/agreements/" + agreementId
 	for {
-		if err, tpErr := exchange.InvokeExchange(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT*time.Millisecond)}, "DELETE", targetURL, deviceId, token, nil, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)}, "DELETE", targetURL, deviceId, token, nil, &resp); err != nil {
 			glog.Errorf(logString(fmt.Sprintf(err.Error())))
 			return err
 		} else if tpErr != nil {

--- a/agreementbot/activecontracts.go
+++ b/agreementbot/activecontracts.go
@@ -1,144 +1,142 @@
 package agreementbot
 
 import (
-    "bytes"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "github.com/golang/glog"
-    "github.com/open-horizon/anax/config"
-    "net/http"
-    "os"
-    "time"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/open-horizon/anax/config"
+	"net/http"
+	"os"
+	"time"
 )
-
 
 // Following test data was given for JSON schema
 // const testActiveData = `[{"id":"1","lat":41.0064,"lon":-111.9393,"contracts":[{"id":"0x0abcde","type":1,"ts":1447195061},{"id":"0x0ddddd","type":2,"ts":1447195061}]},`+
 //                          `{"id":"2","lat":-41.0064,"lon":111.9393,"contracts":[{"id":"0x0deadbeef","type":1,"ts":1447195061},{"id":"0x0beefdead","type":2,"ts":1447195061}]}]`
 
 type AgreementEntry struct {
-    Id   string `json:"id"`
-    Type int    `json:"type"`
-    Ts   uint64 `json:"ts"`
+	Id   string `json:"id"`
+	Type int    `json:"type"`
+	Ts   uint64 `json:"ts"`
 }
 
 type DeviceEntry struct {
-    Id        string          `json:"id"`
-    Lat       float64         `json:"lat"`
-    Lon       float64         `json:"lon"`
-    Agreements []AgreementEntry `json:"contracts"`
+	Id         string           `json:"id"`
+	Lat        float64          `json:"lat"`
+	Lon        float64          `json:"lon"`
+	Agreements []AgreementEntry `json:"contracts"`
 }
 
 func GetActiveAgreements(in_devices map[string][]string, agreement Agreement, config *config.AGConfig) ([]string, error) {
-    err := error(nil)
+	err := error(nil)
 
-    // If the agreement record was created with the ActiveContractsURL field, then it means that the policy which created the
-    // agreement specified a specific data verification URL. If not, then the default data verification URL is used from
-    // the config.
+	// If the agreement record was created with the ActiveContractsURL field, then it means that the policy which created the
+	// agreement specified a specific data verification URL. If not, then the default data verification URL is used from
+	// the config.
 
-    // This field is true when data verification is explicitly turned off in agreement's policy file.
-    if agreement.DisableDataVerificationChecks == true {
-        res := make([]string, 0, 1)
-        return res, err
-    }
+	// This field is true when data verification is explicitly turned off in agreement's policy file.
+	if agreement.DisableDataVerificationChecks == true {
+		res := make([]string, 0, 1)
+		return res, err
+	}
 
-    activeAgreementsURL := agreement.DataVerificationURL
-    if activeAgreementsURL == "" {
-        activeAgreementsURL = config.ActiveAgreementsURL
-    }
+	activeAgreementsURL := agreement.DataVerificationURL
+	if activeAgreementsURL == "" {
+		activeAgreementsURL = config.ActiveAgreementsURL
+	}
 
-    activeAgreementsUser := agreement.DataVerificationUser
-    if activeAgreementsUser == "" {
-        activeAgreementsUser = config.ActiveAgreementsUser
-    }
+	activeAgreementsUser := agreement.DataVerificationUser
+	if activeAgreementsUser == "" {
+		activeAgreementsUser = config.ActiveAgreementsUser
+	}
 
-    activeAgreementsPW := agreement.DataVerificationPW
-    if activeAgreementsPW == "" {
-        activeAgreementsPW = config.ActiveAgreementsPW
-    }
+	activeAgreementsPW := agreement.DataVerificationPW
+	if activeAgreementsPW == "" {
+		activeAgreementsPW = config.ActiveAgreementsPW
+	}
 
-    if _, ok := in_devices[activeAgreementsURL]; !ok {
-        devices := make([]string, 0, 10)
-        response := make([]DeviceEntry, 0, 10)
+	if _, ok := in_devices[activeAgreementsURL]; !ok {
+		devices := make([]string, 0, 10)
+		response := make([]DeviceEntry, 0, 10)
 
-        // Assume the REST API is unreliable. If it fails, retry a few times before returning an
-        // error to the caller.
-        retries := 0
-        for {
-            if err = Invoke_rest("GET", activeAgreementsURL, activeAgreementsUser, activeAgreementsPW, nil, &response); err != nil {
-                glog.Errorf("Error getting active agreements: %v", err)
-                if retries == 2 {
-                    break
-                } else {
-                    retries += 1
-                    time.Sleep(1 * time.Second)
-                }
-            } else {
-                glog.V(4).Infof("Active agreement response: %v", response)
-                for _, dev := range response {
-                    for _, con := range dev.Agreements {
-                        devices = append(devices, con.Id)
-                    }
-                }
-                glog.V(3).Infof("For URL %v Gathered agreements: %v", activeAgreementsURL, devices)
-                err = error(nil)
-                break
-            }
-        }
-        in_devices[activeAgreementsURL] = devices
-        return devices, err
-    } else {
-        return in_devices[activeAgreementsURL], err
-    }
+		// Assume the REST API is unreliable. If it fails, retry a few times before returning an
+		// error to the caller.
+		retries := 0
+		for {
+			if err = Invoke_rest("GET", activeAgreementsURL, activeAgreementsUser, activeAgreementsPW, nil, &response); err != nil {
+				glog.Errorf("Error getting active agreements: %v", err)
+				if retries == 2 {
+					break
+				} else {
+					retries += 1
+					time.Sleep(1 * time.Second)
+				}
+			} else {
+				glog.V(4).Infof("Active agreement response: %v", response)
+				for _, dev := range response {
+					for _, con := range dev.Agreements {
+						devices = append(devices, con.Id)
+					}
+				}
+				glog.V(3).Infof("For URL %v Gathered agreements: %v", activeAgreementsURL, devices)
+				err = error(nil)
+				break
+			}
+		}
+		in_devices[activeAgreementsURL] = devices
+		return devices, err
+	} else {
+		return in_devices[activeAgreementsURL], err
+	}
 }
 
 func ActiveAgreementsContains(activeAgreements []string, agreement Agreement, prefix string) bool {
 
-    inttest_mode := os.Getenv("mtn_integration_test")
-    if inttest_mode != "" || agreement.DisableDataVerificationChecks == true {
-        return true
-    }
+	inttest_mode := os.Getenv("mtn_integration_test")
+	if inttest_mode != "" || agreement.DisableDataVerificationChecks == true {
+		return true
+	}
 
-    for _, dev := range activeAgreements {
-        if dev == agreement.CurrentAgreementId || dev == prefix + agreement.CurrentAgreementId {
-            return true
-        }
-    }
+	for _, dev := range activeAgreements {
+		if dev == agreement.CurrentAgreementId || dev == prefix+agreement.CurrentAgreementId {
+			return true
+		}
+	}
 
-    return false
+	return false
 }
 
 func Invoke_rest(method string, url string, user string, pw string, body []byte, outstruct interface{}) error {
-    req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
-    req.Header.Set("Content-Type", "application/json")
-    if user != "" && pw != "" {
-        req.SetBasicAuth(user, pw)
-    }
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	if user != "" && pw != "" {
+		req.SetBasicAuth(user, pw)
+	}
 
-    req.Close = true // work around to ensure that Go doesn't get connections confused. Supposed to be fixed in Go 1.6.
+	req.Close = true // work around to ensure that Go doesn't get connections confused. Supposed to be fixed in Go 1.6.
 
-    client := &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT*time.Millisecond)}
-    rawresp, err := client.Do(req)
-    if err != nil {
-        return err
-    } else if method == "GET" && rawresp.StatusCode != 200 {
-        return errors.New(fmt.Sprintf("Error response from REST GET %v call: %v", url, rawresp.Status))
-    } else if (method == "POST" || method == "PUT") && rawresp.StatusCode != 201 {
-        return errors.New(fmt.Sprintf("Error response from REST %v %v call: %v", method, url, rawresp.Status))
-    }
+	client := &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)}
+	rawresp, err := client.Do(req)
+	if err != nil {
+		return err
+	} else if method == "GET" && rawresp.StatusCode != 200 {
+		return errors.New(fmt.Sprintf("Error response from REST GET %v call: %v", url, rawresp.Status))
+	} else if (method == "POST" || method == "PUT") && rawresp.StatusCode != 201 {
+		return errors.New(fmt.Sprintf("Error response from REST %v %v call: %v", method, url, rawresp.Status))
+	}
 
-    defer rawresp.Body.Close()
-    // glog.Infof("Raw Response: %v", rawresp.Body)
+	defer rawresp.Body.Close()
+	// glog.Infof("Raw Response: %v", rawresp.Body)
 
-    if outstruct != nil {
-        if err = json.NewDecoder(rawresp.Body).Decode(&outstruct); err != nil {
-            glog.Errorf("Error decoding http response: %v", err)
-        } else {
-            // glog.Infof("Decoded Response: %v", outstruct)
-        }
-    }
+	if outstruct != nil {
+		if err = json.NewDecoder(rawresp.Body).Decode(&outstruct); err != nil {
+			glog.Errorf("Error decoding http response: %v", err)
+		} else {
+			// glog.Infof("Decoded Response: %v", outstruct)
+		}
+	}
 
-    return err
+	return err
 }
-

--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -23,19 +23,19 @@ import (
 
 // must be safely-constructed!!
 type AgreementBotWorker struct {
-	worker.Worker   // embedded field
-	db              *bolt.DB
-	httpClient      *http.Client
-	agbotId         string
-	token           string
-	pm              *policy.PolicyManager
-	consumerPH      map[string]ConsumerProtocolHandler
-	ready           bool
+	worker.Worker // embedded field
+	db            *bolt.DB
+	httpClient    *http.Client
+	agbotId       string
+	token         string
+	pm            *policy.PolicyManager
+	consumerPH    map[string]ConsumerProtocolHandler
+	ready         bool
 }
 
 func NewAgreementBotWorker(cfg *config.HorizonConfig, db *bolt.DB) *AgreementBotWorker {
-	messages := make(chan events.Message, 100)   // The channel for outbound messages to the anax wide bus
-	commands := make(chan worker.Command, 100)   // The channel for commands into the agreement bot worker
+	messages := make(chan events.Message, 100) // The channel for outbound messages to the anax wide bus
+	commands := make(chan worker.Command, 100) // The channel for commands into the agreement bot worker
 
 	worker := &AgreementBotWorker{
 		Worker: worker.Worker{
@@ -47,12 +47,12 @@ func NewAgreementBotWorker(cfg *config.HorizonConfig, db *bolt.DB) *AgreementBot
 			Commands: commands,
 		},
 
-		db:              db,
-		httpClient:      &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT*time.Millisecond)},
-		agbotId:         cfg.AgreementBot.ExchangeId,
-		token:           cfg.AgreementBot.ExchangeToken,
-		consumerPH:      make(map[string]ConsumerProtocolHandler),
-		ready:           false,
+		db:         db,
+		httpClient: &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
+		agbotId:    cfg.AgreementBot.ExchangeId,
+		token:      cfg.AgreementBot.ExchangeToken,
+		consumerPH: make(map[string]ConsumerProtocolHandler),
+		ready:      false,
 	}
 
 	glog.Info("Starting AgreementBot worker")
@@ -221,7 +221,7 @@ func (w *AgreementBotWorker) start() {
 
 		// Begin heartbeating with the exchange.
 		targetURL := w.Manager.Config.AgreementBot.ExchangeURL + "agbots/" + w.agbotId + "/heartbeat"
-		go exchange.Heartbeat(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT*time.Millisecond)}, targetURL, w.agbotId, w.token, w.Worker.Manager.Config.AgreementBot.ExchangeHeartbeat)
+		go exchange.Heartbeat(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)}, targetURL, w.agbotId, w.token, w.Worker.Manager.Config.AgreementBot.ExchangeHeartbeat)
 
 		// Start the governance routines.
 		go w.GovernAgreements()
@@ -457,7 +457,7 @@ func (w *AgreementBotWorker) findAndMakeAgreements() {
 					if producerPolicy, err := w.MergeAllProducerPolicies(&dev); err != nil {
 						glog.Errorf("AgreementBotWorker unable to merge microservice policies, error: %v", err)
 
-					// Check to see if the device's policy is compatible
+						// Check to see if the device's policy is compatible
 
 					} else if err := policy.Are_Compatible(producerPolicy, &consumerPolicy); err != nil {
 						glog.Errorf("AgreementBotWorker received error comparing %v and %v, error: %v", *producerPolicy, consumerPolicy, err)
@@ -485,7 +485,7 @@ func (w *AgreementBotWorker) findAndMakeAgreements() {
 						} else if bcType != "" && !w.consumerPH[protocol].IsBlockchainWritable(bcType, bcName) {
 							// Older devices assume that the agbot has the blockchain up and running before an agreement can be made.
 							// Get that blockchain running if it isn't up.
-							glog.V(5).Infof("AgreementBotWorker skipping device id %v, requires blockchain %v %v that isnt ready yet.", dev.Id,  bcType, bcName)
+							glog.V(5).Infof("AgreementBotWorker skipping device id %v, requires blockchain %v %v that isnt ready yet.", dev.Id, bcType, bcName)
 							w.Worker.Manager.Messages <- events.NewNewBCContainerMessage(events.NEW_BC_CLIENT, bcType, bcName, w.Manager.Config.AgreementBot.ExchangeURL, w.agbotId, w.token)
 							continue
 						} else if !w.consumerPH[protocol].AcceptCommand(cmd) {
@@ -627,7 +627,7 @@ func DeleteConsumerAgreement(url string, agbotId string, token string, agreement
 	resp = new(exchange.PostDeviceResponse)
 	targetURL := url + "agbots/" + agbotId + "/agreements/" + agreementId
 	for {
-		if err, tpErr := exchange.InvokeExchange(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT*time.Millisecond)}, "DELETE", targetURL, agbotId, token, nil, &resp); err != nil && !strings.Contains(err.Error(), "not found") {
+		if err, tpErr := exchange.InvokeExchange(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)}, "DELETE", targetURL, agbotId, token, nil, &resp); err != nil && !strings.Contains(err.Error(), "not found") {
 			glog.Errorf(logString(fmt.Sprintf(err.Error())))
 			return err
 		} else if tpErr != nil {
@@ -749,7 +749,6 @@ func (w *AgreementBotWorker) makeNewMSSearchElement(specRef string, version stri
 	}
 	return newMS, nil
 }
-
 
 func (w *AgreementBotWorker) syncOnInit() error {
 	glog.V(3).Infof(AWlogString("beginning sync up."))
@@ -942,7 +941,7 @@ func (w *AgreementBotWorker) recordConsumerAgreementState(agreementId string, po
 func (w *AgreementBotWorker) incompleteHAGroup(dev exchange.SearchResultDevice, producerPolicy *policy.Policy) error {
 
 	// If the HA group specification is empty, there is nothing to check.
-	if len(producerPolicy.HAGroup.Partners) == 0  {
+	if len(producerPolicy.HAGroup.Partners) == 0 {
 		return nil
 	} else {
 
@@ -967,7 +966,7 @@ func getTheDevice(deviceId string, url string, agbotId string, token string) (*e
 	resp = new(exchange.GetDevicesResponse)
 	targetURL := url + "devices/" + deviceId
 	for {
-		if err, tpErr := exchange.InvokeExchange(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT*time.Millisecond)}, "GET", targetURL, agbotId, token, nil, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)}, "GET", targetURL, agbotId, token, nil, &resp); err != nil {
 			glog.Errorf(AWlogString(fmt.Sprintf(err.Error())))
 			return nil, err
 		} else if tpErr != nil {

--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -280,11 +280,11 @@ func (b *BaseAgreementWorker) InitiateNewAgreement(cph ConsumerProtocolHandler, 
 	if err := AgreementAttempt(b.db, agreementIdString, wi.Device.Id, wi.ConsumerPolicy.Header.Name, bcType, bcName, cph.Name()); err != nil {
 		glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("error persisting agreement attempt: %v", err)))
 
-	// Create message target for protocol message
+		// Create message target for protocol message
 	} else if mt, err := exchange.CreateMessageTarget(wi.Device.Id, nil, wi.Device.PublicKey, wi.Device.MsgEndPoint); err != nil {
 		glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("error creating message target: %v", err)))
 
-	// Initiate the protocol
+		// Initiate the protocol
 	} else if proposal, err := protocolHandler.InitiateAgreement(agreementIdString, &wi.ProducerPolicy, &wi.ConsumerPolicy, cph.ExchangeId(), mt, workload, b.config.AgreementBot.DefaultWorkloadPW, b.config.AgreementBot.NoDataIntervalS, cph.GetSendMessage()); err != nil {
 		glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("error initiating agreement: %v", err)))
 
@@ -295,7 +295,7 @@ func (b *BaseAgreementWorker) InitiateNewAgreement(cph ConsumerProtocolHandler, 
 
 		// TODO: Publish error on the message bus
 
-	// Update the agreement in the DB with the proposal and policy
+		// Update the agreement in the DB with the proposal and policy
 	} else if err := cph.PersistAgreement(wi, proposal, workerId); err != nil {
 		glog.Errorf(err.Error())
 	}
@@ -305,7 +305,7 @@ func (b *BaseAgreementWorker) InitiateNewAgreement(cph ConsumerProtocolHandler, 
 func (b *BaseAgreementWorker) HandleAgreementReply(cph ConsumerProtocolHandler, wi *HandleReply, workerId string) bool {
 
 	reply := wi.Reply
-	protocolHandler := cph.AgreementProtocolHandler("", "") 	// Use the generic protocol handler
+	protocolHandler := cph.AgreementProtocolHandler("", "") // Use the generic protocol handler
 
 	// The reply message is usually deleted before recording on the blockchain. For now assume it will be deleted at the end. Early exit from
 	// this function is NOT allowed.
@@ -334,7 +334,7 @@ func (b *BaseAgreementWorker) HandleAgreementReply(cph ConsumerProtocolHandler, 
 			// this will cause us to not send a reply ack, which is what we want in this case
 			sendReply = false
 
-		// Now we need to write the info to the exchange and the database
+			// Now we need to write the info to the exchange and the database
 		} else if proposal, err := protocolHandler.DemarshalProposal(agreement.Proposal); err != nil {
 			glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("error validating proposal from pending agreement %v, error: %v", reply.AgreementId(), err)))
 		} else if pol, err := policy.DemarshalPolicy(proposal.TsAndCs()); err != nil {
@@ -346,7 +346,7 @@ func (b *BaseAgreementWorker) HandleAgreementReply(cph ConsumerProtocolHandler, 
 		} else if err := cph.RecordConsumerAgreementState(reply.AgreementId(), pol, "Producer agreed", b.workerID); err != nil {
 			glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("error setting agreement state for %v", reply.AgreementId())))
 
-		// We need to send a reply ack and write the info to the blockchain
+			// We need to send a reply ack and write the info to the blockchain
 		} else if consumerPolicy, err := policy.DemarshalPolicy(agreement.Policy); err != nil {
 			glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("unable to demarshal policy for agreement %v, error %v", reply.AgreementId(), err)))
 		} else {
@@ -625,11 +625,11 @@ func (b *BaseAgreementWorker) ExternalCancel(cph ConsumerProtocolHandler, agreem
 		} else {
 			glog.V(3).Infof(BAWlogstring(workerId, fmt.Sprintf("deferring blockchain cancel for %v", agreementId)))
 			cph.DeferCommand(AsyncCancelAgreement{
-					workType:    ASYNC_CANCEL,
-					AgreementId: agreementId,
-					Protocol:    cph.Name(),
-					Reason:      reason,
-				})
+				workType:    ASYNC_CANCEL,
+				AgreementId: agreementId,
+				Protocol:    cph.Name(),
+				Reason:      reason,
+			})
 		}
 	}
 }

--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -210,7 +210,7 @@ func (b *BaseAgreementWorker) InitiateNewAgreement(cph ConsumerProtocolHandler, 
 		// version API specs, then we will try the next workload.
 		if workload.WorkloadURL != "" {
 
-			if workloadDetails, err := exchange.GetWorkload(workload.WorkloadURL, workload.Version, workload.Arch, b.config.AgreementBot.ExchangeURL, cph.ExchangeId(), cph.ExchangeToken()); err != nil {
+			if workloadDetails, err := exchange.GetWorkload(b.config.Collaborators.HTTPClientFactory, workload.WorkloadURL, workload.Version, workload.Arch, b.config.AgreementBot.ExchangeURL, cph.ExchangeId(), cph.ExchangeToken()); err != nil {
 				glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("error searching for workload details %v, error: %v", workload, err)))
 				return
 			} else {
@@ -552,7 +552,7 @@ func (b *BaseAgreementWorker) CancelAgreement(cph ConsumerProtocolHandler, agree
 	}
 
 	// Update state in exchange
-	if err := DeleteConsumerAgreement(b.config.AgreementBot.ExchangeURL, cph.ExchangeId(), cph.ExchangeToken(), agreementId); err != nil {
+	if err := DeleteConsumerAgreement(b.config.Collaborators.HTTPClientFactory.NewHTTPClient(nil), b.config.AgreementBot.ExchangeURL, cph.ExchangeId(), cph.ExchangeToken(), agreementId); err != nil {
 		glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("error deleting agreement %v in exchange: %v", agreementId, err)))
 	}
 

--- a/agreementbot/api.go
+++ b/agreementbot/api.go
@@ -3,9 +3,9 @@ package agreementbot
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/mux"
 	"github.com/boltdb/bolt"
 	"github.com/golang/glog"
+	"github.com/gorilla/mux"
 	"github.com/open-horizon/anax/config"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/exchange"

--- a/agreementbot/api.go
+++ b/agreementbot/api.go
@@ -211,7 +211,7 @@ func (a *API) policyUpgrade(w http.ResponseWriter, r *http.Request) {
 		glog.V(3).Infof(APIlogString(fmt.Sprintf("handling POST of policy: %v", policyName)))
 
 		workloadResolver := func(wURL string, wVersion string, wArch string) (*policy.APISpecList, error) {
-			asl, err := exchange.WorkloadResolver(wURL, wVersion, wArch, a.Config.AgreementBot.ExchangeURL, a.Config.AgreementBot.ExchangeId, a.Config.AgreementBot.ExchangeToken)
+			asl, err := exchange.WorkloadResolver(a.Config.Collaborators.HTTPClientFactory, wURL, wVersion, wArch, a.Config.AgreementBot.ExchangeURL, a.Config.AgreementBot.ExchangeId, a.Config.AgreementBot.ExchangeToken)
 			if err != nil {
 				glog.Errorf(APIlogString(fmt.Sprintf("unable to resolve workload, error %v", err)))
 			}

--- a/agreementbot/basic_agreement_worker.go
+++ b/agreementbot/basic_agreement_worker.go
@@ -8,9 +8,7 @@ import (
 	"github.com/open-horizon/anax/policy"
 	"github.com/satori/go.uuid"
 	"math/rand"
-	"net/http"
 	"runtime"
-	"time"
 )
 
 type BasicAgreementWorker struct {
@@ -27,7 +25,7 @@ func NewBasicAgreementWorker(c *BasicProtocolHandler, cfg *config.HorizonConfig,
 			config:     cfg,
 			alm:        alm,
 			workerID:   uuid.NewV4().String(),
-			httpClient: &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
+			httpClient: cfg.Collaborators.HTTPClientFactory.NewHTTPClient(nil),
 		},
 		protocolHandler: c,
 	}

--- a/agreementbot/basic_agreement_worker.go
+++ b/agreementbot/basic_agreement_worker.go
@@ -1,95 +1,95 @@
 package agreementbot
 
 import (
-    "fmt"
-    "github.com/boltdb/bolt"
-    "github.com/golang/glog"
-    "github.com/open-horizon/anax/config"
-    "github.com/open-horizon/anax/policy"
-    "github.com/satori/go.uuid"
-    "math/rand"
-    "net/http"
-    "runtime"
-    "time"
+	"fmt"
+	"github.com/boltdb/bolt"
+	"github.com/golang/glog"
+	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/policy"
+	"github.com/satori/go.uuid"
+	"math/rand"
+	"net/http"
+	"runtime"
+	"time"
 )
 
 type BasicAgreementWorker struct {
-    *BaseAgreementWorker
-    protocolHandler *BasicProtocolHandler
+	*BaseAgreementWorker
+	protocolHandler *BasicProtocolHandler
 }
 
 func NewBasicAgreementWorker(c *BasicProtocolHandler, cfg *config.HorizonConfig, db *bolt.DB, pm *policy.PolicyManager, alm *AgreementLockManager) *BasicAgreementWorker {
 
-    p := &BasicAgreementWorker{
-        BaseAgreementWorker: &BaseAgreementWorker{
-            pm:         pm,
-            db:         db,
-            config:     cfg,
-            alm:        alm,
-            workerID:   uuid.NewV4().String(),
-            httpClient: &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
-        },
-        protocolHandler: c,
-    }
+	p := &BasicAgreementWorker{
+		BaseAgreementWorker: &BaseAgreementWorker{
+			pm:         pm,
+			db:         db,
+			config:     cfg,
+			alm:        alm,
+			workerID:   uuid.NewV4().String(),
+			httpClient: &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
+		},
+		protocolHandler: c,
+	}
 
-    return p
+	return p
 }
 
 // This function receives an event to "make a new agreement" from the Process function, and then synchronously calls a function
 // to actually work through the agreement protocol.
 func (a *BasicAgreementWorker) start(work chan AgreementWork, random *rand.Rand) {
 
-    for {
-        glog.V(5).Infof(bwlogstring(a.workerID, fmt.Sprintf("blocking for work")))
-        workItem := <-work // block waiting for work
-        glog.V(2).Infof(bwlogstring(a.workerID, fmt.Sprintf("received work: %v", workItem)))
+	for {
+		glog.V(5).Infof(bwlogstring(a.workerID, fmt.Sprintf("blocking for work")))
+		workItem := <-work // block waiting for work
+		glog.V(2).Infof(bwlogstring(a.workerID, fmt.Sprintf("received work: %v", workItem)))
 
-        if workItem.Type() == INITIATE {
-            wi := workItem.(InitiateAgreement)
-            a.InitiateNewAgreement(a.protocolHandler, &wi, random, a.workerID)
+		if workItem.Type() == INITIATE {
+			wi := workItem.(InitiateAgreement)
+			a.InitiateNewAgreement(a.protocolHandler, &wi, random, a.workerID)
 
-        } else if workItem.Type() == REPLY {
-            wi := workItem.(HandleReply)
-            if ok := a.HandleAgreementReply(a.protocolHandler, &wi, a.workerID); ok {
-                // Update state in the database
-                if ag, err := AgreementFinalized(a.db, wi.Reply.AgreementId(), a.protocolHandler.Name()); err != nil {
-                    glog.Errorf(bwlogstring(a.workerID, fmt.Sprintf("error persisting agreement %v finalized: %v", wi.Reply.AgreementId(), err)))
+		} else if workItem.Type() == REPLY {
+			wi := workItem.(HandleReply)
+			if ok := a.HandleAgreementReply(a.protocolHandler, &wi, a.workerID); ok {
+				// Update state in the database
+				if ag, err := AgreementFinalized(a.db, wi.Reply.AgreementId(), a.protocolHandler.Name()); err != nil {
+					glog.Errorf(bwlogstring(a.workerID, fmt.Sprintf("error persisting agreement %v finalized: %v", wi.Reply.AgreementId(), err)))
 
-                // Update state in exchange
-                } else if pol, err := policy.DemarshalPolicy(ag.Policy); err != nil {
-                    glog.Errorf(bwlogstring(a.workerID, fmt.Sprintf("error demarshalling policy from agreement %v, error: %v", wi.Reply.AgreementId(), err)))
-                } else if err := a.protocolHandler.RecordConsumerAgreementState(wi.Reply.AgreementId(), pol, "Finalized Agreement", a.workerID); err != nil {
-                    glog.Errorf(bwlogstring(a.workerID, fmt.Sprintf("error setting agreement %v finalized state in exchange: %v", wi.Reply.AgreementId(), err)))
-                }
-            }
+					// Update state in exchange
+				} else if pol, err := policy.DemarshalPolicy(ag.Policy); err != nil {
+					glog.Errorf(bwlogstring(a.workerID, fmt.Sprintf("error demarshalling policy from agreement %v, error: %v", wi.Reply.AgreementId(), err)))
+				} else if err := a.protocolHandler.RecordConsumerAgreementState(wi.Reply.AgreementId(), pol, "Finalized Agreement", a.workerID); err != nil {
+					glog.Errorf(bwlogstring(a.workerID, fmt.Sprintf("error setting agreement %v finalized state in exchange: %v", wi.Reply.AgreementId(), err)))
+				}
+			}
 
-        } else if workItem.Type() == DATARECEIVEDACK {
-            wi := workItem.(HandleDataReceivedAck)
-            a.HandleDataReceivedAck(a.protocolHandler, &wi, a.workerID)
+		} else if workItem.Type() == DATARECEIVEDACK {
+			wi := workItem.(HandleDataReceivedAck)
+			a.HandleDataReceivedAck(a.protocolHandler, &wi, a.workerID)
 
-        } else if workItem.Type() == CANCEL {
-            wi := workItem.(CancelAgreement)
-            a.CancelAgreementWithLock(a.protocolHandler, wi.AgreementId, wi.Reason, a.workerID)
+		} else if workItem.Type() == CANCEL {
+			wi := workItem.(CancelAgreement)
+			a.CancelAgreementWithLock(a.protocolHandler, wi.AgreementId, wi.Reason, a.workerID)
 
-        } else if workItem.Type() == WORKLOAD_UPGRADE {
-            // upgrade a workload on a device
-            wi := workItem.(HandleWorkloadUpgrade)
-            a.HandleWorkloadUpgrade(a.protocolHandler, &wi, a.workerID)
+		} else if workItem.Type() == WORKLOAD_UPGRADE {
+			// upgrade a workload on a device
+			wi := workItem.(HandleWorkloadUpgrade)
+			a.HandleWorkloadUpgrade(a.protocolHandler, &wi, a.workerID)
 
-        } else if workItem.Type() == ASYNC_CANCEL {
-            wi := workItem.(AsyncCancelAgreement)
-            a.ExternalCancel(a.protocolHandler, wi.AgreementId, wi.Reason, a.workerID)
+		} else if workItem.Type() == ASYNC_CANCEL {
+			wi := workItem.(AsyncCancelAgreement)
+			a.ExternalCancel(a.protocolHandler, wi.AgreementId, wi.Reason, a.workerID)
 
-        } else {
-            glog.Errorf(bwlogstring(a.workerID, fmt.Sprintf("received unknown work request: %v", workItem)))
-        }
+		} else {
+			glog.Errorf(bwlogstring(a.workerID, fmt.Sprintf("received unknown work request: %v", workItem)))
+		}
 
-        glog.V(5).Infof(bwlogstring(a.workerID, fmt.Sprintf("handled work: %v", workItem)))
-        runtime.Gosched()
+		glog.V(5).Infof(bwlogstring(a.workerID, fmt.Sprintf("handled work: %v", workItem)))
+		runtime.Gosched()
 
-    }
+	}
 }
 
 var bwlogstring = func(workerID string, v interface{}) string {
-    return fmt.Sprintf("BasicAgreementWorker (%v): %v", workerID, v)
+	return fmt.Sprintf("BasicAgreementWorker (%v): %v", workerID, v)
 }

--- a/agreementbot/basic_protocol_handler.go
+++ b/agreementbot/basic_protocol_handler.go
@@ -1,189 +1,189 @@
 package agreementbot
 
 import (
-    "fmt"
-    "github.com/boltdb/bolt"
-    "github.com/golang/glog"
-    "github.com/open-horizon/anax/abstractprotocol"
-    "github.com/open-horizon/anax/basicprotocol"
-    "github.com/open-horizon/anax/config"
-    "github.com/open-horizon/anax/events"
-    "github.com/open-horizon/anax/exchange"
-    "github.com/open-horizon/anax/metering"
-    "github.com/open-horizon/anax/policy"
-    "github.com/open-horizon/anax/worker"
-    "math/rand"
-    "net/http"
-    "time"
+	"fmt"
+	"github.com/boltdb/bolt"
+	"github.com/golang/glog"
+	"github.com/open-horizon/anax/abstractprotocol"
+	"github.com/open-horizon/anax/basicprotocol"
+	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/events"
+	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/anax/metering"
+	"github.com/open-horizon/anax/policy"
+	"github.com/open-horizon/anax/worker"
+	"math/rand"
+	"net/http"
+	"time"
 )
 
 type BasicProtocolHandler struct {
-    *BaseConsumerProtocolHandler
-    agreementPH *basicprotocol.ProtocolHandler
-    Work        chan AgreementWork // outgoing commands for the workers
+	*BaseConsumerProtocolHandler
+	agreementPH *basicprotocol.ProtocolHandler
+	Work        chan AgreementWork // outgoing commands for the workers
 }
 
 func NewBasicProtocolHandler(name string, cfg *config.HorizonConfig, db *bolt.DB, pm *policy.PolicyManager, messages chan events.Message) *BasicProtocolHandler {
-    if name == basicprotocol.PROTOCOL_NAME {
-        return &BasicProtocolHandler{
-            BaseConsumerProtocolHandler: &BaseConsumerProtocolHandler{
-                name:             name,
-                pm:               pm,
-                db:               db,
-                config:           cfg,
-                httpClient:       &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
-                agbotId:          cfg.AgreementBot.ExchangeId,
-                token:            cfg.AgreementBot.ExchangeToken,
-                deferredCommands: nil,
-                messages:         messages,
-            },
-            agreementPH: basicprotocol.NewProtocolHandler(pm),
-            Work:        make(chan AgreementWork),
-        }
-    } else {
-        return nil
-    }
+	if name == basicprotocol.PROTOCOL_NAME {
+		return &BasicProtocolHandler{
+			BaseConsumerProtocolHandler: &BaseConsumerProtocolHandler{
+				name:             name,
+				pm:               pm,
+				db:               db,
+				config:           cfg,
+				httpClient:       &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
+				agbotId:          cfg.AgreementBot.ExchangeId,
+				token:            cfg.AgreementBot.ExchangeToken,
+				deferredCommands: nil,
+				messages:         messages,
+			},
+			agreementPH: basicprotocol.NewProtocolHandler(pm),
+			Work:        make(chan AgreementWork),
+		}
+	} else {
+		return nil
+	}
 }
 
 func (c *BasicProtocolHandler) String() string {
-    return fmt.Sprintf("Name: %v, "+
-        "PM: %v, "+
-        "DB: %v, "+
-        "Agreement PH: %v",
-        c.Name(), c.pm, c.db, c.agreementPH)
+	return fmt.Sprintf("Name: %v, "+
+		"PM: %v, "+
+		"DB: %v, "+
+		"Agreement PH: %v",
+		c.Name(), c.pm, c.db, c.agreementPH)
 }
 
 func (c *BasicProtocolHandler) Initialize() {
 
-    glog.V(5).Infof(BsCPHlogString(fmt.Sprintf("initializing: %v ", c)))
-    // Set up random number gen. This is used to generate agreement id strings.
-    random := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+	glog.V(5).Infof(BsCPHlogString(fmt.Sprintf("initializing: %v ", c)))
+	// Set up random number gen. This is used to generate agreement id strings.
+	random := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
 
-    // Setup a lock to protect concurrent agreement processing
-    agreementLockMgr := NewAgreementLockManager()
+	// Setup a lock to protect concurrent agreement processing
+	agreementLockMgr := NewAgreementLockManager()
 
-    // Set up agreement worker pool based on the current technical config.
-    for ix := 0; ix < c.config.AgreementBot.AgreementWorkers; ix++ {
-        agw := NewBasicAgreementWorker(c, c.config, c.db, c.pm, agreementLockMgr)
-        go agw.start(c.Work, random)
-    }
+	// Set up agreement worker pool based on the current technical config.
+	for ix := 0; ix < c.config.AgreementBot.AgreementWorkers; ix++ {
+		agw := NewBasicAgreementWorker(c, c.config, c.db, c.pm, agreementLockMgr)
+		go agw.start(c.Work, random)
+	}
 
 }
 
 func (c *BasicProtocolHandler) AgreementProtocolHandler(typeName string, name string) abstractprotocol.ProtocolHandler {
-    return c.agreementPH
+	return c.agreementPH
 }
 
 func (c *BasicProtocolHandler) WorkQueue() chan AgreementWork {
-    return c.Work
+	return c.Work
 }
 
 func (c *BasicProtocolHandler) AcceptCommand(cmd worker.Command) bool {
 
-    switch cmd.(type) {
-    case *NewProtocolMessageCommand:
-        return true
-    case *AgreementTimeoutCommand:
-        return true
-    case *PolicyChangedCommand:
-        return true
-    case *PolicyDeletedCommand:
-        return true
-    case *WorkloadUpgradeCommand:
-        return true
-    case *MakeAgreementCommand:
-        return true
-    }
-    return false
+	switch cmd.(type) {
+	case *NewProtocolMessageCommand:
+		return true
+	case *AgreementTimeoutCommand:
+		return true
+	case *PolicyChangedCommand:
+		return true
+	case *PolicyDeletedCommand:
+		return true
+	case *WorkloadUpgradeCommand:
+		return true
+	case *MakeAgreementCommand:
+		return true
+	}
+	return false
 }
 
 func (c *BasicProtocolHandler) PersistAgreement(wi *InitiateAgreement, proposal abstractprotocol.Proposal, workerID string) error {
 
-    return c.BaseConsumerProtocolHandler.PersistBaseAgreement(wi, proposal, workerID, "", "")
+	return c.BaseConsumerProtocolHandler.PersistBaseAgreement(wi, proposal, workerID, "", "")
 }
 
 func (c *BasicProtocolHandler) PersistReply(r abstractprotocol.ProposalReply, pol *policy.Policy, workerID string) error {
 
-    return c.BaseConsumerProtocolHandler.PersistReply(r, pol, workerID)
+	return c.BaseConsumerProtocolHandler.PersistReply(r, pol, workerID)
 }
 
 func (c *BasicProtocolHandler) HandleBlockchainEvent(cmd *BlockchainEventCommand) {
-    return
+	return
 }
 
 func (c *BasicProtocolHandler) CreateMeteringNotification(mp policy.Meter, ag *Agreement) (*metering.MeteringNotification, error) {
 
-    return metering.NewMeteringNotification(mp, ag.AgreementCreationTime, uint64(ag.DataVerificationCheckRate), ag.DataVerificationMissedCount, ag.CurrentAgreementId, ag.ProposalHash, ag.ConsumerProposalSig, "", ag.ProposalSig, "")
+	return metering.NewMeteringNotification(mp, ag.AgreementCreationTime, uint64(ag.DataVerificationCheckRate), ag.DataVerificationMissedCount, ag.CurrentAgreementId, ag.ProposalHash, ag.ConsumerProposalSig, "", ag.ProposalSig, "")
 }
 
 func (c *BasicProtocolHandler) TerminateAgreement(ag *Agreement, reason uint, workerId string) {
-    var messageTarget interface{}
-    if whisperTo, pubkeyTo, err := c.BaseConsumerProtocolHandler.GetDeviceMessageEndpoint(ag.DeviceId, workerId); err != nil {
-        glog.Errorf(BCPHlogstring2(workerId, fmt.Sprintf("error obtaining message target for cancel message: %v", err)))
-    } else if mt, err := exchange.CreateMessageTarget(ag.DeviceId, nil, pubkeyTo, whisperTo); err != nil {
-        glog.Errorf(BCPHlogstring2(workerId, fmt.Sprintf("error creating message target: %v", err)))
-    } else {
-        messageTarget = mt
-    }
-    c.BaseConsumerProtocolHandler.TerminateAgreement(ag, reason, messageTarget, workerId, c)
+	var messageTarget interface{}
+	if whisperTo, pubkeyTo, err := c.BaseConsumerProtocolHandler.GetDeviceMessageEndpoint(ag.DeviceId, workerId); err != nil {
+		glog.Errorf(BCPHlogstring2(workerId, fmt.Sprintf("error obtaining message target for cancel message: %v", err)))
+	} else if mt, err := exchange.CreateMessageTarget(ag.DeviceId, nil, pubkeyTo, whisperTo); err != nil {
+		glog.Errorf(BCPHlogstring2(workerId, fmt.Sprintf("error creating message target: %v", err)))
+	} else {
+		messageTarget = mt
+	}
+	c.BaseConsumerProtocolHandler.TerminateAgreement(ag, reason, messageTarget, workerId, c)
 }
 
 func (c *BasicProtocolHandler) GetTerminationCode(reason string) uint {
-    switch reason {
-    case TERM_REASON_POLICY_CHANGED:
-        return basicprotocol.AB_CANCEL_POLICY_CHANGED
-    // case TERM_REASON_NOT_FINALIZED_TIMEOUT:
-    //     return basicprotocol.AB_CANCEL_NOT_FINALIZED_TIMEOUT
-    case TERM_REASON_NO_DATA_RECEIVED:
-        return basicprotocol.AB_CANCEL_NO_DATA_RECEIVED
-    case TERM_REASON_NO_REPLY:
-        return basicprotocol.AB_CANCEL_NO_REPLY
-    case TERM_REASON_USER_REQUESTED:
-        return basicprotocol.AB_USER_REQUESTED
-    case TERM_REASON_DEVICE_REQUESTED:
-        return basicprotocol.CANCEL_USER_REQUESTED
-    case TERM_REASON_NEGATIVE_REPLY:
-        return basicprotocol.AB_CANCEL_NEGATIVE_REPLY
-    case TERM_REASON_CANCEL_DISCOVERED:
-        return basicprotocol.AB_CANCEL_DISCOVERED
-    case TERM_REASON_CANCEL_FORCED_UPGRADE:
-        return basicprotocol.AB_CANCEL_FORCED_UPGRADE
-    // case TERM_REASON_CANCEL_BC_WRITE_FAILED:
-    //     return basicprotocol.AB_CANCEL_BC_WRITE_FAILED
-    default:
-        return 999
-    }
+	switch reason {
+	case TERM_REASON_POLICY_CHANGED:
+		return basicprotocol.AB_CANCEL_POLICY_CHANGED
+	// case TERM_REASON_NOT_FINALIZED_TIMEOUT:
+	//     return basicprotocol.AB_CANCEL_NOT_FINALIZED_TIMEOUT
+	case TERM_REASON_NO_DATA_RECEIVED:
+		return basicprotocol.AB_CANCEL_NO_DATA_RECEIVED
+	case TERM_REASON_NO_REPLY:
+		return basicprotocol.AB_CANCEL_NO_REPLY
+	case TERM_REASON_USER_REQUESTED:
+		return basicprotocol.AB_USER_REQUESTED
+	case TERM_REASON_DEVICE_REQUESTED:
+		return basicprotocol.CANCEL_USER_REQUESTED
+	case TERM_REASON_NEGATIVE_REPLY:
+		return basicprotocol.AB_CANCEL_NEGATIVE_REPLY
+	case TERM_REASON_CANCEL_DISCOVERED:
+		return basicprotocol.AB_CANCEL_DISCOVERED
+	case TERM_REASON_CANCEL_FORCED_UPGRADE:
+		return basicprotocol.AB_CANCEL_FORCED_UPGRADE
+	// case TERM_REASON_CANCEL_BC_WRITE_FAILED:
+	//     return basicprotocol.AB_CANCEL_BC_WRITE_FAILED
+	default:
+		return 999
+	}
 }
 
 func (c *BasicProtocolHandler) GetTerminationReason(code uint) string {
-    return basicprotocol.DecodeReasonCode(uint64(code))
+	return basicprotocol.DecodeReasonCode(uint64(code))
 }
 
 func (c *BasicProtocolHandler) SetBlockchainWritable(ev *events.AccountFundedMessage) {
-    return
+	return
 }
 
 func (c *BasicProtocolHandler) IsBlockchainWritable(typeName string, name string) bool {
-    return true
+	return true
 }
 
 func (c *BasicProtocolHandler) CanCancelNow(ag *Agreement) bool {
-    return true
+	return true
 }
 
 func (c *BasicProtocolHandler) HandleDeferredCommands() {
-    return
+	return
 }
 
 func (b *BasicProtocolHandler) PostReply(agreementId string, proposal abstractprotocol.Proposal, reply abstractprotocol.ProposalReply, consumerPolicy *policy.Policy, workerId string) error {
 
-    if err := b.agreementPH.RecordAgreement(proposal, reply, "", "", consumerPolicy); err != nil {
-        return err
-    } else {
-        glog.V(3).Infof(BCPHlogstring2(workerId, fmt.Sprintf("recorded agreement %v", agreementId)))
-    }
+	if err := b.agreementPH.RecordAgreement(proposal, reply, "", "", consumerPolicy); err != nil {
+		return err
+	} else {
+		glog.V(3).Infof(BCPHlogstring2(workerId, fmt.Sprintf("recorded agreement %v", agreementId)))
+	}
 
-    return nil
+	return nil
 
 }
 
@@ -191,5 +191,5 @@ func (b *BasicProtocolHandler) PostReply(agreementId string, proposal abstractpr
 // Utility functions
 
 var BsCPHlogString = func(v interface{}) string {
-    return fmt.Sprintf("AgreementBot Basic Protocol Handler %v", v)
+	return fmt.Sprintf("AgreementBot Basic Protocol Handler %v", v)
 }

--- a/agreementbot/basic_protocol_handler.go
+++ b/agreementbot/basic_protocol_handler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/open-horizon/anax/policy"
 	"github.com/open-horizon/anax/worker"
 	"math/rand"
-	"net/http"
 	"time"
 )
 
@@ -31,13 +30,12 @@ func NewBasicProtocolHandler(name string, cfg *config.HorizonConfig, db *bolt.DB
 				pm:               pm,
 				db:               db,
 				config:           cfg,
-				httpClient:       &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
 				agbotId:          cfg.AgreementBot.ExchangeId,
 				token:            cfg.AgreementBot.ExchangeToken,
 				deferredCommands: nil,
 				messages:         messages,
 			},
-			agreementPH: basicprotocol.NewProtocolHandler(pm),
+			agreementPH: basicprotocol.NewProtocolHandler(cfg.Collaborators.HTTPClientFactory.NewHTTPClient(nil), pm),
 			Work:        make(chan AgreementWork),
 		}
 	} else {

--- a/agreementbot/commands.go
+++ b/agreementbot/commands.go
@@ -109,9 +109,9 @@ func NewWorkloadUpgradeCommand(msg events.ABApiWorkloadUpgradeMessage) *Workload
 
 // ==============================================================================================================
 type MakeAgreementCommand struct {
-	ProducerPolicy         policy.Policy               // the producer policy received from the exchange
-	ConsumerPolicy         policy.Policy               // the consumer policy we're matched up with
-	Device                 exchange.SearchResultDevice // the device entry in the exchange
+	ProducerPolicy policy.Policy               // the producer policy received from the exchange
+	ConsumerPolicy policy.Policy               // the consumer policy we're matched up with
+	Device         exchange.SearchResultDevice // the device entry in the exchange
 }
 
 func (e MakeAgreementCommand) ShortString() string {
@@ -120,9 +120,9 @@ func (e MakeAgreementCommand) ShortString() string {
 
 func NewMakeAgreementCommand(pPol policy.Policy, cPol policy.Policy, dev exchange.SearchResultDevice) *MakeAgreementCommand {
 	return &MakeAgreementCommand{
-		ProducerPolicy:         pPol,
-		ConsumerPolicy:         cPol,
-		Device:                 dev,
+		ProducerPolicy: pPol,
+		ConsumerPolicy: cPol,
+		Device:         dev,
 	}
 }
 
@@ -131,13 +131,13 @@ type ClientInitializedCommand struct {
 	Msg events.BlockchainClientInitializedMessage
 }
 
-func (e  ClientInitializedCommand) ShortString() string {
+func (e ClientInitializedCommand) ShortString() string {
 	return e.Msg.ShortString()
 }
 
-func NewClientInitializedCommand(msg *events.BlockchainClientInitializedMessage) * ClientInitializedCommand {
-	return & ClientInitializedCommand{
-		Msg:         *msg,
+func NewClientInitializedCommand(msg *events.BlockchainClientInitializedMessage) *ClientInitializedCommand {
+	return &ClientInitializedCommand{
+		Msg: *msg,
 	}
 }
 
@@ -146,13 +146,13 @@ type ClientStoppingCommand struct {
 	Msg events.BlockchainClientStoppingMessage
 }
 
-func (e  ClientStoppingCommand) ShortString() string {
+func (e ClientStoppingCommand) ShortString() string {
 	return e.Msg.ShortString()
 }
 
-func NewClientStoppingCommand(msg *events.BlockchainClientStoppingMessage) * ClientStoppingCommand {
-	return & ClientStoppingCommand{
-		Msg:         *msg,
+func NewClientStoppingCommand(msg *events.BlockchainClientStoppingMessage) *ClientStoppingCommand {
+	return &ClientStoppingCommand{
+		Msg: *msg,
 	}
 }
 
@@ -167,6 +167,6 @@ func (e AccountFundedCommand) ShortString() string {
 
 func NewAccountFundedCommand(msg *events.AccountFundedMessage) *AccountFundedCommand {
 	return &AccountFundedCommand{
-		Msg:         *msg,
+		Msg: *msg,
 	}
 }

--- a/agreementbot/consumer_protocol_handler.go
+++ b/agreementbot/consumer_protocol_handler.go
@@ -71,7 +71,7 @@ type BaseConsumerProtocolHandler struct {
 	pm               *policy.PolicyManager
 	db               *bolt.DB
 	config           *config.HorizonConfig
-	httpClient       *http.Client
+	httpClient       *http.Client // shared HTTP client instance
 	agbotId          string
 	token            string
 	deferredCommands []AgreementWork // The agreement related work that has to be deferred and retried
@@ -451,7 +451,7 @@ func (b *BaseConsumerProtocolHandler) getDevice(deviceId string, workerId string
 	resp = new(exchange.GetDevicesResponse)
 	targetURL := b.config.AgreementBot.ExchangeURL + "devices/" + deviceId
 	for {
-		if err, tpErr := exchange.InvokeExchange(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)}, "GET", targetURL, b.agbotId, b.token, nil, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(b.config.Collaborators.HTTPClientFactory.NewHTTPClient(nil), "GET", targetURL, b.agbotId, b.token, nil, &resp); err != nil {
 			glog.Errorf(BCPHlogstring2(workerId, fmt.Sprintf(err.Error())))
 			return nil, err
 		} else if tpErr != nil {

--- a/agreementbot/consumer_protocol_handler.go
+++ b/agreementbot/consumer_protocol_handler.go
@@ -74,7 +74,7 @@ type BaseConsumerProtocolHandler struct {
 	httpClient       *http.Client
 	agbotId          string
 	token            string
-	deferredCommands []AgreementWork   // The agreement related work that has to be deferred and retried
+	deferredCommands []AgreementWork // The agreement related work that has to be deferred and retried
 	messages         chan events.Message
 }
 
@@ -343,10 +343,10 @@ func (b *BaseConsumerProtocolHandler) HandleWorkloadUpgrade(cmd *WorkloadUpgrade
 func (b *BaseConsumerProtocolHandler) HandleMakeAgreement(cmd *MakeAgreementCommand, cph ConsumerProtocolHandler) {
 	glog.V(5).Infof(BCPHlogstring(b.Name(), fmt.Sprintf("received make agreement command.")))
 	agreementWork := InitiateAgreement{
-		workType:               INITIATE,
-		ProducerPolicy:         cmd.ProducerPolicy,
-		ConsumerPolicy:         cmd.ConsumerPolicy,
-		Device:                 cmd.Device,
+		workType:       INITIATE,
+		ProducerPolicy: cmd.ProducerPolicy,
+		ConsumerPolicy: cmd.ConsumerPolicy,
+		Device:         cmd.Device,
 	}
 	cph.WorkQueue() <- agreementWork
 	glog.V(5).Infof(BCPHlogstring(b.Name(), fmt.Sprintf("queued make agreement command.")))
@@ -363,7 +363,7 @@ func (b *BaseConsumerProtocolHandler) PersistBaseAgreement(wi *InitiateAgreement
 	} else if _, err := AgreementUpdate(b.db, proposal.AgreementId(), string(pBytes), string(polBytes), pol.DataVerify, b.config.AgreementBot.ProcessGovernanceIntervalS, hash, sig, b.Name(), proposal.Version()); err != nil {
 		return errors.New(BCPHlogstring2(workerID, fmt.Sprintf("error updating agreement with proposal %v in DB, error: %v", proposal, err)))
 
-	// Record that the agreement was initiated, in the exchange
+		// Record that the agreement was initiated, in the exchange
 	} else if err := b.RecordConsumerAgreementState(proposal.AgreementId(), pol, "Formed Proposal", workerID); err != nil {
 		return errors.New(BCPHlogstring2(workerID, fmt.Sprintf("error setting agreement state for %v", proposal.AgreementId())))
 	}
@@ -451,7 +451,7 @@ func (b *BaseConsumerProtocolHandler) getDevice(deviceId string, workerId string
 	resp = new(exchange.GetDevicesResponse)
 	targetURL := b.config.AgreementBot.ExchangeURL + "devices/" + deviceId
 	for {
-		if err, tpErr := exchange.InvokeExchange(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT*time.Millisecond)}, "GET", targetURL, b.agbotId, b.token, nil, &resp); err != nil {
+		if err, tpErr := exchange.InvokeExchange(&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)}, "GET", targetURL, b.agbotId, b.token, nil, &resp); err != nil {
 			glog.Errorf(BCPHlogstring2(workerId, fmt.Sprintf(err.Error())))
 			return nil, err
 		} else if tpErr != nil {
@@ -489,11 +489,11 @@ func (b *BaseConsumerProtocolHandler) HandleExtensionMessage(cmd *NewProtocolMes
 }
 
 func (c *BaseConsumerProtocolHandler) SetBlockchainClientAvailable(ev *events.BlockchainClientInitializedMessage) {
-    return
+	return
 }
 
 func (c *BaseConsumerProtocolHandler) SetBlockchainClientNotAvailable(ev *events.BlockchainClientStoppingMessage) {
-    return
+	return
 }
 
 func (c *BaseConsumerProtocolHandler) AlreadyReceivedReply(ag *Agreement) bool {

--- a/agreementbot/cs_agreementworker.go
+++ b/agreementbot/cs_agreementworker.go
@@ -10,9 +10,7 @@ import (
 	"github.com/open-horizon/anax/policy"
 	"github.com/satori/go.uuid"
 	"math/rand"
-	"net/http"
 	"runtime"
-	"time"
 )
 
 type CSAgreementWorker struct {
@@ -29,7 +27,7 @@ func NewCSAgreementWorker(c *CSProtocolHandler, cfg *config.HorizonConfig, db *b
 			config:     cfg,
 			alm:        alm,
 			workerID:   uuid.NewV4().String(),
-			httpClient: &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
+			httpClient: cfg.Collaborators.HTTPClientFactory.NewHTTPClient(nil),
 		},
 		protocolHandler: c,
 	}

--- a/agreementbot/cs_protocol_handler_test.go
+++ b/agreementbot/cs_protocol_handler_test.go
@@ -1,133 +1,133 @@
 package agreementbot
 
 import (
-    "encoding/json"
-    "github.com/open-horizon/anax/citizenscientist"
-    "github.com/open-horizon/anax/policy"
-    "os"
-    "sync"
-    "testing"
+	"encoding/json"
+	"github.com/open-horizon/anax/citizenscientist"
+	"github.com/open-horizon/anax/policy"
+	"os"
+	"sync"
+	"testing"
 )
 
 func Test_agreement_with_override(t *testing.T) {
 
-    expectedType := policy.Ethereum_bc
-    expectedName := "ethel"
+	expectedType := policy.Ethereum_bc
+	expectedName := "ethel"
 
-    testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
-    testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist"}]}`
+	testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist"}]}`
 
-    os.Setenv("CMTN_BLOCKCHAIN", "ethel")
-    if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
-        t.Errorf("Error creating mock agreement, %v", err)
-    } else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
-        t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
-    }
-    os.Setenv("CMTN_BLOCKCHAIN", "")
+	os.Setenv("CMTN_BLOCKCHAIN", "ethel")
+	if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
+		t.Errorf("Error creating mock agreement, %v", err)
+	} else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
+		t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
+	}
+	os.Setenv("CMTN_BLOCKCHAIN", "")
 
 }
 
 func Test_old_agreement_success(t *testing.T) {
 
-    expectedType := policy.Ethereum_bc
-    expectedName := policy.Default_Blockchain_name
+	expectedType := policy.Ethereum_bc
+	expectedName := policy.Default_Blockchain_name
 
-    testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
-    testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist"}]}`
+	testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist"}]}`
 
-    if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
-        t.Errorf("Error creating mock agreement, %v", err)
-    } else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
-        t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
-    }
+	if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
+		t.Errorf("Error creating mock agreement, %v", err)
+	} else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
+		t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
+	}
 
 }
 
 func Test_new_agreement_success1(t *testing.T) {
 
-    expectedType := "fred"
-    expectedName := "ethel"
+	expectedType := "fred"
+	expectedName := "ethel"
 
-    testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
-    testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"}]}]}`
+	testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"}]}]}`
 
-    if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
-        t.Errorf("Error creating mock agreement, %v", err)
-    } else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
-        t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
-    }
+	if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
+		t.Errorf("Error creating mock agreement, %v", err)
+	} else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
+		t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
+	}
 
 }
 
 func Test_new_agreement_success2(t *testing.T) {
 
-    expectedType := "fred"
-    expectedName := "ethel"
+	expectedType := "fred"
+	expectedName := "ethel"
 
-    testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
-    testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"},{"type":"lucy","name":"dezi"}]}]}`
+	testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"},{"type":"lucy","name":"dezi"}]}]}`
 
-    if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
-        t.Errorf("Error creating mock agreement, %v", err)
-    } else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
-        t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
-    }
+	if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
+		t.Errorf("Error creating mock agreement, %v", err)
+	} else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
+		t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
+	}
 
 }
 
 func Test_new_agreement_success3(t *testing.T) {
 
-    expectedType := "fred"
-    expectedName := "ethel"
+	expectedType := "fred"
+	expectedName := "ethel"
 
-    testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
-    testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"},{"type":"lucy","name":"dezi"}]}]}`
+	testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"},{"type":"lucy","name":"dezi"}]}]}`
 
-    if ag, err := createAgreement(testProposal, testPolicy, 2, expectedType, expectedName); err != nil {
-        t.Errorf("Error creating mock agreement, %v", err)
-    } else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
-        t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
-    }
+	if ag, err := createAgreement(testProposal, testPolicy, 2, expectedType, expectedName); err != nil {
+		t.Errorf("Error creating mock agreement, %v", err)
+	} else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
+		t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
+	}
 
 }
 
 // Utility to help create the testing context
 func createEmptyPH() *CSProtocolHandler {
-    return &CSProtocolHandler{
-            BaseConsumerProtocolHandler: &BaseConsumerProtocolHandler{
-                name:             "test",
-                pm:               nil,
-                db:               nil,
-                config:           nil,
-                httpClient:       nil,
-                agbotId:          "ag12345",
-                token:            "abcdefg",
-                deferredCommands: nil,
-                messages:         nil,
-            },
-            genericAgreementPH: nil,
-            Work:               nil,
-            bcState:            nil,
-            bcStateLock:        sync.Mutex{},
-        }
+	return &CSProtocolHandler{
+		BaseConsumerProtocolHandler: &BaseConsumerProtocolHandler{
+			name:             "test",
+			pm:               nil,
+			db:               nil,
+			config:           nil,
+			httpClient:       nil,
+			agbotId:          "ag12345",
+			token:            "abcdefg",
+			deferredCommands: nil,
+			messages:         nil,
+		},
+		genericAgreementPH: nil,
+		Work:               nil,
+		bcState:            nil,
+		bcStateLock:        sync.Mutex{},
+	}
 }
 
 func createAgreement(proposal string, pol string, agpVersion int, bcType string, bcName string) (*Agreement, error) {
-    if ag, err := agreement("testagid", "deviceid", "testpolicy", bcType, bcName, "Citizen Scientist"); err != nil {
-        return nil, err
-    } else {
-        prop := new(citizenscientist.CSProposal)
-        if err := json.Unmarshal([]byte(proposal), prop); err != nil {
-            return nil, err
-        } else {
-            prop.TsandCs = pol
-            if propString, err := json.Marshal(prop); err != nil {
-                return nil, err
-            } else {
-                ag.Proposal = string(propString)
-                ag.AgreementProtocolVersion = agpVersion
-                return ag, nil
-            }
-        }
-    }
+	if ag, err := agreement("testagid", "deviceid", "testpolicy", bcType, bcName, "Citizen Scientist"); err != nil {
+		return nil, err
+	} else {
+		prop := new(citizenscientist.CSProposal)
+		if err := json.Unmarshal([]byte(proposal), prop); err != nil {
+			return nil, err
+		} else {
+			prop.TsandCs = pol
+			if propString, err := json.Marshal(prop); err != nil {
+				return nil, err
+			} else {
+				ag.Proposal = string(propString)
+				ag.AgreementProtocolVersion = agpVersion
+				return ag, nil
+			}
+		}
+	}
 }

--- a/agreementbot/lock_manager.go
+++ b/agreementbot/lock_manager.go
@@ -1,40 +1,40 @@
 package agreementbot
 
 import (
-    "sync"
+	"sync"
 )
 
 type AgreementLockManager struct {
-    MapLock           sync.Mutex              // The lock that protects the map of agreement locks
-    AgreementMapLocks map[string]*sync.Mutex  // A map of locks by agreement id
+	MapLock           sync.Mutex             // The lock that protects the map of agreement locks
+	AgreementMapLocks map[string]*sync.Mutex // A map of locks by agreement id
 }
 
 func NewAgreementLockManager() *AgreementLockManager {
-    lm := new(AgreementLockManager)
-    lm.AgreementMapLocks = make(map[string]*sync.Mutex, 10)
-    return lm
+	lm := new(AgreementLockManager)
+	lm.AgreementMapLocks = make(map[string]*sync.Mutex, 10)
+	return lm
 }
 
 func (self *AgreementLockManager) getAgreementLock(agid string) *sync.Mutex {
-    self.MapLock.Lock()
-    defer self.MapLock.Unlock()
+	self.MapLock.Lock()
+	defer self.MapLock.Unlock()
 
-    if _, ok := self.AgreementMapLocks[agid]; !ok {
-        self.AgreementMapLocks[agid] = new(sync.Mutex)
-    }
+	if _, ok := self.AgreementMapLocks[agid]; !ok {
+		self.AgreementMapLocks[agid] = new(sync.Mutex)
+	}
 
-    return self.AgreementMapLocks[agid]
+	return self.AgreementMapLocks[agid]
 
 }
 
 func (self *AgreementLockManager) deleteAgreementLock(agid string) {
-    self.MapLock.Lock()
-    defer self.MapLock.Unlock()
+	self.MapLock.Lock()
+	defer self.MapLock.Unlock()
 
-    if _, ok := self.AgreementMapLocks[agid]; !ok {
-        return
-    }
+	if _, ok := self.AgreementMapLocks[agid]; !ok {
+		return
+	}
 
-    delete(self.AgreementMapLocks, agid)
+	delete(self.AgreementMapLocks, agid)
 
 }

--- a/agreementbot/lock_manager_test.go
+++ b/agreementbot/lock_manager_test.go
@@ -1,91 +1,91 @@
 package agreementbot
 
 import (
-    "runtime"
-    "testing"
-    "time"
+	"runtime"
+	"testing"
+	"time"
 )
 
 func Test_lock_lifecycle1(t *testing.T) {
 
-    alm := NewAgreementLockManager()
+	alm := NewAgreementLockManager()
 
-    alock := alm.getAgreementLock("abc")
+	alock := alm.getAgreementLock("abc")
 
-    if len(alm.AgreementMapLocks) != 1 {
-        t.Errorf("There should be 1 lock in the map")
-    }
+	if len(alm.AgreementMapLocks) != 1 {
+		t.Errorf("There should be 1 lock in the map")
+	}
 
-    alm.deleteAgreementLock("abc")
+	alm.deleteAgreementLock("abc")
 
-    if len(alm.AgreementMapLocks) != 0 {
-        t.Errorf("There should be 0 locks in the map")
-    }
+	if len(alm.AgreementMapLocks) != 0 {
+		t.Errorf("There should be 0 locks in the map")
+	}
 
-    alock.Lock()
-    alock.Unlock()
+	alock.Lock()
+	alock.Unlock()
 
 }
 
 func Test_lock_lifecycle2(t *testing.T) {
 
-    s1 := -1 
-    s2 := -1
-    alm := NewAgreementLockManager()
+	s1 := -1
+	s2 := -1
+	alm := NewAgreementLockManager()
 
-    modifySharedState := func(id string, s *int) {
-        for i := 0; i < 100; i ++ {
-            lock := alm.getAgreementLock(id)
-            runtime.Gosched()
-            lock.Lock()
-            runtime.Gosched()
-            *s = i
-            runtime.Gosched()
-            lock.Unlock()
-            runtime.Gosched()
-        }
-    }
+	modifySharedState := func(id string, s *int) {
+		for i := 0; i < 100; i++ {
+			lock := alm.getAgreementLock(id)
+			runtime.Gosched()
+			lock.Lock()
+			runtime.Gosched()
+			*s = i
+			runtime.Gosched()
+			lock.Unlock()
+			runtime.Gosched()
+		}
+	}
 
-    go modifySharedState("abc", &s1)
-    go modifySharedState("abc", &s1)
-    go modifySharedState("def", &s2)
-    go modifySharedState("def", &s2)
+	go modifySharedState("abc", &s1)
+	go modifySharedState("abc", &s1)
+	go modifySharedState("def", &s2)
+	go modifySharedState("def", &s2)
 
-    // Give time to finish
-    time.Sleep(3 * time.Second)
+	// Give time to finish
+	time.Sleep(3 * time.Second)
 
-    if s1 != 99 && s2 != 99 {
-        t.Errorf("Shared state did not get to correct final values, is %v %v", s1, s2)
-    }
+	if s1 != 99 && s2 != 99 {
+		t.Errorf("Shared state did not get to correct final values, is %v %v", s1, s2)
+	}
 
 }
 
 func Test_lock_lifecycle3(t *testing.T) {
 
-    alm := NewAgreementLockManager()
+	alm := NewAgreementLockManager()
 
-    getDelLock := func(id string) {
-        for i := 0; i <100; i++ {
-            runtime.Gosched()
-            alock := alm.getAgreementLock(id)
-            runtime.Gosched()
-            alm.deleteAgreementLock(id)
-            runtime.Gosched()
-            alock.Lock()
-            runtime.Gosched()
-            alock.Unlock()
-            runtime.Gosched()
-        }
-    }
+	getDelLock := func(id string) {
+		for i := 0; i < 100; i++ {
+			runtime.Gosched()
+			alock := alm.getAgreementLock(id)
+			runtime.Gosched()
+			alm.deleteAgreementLock(id)
+			runtime.Gosched()
+			alock.Lock()
+			runtime.Gosched()
+			alock.Unlock()
+			runtime.Gosched()
+		}
+	}
 
-    go getDelLock("abc")
-    go getDelLock("abc")
-    go getDelLock("def")
-    go getDelLock("def")
-    go getDelLock("ghi")
-    go getDelLock("ghi")
+	go getDelLock("abc")
+	go getDelLock("abc")
+	go getDelLock("def")
+	go getDelLock("def")
+	go getDelLock("ghi")
+	go getDelLock("ghi")
 
-    // Give time to finish
-    time.Sleep(3 * time.Second)
+	// Give time to finish
+	time.Sleep(3 * time.Second)
 
 }

--- a/agreementbot/persistence.go
+++ b/agreementbot/persistence.go
@@ -13,77 +13,77 @@ import (
 const AGREEMENTS = "agreements"
 
 type Agreement struct {
-	CurrentAgreementId             string   `json:"current_agreement_id"`             // unique
-	DeviceId                       string   `json:"device_id"`                        // the device id we are working with, immutable after construction
-	HAPartners                     []string `json:"ha_partners"`                      // list of HA partner device IDs
-	AgreementProtocol              string   `json:"agreement_protocol"`               // immutable after construction - name of protocol in use
-	AgreementProtocolVersion       int      `json:"agreement_protocol_version"`       // version of protocol in use - New in V2 protocol
-	AgreementInceptionTime         uint64   `json:"agreement_inception_time"`         // immutable after construction
-	AgreementCreationTime          uint64   `json:"agreement_creation_time"`          // device responds affirmatively to proposal
-	AgreementFinalizedTime         uint64   `json:"agreement_finalized_time"`         // agreement is seen in the blockchain
-	AgreementTimedout              uint64   `json:"agreement_timeout"`                // agreement was not finalized before it timed out
-	ProposalSig                    string   `json:"proposal_signature"`               // The signature used to create the agreement - from the producer
-	Proposal                       string   `json:"proposal"`                         // JSON serialization of the proposal
-	ProposalHash                   string   `json:"proposal_hash"`                    // Hash of the proposal
-	ConsumerProposalSig            string   `json:"consumer_proposal_sig"`            // Consumer's signature of the proposal
-	Policy                         string   `json:"policy"`                           // JSON serialization of the policy used to make the proposal
-	PolicyName                     string   `json:"policy_name"`                      // The name of the policy for this agreement, policy names are unique
-	CounterPartyAddress            string   `json:"counter_party_address"`            // The blockchain address of the counterparty in the agreement
-	DataVerificationURL            string   `json:"data_verification_URL"`            // The URL to use to ensure that this agreement is sending data.
-	DataVerificationUser           string   `json:"data_verification_user"`           // The user to use with the DataVerificationURL
-	DataVerificationPW             string   `json:"data_verification_pw"`             // The pw of the data verification user
-	DataVerificationCheckRate      int      `json:"data_verification_check_rate"`     // How often to check for data
-	DataVerificationMissedCount    uint64   `json:"data_verification_missed_count"`   // Number of data verification misses
+	CurrentAgreementId             string   `json:"current_agreement_id"`              // unique
+	DeviceId                       string   `json:"device_id"`                         // the device id we are working with, immutable after construction
+	HAPartners                     []string `json:"ha_partners"`                       // list of HA partner device IDs
+	AgreementProtocol              string   `json:"agreement_protocol"`                // immutable after construction - name of protocol in use
+	AgreementProtocolVersion       int      `json:"agreement_protocol_version"`        // version of protocol in use - New in V2 protocol
+	AgreementInceptionTime         uint64   `json:"agreement_inception_time"`          // immutable after construction
+	AgreementCreationTime          uint64   `json:"agreement_creation_time"`           // device responds affirmatively to proposal
+	AgreementFinalizedTime         uint64   `json:"agreement_finalized_time"`          // agreement is seen in the blockchain
+	AgreementTimedout              uint64   `json:"agreement_timeout"`                 // agreement was not finalized before it timed out
+	ProposalSig                    string   `json:"proposal_signature"`                // The signature used to create the agreement - from the producer
+	Proposal                       string   `json:"proposal"`                          // JSON serialization of the proposal
+	ProposalHash                   string   `json:"proposal_hash"`                     // Hash of the proposal
+	ConsumerProposalSig            string   `json:"consumer_proposal_sig"`             // Consumer's signature of the proposal
+	Policy                         string   `json:"policy"`                            // JSON serialization of the policy used to make the proposal
+	PolicyName                     string   `json:"policy_name"`                       // The name of the policy for this agreement, policy names are unique
+	CounterPartyAddress            string   `json:"counter_party_address"`             // The blockchain address of the counterparty in the agreement
+	DataVerificationURL            string   `json:"data_verification_URL"`             // The URL to use to ensure that this agreement is sending data.
+	DataVerificationUser           string   `json:"data_verification_user"`            // The user to use with the DataVerificationURL
+	DataVerificationPW             string   `json:"data_verification_pw"`              // The pw of the data verification user
+	DataVerificationCheckRate      int      `json:"data_verification_check_rate"`      // How often to check for data
+	DataVerificationMissedCount    uint64   `json:"data_verification_missed_count"`    // Number of data verification misses
 	DataVerificationNoDataInterval int      `json:"data_verification_nodata_interval"` // How long to wait before deciding there is no data
-	DisableDataVerificationChecks  bool     `json:"disable_data_verification_checks"` // disable data verification checks, assume data is being sent.
-	DataVerifiedTime               uint64   `json:"data_verification_time"`           // The last time that data verification was successful
-	DataNotificationSent           uint64   `json:"data_notification_sent"`           // The timestamp for when data notification was sent to the device
-	MeteringTokens                 uint64   `json:"metering_tokens"`                  // Number of metering tokens from proposal
-	MeteringPerTimeUnit            string   `json:"metering_per_time_unit"`           // The time units of tokens per, from the proposal
-	MeteringNotificationInterval   int      `json:"metering_notify_interval"`         // The interval of time between metering notifications (seconds)
-	MeteringNotificationSent       uint64   `json:"metering_notification_sent"`       // The last time a metering notification was sent
-	MeteringNotificationMsgs       []string `json:"metering_notification_msgs"`       // The last metering messages that were sent, oldest at the end
-	Archived                       bool     `json:"archived"`                         // The record is archived
-	TerminatedReason               uint     `json:"terminated_reason"`                // The reason the agreement was terminated
-	TerminatedDescription          string   `json:"terminated_description"`           // The description of why the agreement was terminated
-	BlockchainType                 string   `json:"blockchain_type"`                  // The name of the blockchain type that is being used (new V2 protocol)
-	BlockchainName                 string   `json:"blockchain_name"`                  // The name of the blockchain being used (new V2 protocol)
-	BCUpdateAckTime                uint64   `json:"blockchain_update_ack_time"`       // The time when the producer ACked our update ot him (new V2 protocol)
+	DisableDataVerificationChecks  bool     `json:"disable_data_verification_checks"`  // disable data verification checks, assume data is being sent.
+	DataVerifiedTime               uint64   `json:"data_verification_time"`            // The last time that data verification was successful
+	DataNotificationSent           uint64   `json:"data_notification_sent"`            // The timestamp for when data notification was sent to the device
+	MeteringTokens                 uint64   `json:"metering_tokens"`                   // Number of metering tokens from proposal
+	MeteringPerTimeUnit            string   `json:"metering_per_time_unit"`            // The time units of tokens per, from the proposal
+	MeteringNotificationInterval   int      `json:"metering_notify_interval"`          // The interval of time between metering notifications (seconds)
+	MeteringNotificationSent       uint64   `json:"metering_notification_sent"`        // The last time a metering notification was sent
+	MeteringNotificationMsgs       []string `json:"metering_notification_msgs"`        // The last metering messages that were sent, oldest at the end
+	Archived                       bool     `json:"archived"`                          // The record is archived
+	TerminatedReason               uint     `json:"terminated_reason"`                 // The reason the agreement was terminated
+	TerminatedDescription          string   `json:"terminated_description"`            // The description of why the agreement was terminated
+	BlockchainType                 string   `json:"blockchain_type"`                   // The name of the blockchain type that is being used (new V2 protocol)
+	BlockchainName                 string   `json:"blockchain_name"`                   // The name of the blockchain being used (new V2 protocol)
+	BCUpdateAckTime                uint64   `json:"blockchain_update_ack_time"`        // The time when the producer ACked our update ot him (new V2 protocol)
 }
 
 func (a Agreement) String() string {
-	return fmt.Sprintf("Archived: %v, " +
-		"CurrentAgreementId: %v, " +
-		"AgreementProtocol: %v, " +
-		"AgreementProtocolVersion: %v, " +
-		"DeviceId: %v, " +
-		"HA Partners: %v, " +
-		"AgreementInceptionTime: %v, " +
-		"AgreementCreationTime: %v, " +
-		"AgreementFinalizedTime: %v, " +
-		"AgreementTimedout: %v, " +
-		"ProposalSig: %v, " +
-		"ProposalHash: %v, " +
-		"ConsumerProposalSig: %v, " +
-		"Policy Name: %v, " +
-		"CounterPartyAddress: %v, " +
-		"DataVerificationURL: %v, " +
-		"DataVerificationUser: %v, " +
-		"DataVerificationCheckRate: %v, " +
-		"DataVerificationMissedCount: %v, " +
-		"DataVerificationNoDataInterval: %v, " +
-		"DisableDataVerification: %v, " +
-		"DataVerifiedTime: %v, " +
-		"DataNotificationSent: %v, " +
-		"MeteringTokens: %v, " +
-		"MeteringPerTimeUnit: %v, " +
-		"MeteringNotificationInterval: %v, " +
-		"MeteringNotificationSent: %v, " +
-		"MeteringNotificationMsgs: %v, " +
-		"TerminatedReason: %v, " +
-		"TerminatedDescription: %v, " +
-		"BlockchainType: %v, " +
-		"BlockchainName: %v, " +
+	return fmt.Sprintf("Archived: %v, "+
+		"CurrentAgreementId: %v, "+
+		"AgreementProtocol: %v, "+
+		"AgreementProtocolVersion: %v, "+
+		"DeviceId: %v, "+
+		"HA Partners: %v, "+
+		"AgreementInceptionTime: %v, "+
+		"AgreementCreationTime: %v, "+
+		"AgreementFinalizedTime: %v, "+
+		"AgreementTimedout: %v, "+
+		"ProposalSig: %v, "+
+		"ProposalHash: %v, "+
+		"ConsumerProposalSig: %v, "+
+		"Policy Name: %v, "+
+		"CounterPartyAddress: %v, "+
+		"DataVerificationURL: %v, "+
+		"DataVerificationUser: %v, "+
+		"DataVerificationCheckRate: %v, "+
+		"DataVerificationMissedCount: %v, "+
+		"DataVerificationNoDataInterval: %v, "+
+		"DisableDataVerification: %v, "+
+		"DataVerifiedTime: %v, "+
+		"DataNotificationSent: %v, "+
+		"MeteringTokens: %v, "+
+		"MeteringPerTimeUnit: %v, "+
+		"MeteringNotificationInterval: %v, "+
+		"MeteringNotificationSent: %v, "+
+		"MeteringNotificationMsgs: %v, "+
+		"TerminatedReason: %v, "+
+		"TerminatedDescription: %v, "+
+		"BlockchainType: %v, "+
+		"BlockchainName: %v, "+
 		"BCUpdateAckTime: %v",
 		a.Archived, a.CurrentAgreementId, a.AgreementProtocol, a.AgreementProtocolVersion, a.DeviceId, a.HAPartners,
 		a.AgreementInceptionTime, a.AgreementCreationTime, a.AgreementFinalizedTime,
@@ -128,7 +128,7 @@ func agreement(agreementid string, deviceid string, policyName string, bcType st
 			MeteringPerTimeUnit:            "",
 			MeteringNotificationInterval:   0,
 			MeteringNotificationSent:       0,
-			MeteringNotificationMsgs:       []string{"",""},
+			MeteringNotificationMsgs:       []string{"", ""},
 			Archived:                       false,
 			TerminatedReason:               0,
 			TerminatedDescription:          "",
@@ -279,7 +279,7 @@ func MeteringNotification(db *bolt.DB, agreementid string, protocol string, mn s
 	if agreement, err := singleAgreementUpdate(db, agreementid, protocol, func(a Agreement) *Agreement {
 		a.MeteringNotificationSent = uint64(time.Now().Unix())
 		if len(a.MeteringNotificationMsgs) == 0 {
-			a.MeteringNotificationMsgs = []string{"",""}
+			a.MeteringNotificationMsgs = []string{"", ""}
 		}
 		a.MeteringNotificationMsgs[1] = a.MeteringNotificationMsgs[0]
 		a.MeteringNotificationMsgs[0] = mn
@@ -366,97 +366,97 @@ func persistUpdatedAgreement(db *bolt.DB, agreementid string, protocol string, u
 				// This code is running in a database transaction. Within the tx, the current record is
 				// read and then updated according to the updates within the input update record. It is critical
 				// to check for correct data transitions within the tx .
-				if mod.AgreementCreationTime == 0 {		// 1 transition from zero to non-zero
+				if mod.AgreementCreationTime == 0 { // 1 transition from zero to non-zero
 					mod.AgreementCreationTime = update.AgreementCreationTime
 				}
-				if mod.AgreementFinalizedTime == 0 {	// 1 transition from zero to non-zero
+				if mod.AgreementFinalizedTime == 0 { // 1 transition from zero to non-zero
 					mod.AgreementFinalizedTime = update.AgreementFinalizedTime
 				}
-				if mod.AgreementTimedout == 0 {			// 1 transition from zero to non-zero
+				if mod.AgreementTimedout == 0 { // 1 transition from zero to non-zero
 					mod.AgreementTimedout = update.AgreementTimedout
 				}
-				if mod.CounterPartyAddress == "" {		// 1 transition from empty to non-empty
+				if mod.CounterPartyAddress == "" { // 1 transition from empty to non-empty
 					mod.CounterPartyAddress = update.CounterPartyAddress
 				}
-				if mod.Proposal == "" {					// 1 transition from empty to non-empty
+				if mod.Proposal == "" { // 1 transition from empty to non-empty
 					mod.Proposal = update.Proposal
 				}
-				if mod.ProposalHash == "" {				// 1 transition from empty to non-empty
+				if mod.ProposalHash == "" { // 1 transition from empty to non-empty
 					mod.ProposalHash = update.ProposalHash
 				}
-				if mod.ConsumerProposalSig == "" {		// 1 transition from empty to non-empty
+				if mod.ConsumerProposalSig == "" { // 1 transition from empty to non-empty
 					mod.ConsumerProposalSig = update.ConsumerProposalSig
 				}
-				if mod.Policy == "" {					// 1 transition from empty to non-empty
+				if mod.Policy == "" { // 1 transition from empty to non-empty
 					mod.Policy = update.Policy
 				}
-				if mod.ProposalSig == "" {				// 1 transition from empty to non-empty
+				if mod.ProposalSig == "" { // 1 transition from empty to non-empty
 					mod.ProposalSig = update.ProposalSig
 				}
-				if mod.DataVerificationURL == "" {		// 1 transition from empty to non-empty
+				if mod.DataVerificationURL == "" { // 1 transition from empty to non-empty
 					mod.DataVerificationURL = update.DataVerificationURL
 				}
-				if mod.DataVerificationUser == "" {		// 1 transition from empty to non-empty
+				if mod.DataVerificationUser == "" { // 1 transition from empty to non-empty
 					mod.DataVerificationUser = update.DataVerificationUser
 				}
-				if mod.DataVerificationPW == "" {		// 1 transition from empty to non-empty
+				if mod.DataVerificationPW == "" { // 1 transition from empty to non-empty
 					mod.DataVerificationPW = update.DataVerificationPW
 				}
-				if mod.DataVerificationCheckRate == 0 {	// 1 transition from zero to non-zero
+				if mod.DataVerificationCheckRate == 0 { // 1 transition from zero to non-zero
 					mod.DataVerificationCheckRate = update.DataVerificationCheckRate
 				}
-				if mod.DataVerificationMissedCount < update.DataVerificationMissedCount {	// Valid transitions must move forward
+				if mod.DataVerificationMissedCount < update.DataVerificationMissedCount { // Valid transitions must move forward
 					mod.DataVerificationMissedCount = update.DataVerificationMissedCount
 				}
-				if mod.DataVerificationNoDataInterval == 0 {	// 1 transition from zero to non-zero
+				if mod.DataVerificationNoDataInterval == 0 { // 1 transition from zero to non-zero
 					mod.DataVerificationNoDataInterval = update.DataVerificationNoDataInterval
 				}
-				if !mod.DisableDataVerificationChecks {		// 1 transition from false to true
+				if !mod.DisableDataVerificationChecks { // 1 transition from false to true
 					mod.DisableDataVerificationChecks = update.DisableDataVerificationChecks
 				}
-				if mod.DataVerifiedTime < update.DataVerifiedTime {	// Valid transitions must move forward
+				if mod.DataVerifiedTime < update.DataVerifiedTime { // Valid transitions must move forward
 					mod.DataVerifiedTime = update.DataVerifiedTime
 				}
-				if mod.DataNotificationSent < update.DataNotificationSent {	// Valid transitions must move forward
+				if mod.DataNotificationSent < update.DataNotificationSent { // Valid transitions must move forward
 					mod.DataNotificationSent = update.DataNotificationSent
 				}
-				if len(mod.HAPartners) == 0 { 		// 1 transition from empty array to non-empty
+				if len(mod.HAPartners) == 0 { // 1 transition from empty array to non-empty
 					mod.HAPartners = update.HAPartners
 				}
-				if mod.MeteringTokens == 0 {		// 1 transition from zero to non-zero
+				if mod.MeteringTokens == 0 { // 1 transition from zero to non-zero
 					mod.MeteringTokens = update.MeteringTokens
 				}
-				if mod.MeteringPerTimeUnit == "" {	// 1 transition from empty to non-empty
+				if mod.MeteringPerTimeUnit == "" { // 1 transition from empty to non-empty
 					mod.MeteringPerTimeUnit = update.MeteringPerTimeUnit
 				}
-				if mod.MeteringNotificationInterval == 0 {	// 1 transition from zero to non-zero
+				if mod.MeteringNotificationInterval == 0 { // 1 transition from zero to non-zero
 					mod.MeteringNotificationInterval = update.MeteringNotificationInterval
 				}
-				if mod.MeteringNotificationSent < update.MeteringNotificationSent {	// Valid transitions must move forward
+				if mod.MeteringNotificationSent < update.MeteringNotificationSent { // Valid transitions must move forward
 					mod.MeteringNotificationSent = update.MeteringNotificationSent
 				}
-				if len(mod.MeteringNotificationMsgs) == 0 || mod.MeteringNotificationMsgs[0] == update.MeteringNotificationMsgs[1] {	// msgs must move from new to old in the array
+				if len(mod.MeteringNotificationMsgs) == 0 || mod.MeteringNotificationMsgs[0] == update.MeteringNotificationMsgs[1] { // msgs must move from new to old in the array
 					mod.MeteringNotificationMsgs = update.MeteringNotificationMsgs
 				}
-				if !mod.Archived {					// 1 transition from false to true
+				if !mod.Archived { // 1 transition from false to true
 					mod.Archived = update.Archived
 				}
-				if mod.TerminatedReason == 0 {		// 1 valid transition from zero to non-zero
+				if mod.TerminatedReason == 0 { // 1 valid transition from zero to non-zero
 					mod.TerminatedReason = update.TerminatedReason
 				}
-				if mod.TerminatedDescription == "" {	// 1 transition from empty to non-empty
+				if mod.TerminatedDescription == "" { // 1 transition from empty to non-empty
 					mod.TerminatedDescription = update.TerminatedDescription
 				}
-				if mod.BlockchainType == "" {		// 1 transition from empty to non-empty
+				if mod.BlockchainType == "" { // 1 transition from empty to non-empty
 					mod.BlockchainType = update.BlockchainType
 				}
-				if mod.BlockchainName == "" {		// 1 transition from empty to non-empty
+				if mod.BlockchainName == "" { // 1 transition from empty to non-empty
 					mod.BlockchainName = update.BlockchainName
 				}
-				if mod.AgreementProtocolVersion == 0 {		// 1 transition from empty to non-empty
+				if mod.AgreementProtocolVersion == 0 { // 1 transition from empty to non-empty
 					mod.AgreementProtocolVersion = update.AgreementProtocolVersion
 				}
-				if mod.BCUpdateAckTime == 0 { 		// 1 transition from zero to non-zero
+				if mod.BCUpdateAckTime == 0 { // 1 transition from zero to non-zero
 					mod.BCUpdateAckTime = update.BCUpdateAckTime
 				}
 				if serialized, err := json.Marshal(mod); err != nil {

--- a/agreementbot/wl_persistence.go
+++ b/agreementbot/wl_persistence.go
@@ -1,378 +1,378 @@
 package agreementbot
 
 import (
-    "encoding/json"
-    "errors"
-    "fmt"
-    "github.com/boltdb/bolt"
-    "github.com/golang/glog"
-    "strconv"
-    "time"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/boltdb/bolt"
+	"github.com/golang/glog"
+	"strconv"
+	"time"
 )
 
 const WORKLOAD_USAGE = "workload_usage"
 
 type WorkloadUsage struct {
-    Id                 uint64   `json:"record_id"`             // unique primary key for records
-    DeviceId           string   `json:"device_id"`             // the device id we are working with, immutable after construction
-    HAPartners         []string `json:"ha_partners"`           // list of device id(s) which are partners to this device
-    PendingUpgradeTime uint64   `json:"pending_upgrade_time"`  // time when this usage was marked for pending upgrade
-    Policy             string   `json:"policy"`                // the policy containing the workloads we're managing
-    PolicyName         string   `json:"policy_name"`           // the name of the policy containing the workloads we're managing
-    Priority           int      `json:"priority"`              // the workload priority that we're working with 
-    RetryCount         int      `json:"retry_count"`           // The number of retries attempted so far
-    RetryDurationS     int      `json:"retry_durations"`       // The number of seconds in which the specified number of retries must occur in order for the next priority workload to be attempted.
-    CurrentAgreementId string   `json:"current_agreement_id"`  // the agreement id currently in use
-    FirstTryTime       uint64   `json:"first_try_time"`        // time when first agrement attempt was made, used to count retries per time
-    LatestRetryTime    uint64   `json:"latest_retry_time"`     // time when the newest retry has occurred
-    DisableRetry       bool     `json:"disable_retry"`         // when true, retry and retry durations are disbled which effectively disables workload rollback
-    VerifiedDurationS  int      `json:"verified_durations"`    // the number of seconds for successful data verification before disabling workload rollback retries
-    ReqsNotMet         bool     `json:"requirements_not_met"`  // this workload usage record is not at the highest priority because the device did not meet the API spec requirements at one of the higher priorities
+	Id                 uint64   `json:"record_id"`            // unique primary key for records
+	DeviceId           string   `json:"device_id"`            // the device id we are working with, immutable after construction
+	HAPartners         []string `json:"ha_partners"`          // list of device id(s) which are partners to this device
+	PendingUpgradeTime uint64   `json:"pending_upgrade_time"` // time when this usage was marked for pending upgrade
+	Policy             string   `json:"policy"`               // the policy containing the workloads we're managing
+	PolicyName         string   `json:"policy_name"`          // the name of the policy containing the workloads we're managing
+	Priority           int      `json:"priority"`             // the workload priority that we're working with
+	RetryCount         int      `json:"retry_count"`          // The number of retries attempted so far
+	RetryDurationS     int      `json:"retry_durations"`      // The number of seconds in which the specified number of retries must occur in order for the next priority workload to be attempted.
+	CurrentAgreementId string   `json:"current_agreement_id"` // the agreement id currently in use
+	FirstTryTime       uint64   `json:"first_try_time"`       // time when first agrement attempt was made, used to count retries per time
+	LatestRetryTime    uint64   `json:"latest_retry_time"`    // time when the newest retry has occurred
+	DisableRetry       bool     `json:"disable_retry"`        // when true, retry and retry durations are disbled which effectively disables workload rollback
+	VerifiedDurationS  int      `json:"verified_durations"`   // the number of seconds for successful data verification before disabling workload rollback retries
+	ReqsNotMet         bool     `json:"requirements_not_met"` // this workload usage record is not at the highest priority because the device did not meet the API spec requirements at one of the higher priorities
 }
 
 func (w WorkloadUsage) String() string {
-    return fmt.Sprintf("Id: %v, " +
-        "DeviceId: %v, " +
-        "HA Partners: %v, " +
-        "Pending Upgrade Time: %v, " +
-        "PolicyName: %v, " +
-        "Priority: %v, " +
-        "RetryCount: %v, " +
-        "RetryDurationS: %v, " +
-        "CurrentAgreementId: %v, " +
-        "FirstTryTime: %v, " +
-        "LatestRetryTime: %v, " +
-        "DisableRetry: %v, " +
-        "VerifiedDurationS: %v, " +
-        "ReqsNotMet: %v, " +
-        "Policy: %v",
-        w.Id, w.DeviceId, w.HAPartners, w.PendingUpgradeTime, w.PolicyName, w.Priority, w.RetryCount,
-        w.RetryDurationS, w.CurrentAgreementId, w.FirstTryTime, w.LatestRetryTime, w.DisableRetry, w.VerifiedDurationS, w.ReqsNotMet, w.Policy)
+	return fmt.Sprintf("Id: %v, "+
+		"DeviceId: %v, "+
+		"HA Partners: %v, "+
+		"Pending Upgrade Time: %v, "+
+		"PolicyName: %v, "+
+		"Priority: %v, "+
+		"RetryCount: %v, "+
+		"RetryDurationS: %v, "+
+		"CurrentAgreementId: %v, "+
+		"FirstTryTime: %v, "+
+		"LatestRetryTime: %v, "+
+		"DisableRetry: %v, "+
+		"VerifiedDurationS: %v, "+
+		"ReqsNotMet: %v, "+
+		"Policy: %v",
+		w.Id, w.DeviceId, w.HAPartners, w.PendingUpgradeTime, w.PolicyName, w.Priority, w.RetryCount,
+		w.RetryDurationS, w.CurrentAgreementId, w.FirstTryTime, w.LatestRetryTime, w.DisableRetry, w.VerifiedDurationS, w.ReqsNotMet, w.Policy)
 }
 
 // private factory method for workloadusage w/out persistence safety:
 func workloadUsage(deviceid string, hapartners []string, policy string, policyName string, priority int, retryDurationS int, verifiedDurationS int, reqsNotMet bool, agid string) (*WorkloadUsage, error) {
 
-    if deviceid == "" || policyName == "" || priority == 0 || retryDurationS == 0 || agid == "" {
-        return nil, errors.New("Illegal input: one of deviceid, policy, policyName, priority, retryDurationS, retryLimit or agreement id is empty")
-    } else {
-        return &WorkloadUsage{
-            DeviceId:           deviceid,
-            HAPartners:         hapartners,
-            PendingUpgradeTime: 0,
-            Policy:             policy,
-            PolicyName:         policyName,
-            Priority:           priority,
-            RetryCount:         0,
-            RetryDurationS:     retryDurationS,
-            CurrentAgreementId: agid,
-            FirstTryTime:       uint64(time.Now().Unix()),
-            LatestRetryTime:    0,
-            DisableRetry:       false,
-            VerifiedDurationS:  verifiedDurationS,
-            ReqsNotMet:         reqsNotMet,
-        }, nil
-    }
+	if deviceid == "" || policyName == "" || priority == 0 || retryDurationS == 0 || agid == "" {
+		return nil, errors.New("Illegal input: one of deviceid, policy, policyName, priority, retryDurationS, retryLimit or agreement id is empty")
+	} else {
+		return &WorkloadUsage{
+			DeviceId:           deviceid,
+			HAPartners:         hapartners,
+			PendingUpgradeTime: 0,
+			Policy:             policy,
+			PolicyName:         policyName,
+			Priority:           priority,
+			RetryCount:         0,
+			RetryDurationS:     retryDurationS,
+			CurrentAgreementId: agid,
+			FirstTryTime:       uint64(time.Now().Unix()),
+			LatestRetryTime:    0,
+			DisableRetry:       false,
+			VerifiedDurationS:  verifiedDurationS,
+			ReqsNotMet:         reqsNotMet,
+		}, nil
+	}
 }
 
 func NewWorkloadUsage(db *bolt.DB, deviceid string, hapartners []string, policy string, policyName string, priority int, retryDurationS int, verifiedDurationS int, reqsNotMet bool, agid string) error {
-    if wlUsage, err := workloadUsage(deviceid, hapartners, policy, policyName, priority, retryDurationS, verifiedDurationS, reqsNotMet, agid); err != nil {
-        return err
-    } else if existing, err := FindSingleWorkloadUsageByDeviceAndPolicyName(db, deviceid, policyName); err != nil {
-        return err
-    } else if existing != nil {
-        return fmt.Errorf("Workload usage record with device id %v and policy name %v already exists.", deviceid, policyName)
-    } else if err := WUPersistNew(db, wuBucketName(), wlUsage); err != nil {
-        return err
-    } else {
-        return nil
-    }
+	if wlUsage, err := workloadUsage(deviceid, hapartners, policy, policyName, priority, retryDurationS, verifiedDurationS, reqsNotMet, agid); err != nil {
+		return err
+	} else if existing, err := FindSingleWorkloadUsageByDeviceAndPolicyName(db, deviceid, policyName); err != nil {
+		return err
+	} else if existing != nil {
+		return fmt.Errorf("Workload usage record with device id %v and policy name %v already exists.", deviceid, policyName)
+	} else if err := WUPersistNew(db, wuBucketName(), wlUsage); err != nil {
+		return err
+	} else {
+		return nil
+	}
 }
 
 func UpdateRetryCount(db *bolt.DB, deviceid string, policyName string, retryCount int, agid string) (*WorkloadUsage, error) {
-    if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
-        w.CurrentAgreementId = agid
-        w.RetryCount = retryCount
-        // Reset the retry interval time. There is a big assumption here, which is that the caller has already made sure
-        // that it's not time to switch the workload usage to a different priority, and therefore the reason for updating
-        // the retry count is because the caller thinks they want to stay with the current workload. Since we know it's ok
-        // to stay with the current workload priority, then we can safely start a new retry interval. It's important to have
-        // an accurate current workload interval in case the workload starts misbehaving.
-        now := uint64(time.Now().Unix())
-        w.LatestRetryTime = now
-        if w.FirstTryTime + uint64(w.RetryDurationS) < now {
-            w.FirstTryTime = uint64(time.Now().Unix())
-            w.RetryCount = 1       // We used one retry simply because we are here updating retry counts.
-        }
-        return &w
-    }); err != nil {
-        return nil, err
-    } else {
-        return wlUsage, nil
-    }
+	if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
+		w.CurrentAgreementId = agid
+		w.RetryCount = retryCount
+		// Reset the retry interval time. There is a big assumption here, which is that the caller has already made sure
+		// that it's not time to switch the workload usage to a different priority, and therefore the reason for updating
+		// the retry count is because the caller thinks they want to stay with the current workload. Since we know it's ok
+		// to stay with the current workload priority, then we can safely start a new retry interval. It's important to have
+		// an accurate current workload interval in case the workload starts misbehaving.
+		now := uint64(time.Now().Unix())
+		w.LatestRetryTime = now
+		if w.FirstTryTime+uint64(w.RetryDurationS) < now {
+			w.FirstTryTime = uint64(time.Now().Unix())
+			w.RetryCount = 1 // We used one retry simply because we are here updating retry counts.
+		}
+		return &w
+	}); err != nil {
+		return nil, err
+	} else {
+		return wlUsage, nil
+	}
 }
 
 func UpdatePriority(db *bolt.DB, deviceid string, policyName string, priority int, retryDurationS int, verifiedDurationS int, agid string) (*WorkloadUsage, error) {
-    if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
-        w.CurrentAgreementId = agid
-        w.Priority = priority
-        w.RetryCount = 0
-        w.RetryDurationS = retryDurationS
-        w.VerifiedDurationS = verifiedDurationS
-        w.FirstTryTime = uint64(time.Now().Unix())
-        return &w
-    }); err != nil {
-        return nil, err
-    } else {
-        return wlUsage, nil
-    }
+	if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
+		w.CurrentAgreementId = agid
+		w.Priority = priority
+		w.RetryCount = 0
+		w.RetryDurationS = retryDurationS
+		w.VerifiedDurationS = verifiedDurationS
+		w.FirstTryTime = uint64(time.Now().Unix())
+		return &w
+	}); err != nil {
+		return nil, err
+	} else {
+		return wlUsage, nil
+	}
 }
 
 func UpdatePendingUpgrade(db *bolt.DB, deviceid string, policyName string) (*WorkloadUsage, error) {
-    if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
-        w.PendingUpgradeTime = uint64(time.Now().Unix())
-        return &w
-    }); err != nil {
-        return nil, err
-    } else {
-        return wlUsage, nil
-    }
+	if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
+		w.PendingUpgradeTime = uint64(time.Now().Unix())
+		return &w
+	}); err != nil {
+		return nil, err
+	} else {
+		return wlUsage, nil
+	}
 }
 
 func UpdateWUAgreementId(db *bolt.DB, deviceid string, policyName string, agid string) (*WorkloadUsage, error) {
-    if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
-        w.CurrentAgreementId = agid
-        return &w
-    }); err != nil {
-        return nil, err
-    } else {
-        return wlUsage, nil
-    }
+	if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
+		w.CurrentAgreementId = agid
+		return &w
+	}); err != nil {
+		return nil, err
+	} else {
+		return wlUsage, nil
+	}
 }
 
 func DisableRollbackChecking(db *bolt.DB, deviceid string, policyName string) (*WorkloadUsage, error) {
-    if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
-        w.DisableRetry = true
-        w.RetryCount = 0
-        return &w
-    }); err != nil {
-        return nil, err
-    } else {
-        return wlUsage, nil
-    }
+	if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
+		w.DisableRetry = true
+		w.RetryCount = 0
+		return &w
+	}); err != nil {
+		return nil, err
+	} else {
+		return wlUsage, nil
+	}
 }
 
 func UpdatePolicy(db *bolt.DB, deviceid string, policyName string, pol string) (*WorkloadUsage, error) {
-    if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
-        w.Policy = pol
-        return &w
-    }); err != nil {
-        return nil, err
-    } else {
-        return wlUsage, nil
-    }
+	if wlUsage, err := singleWorkloadUsageUpdate(db, deviceid, policyName, func(w WorkloadUsage) *WorkloadUsage {
+		w.Policy = pol
+		return &w
+	}); err != nil {
+		return nil, err
+	} else {
+		return wlUsage, nil
+	}
 }
 
 func FindSingleWorkloadUsageByDeviceAndPolicyName(db *bolt.DB, deviceid string, policyName string) (*WorkloadUsage, error) {
-    filters := make([]WUFilter, 0)
-    filters = append(filters, DaPWUFilter(deviceid, policyName))
+	filters := make([]WUFilter, 0)
+	filters = append(filters, DaPWUFilter(deviceid, policyName))
 
-    if wlUsages, err := FindWorkloadUsages(db, filters); err != nil {
-        return nil, err
-    } else if len(wlUsages) > 1 {
-        return nil, fmt.Errorf("Expected only one record for device: %v and policy: %v, but retrieved: %v", deviceid, policyName, wlUsages)
-    } else if len(wlUsages) == 0 {
-        return nil, nil
-    } else {
-        return &wlUsages[0], nil
-    }
+	if wlUsages, err := FindWorkloadUsages(db, filters); err != nil {
+		return nil, err
+	} else if len(wlUsages) > 1 {
+		return nil, fmt.Errorf("Expected only one record for device: %v and policy: %v, but retrieved: %v", deviceid, policyName, wlUsages)
+	} else if len(wlUsages) == 0 {
+		return nil, nil
+	} else {
+		return &wlUsages[0], nil
+	}
 }
 
 func singleWorkloadUsageUpdate(db *bolt.DB, deviceid string, policyName string, fn func(WorkloadUsage) *WorkloadUsage) (*WorkloadUsage, error) {
-    if wlUsage, err := FindSingleWorkloadUsageByDeviceAndPolicyName(db, deviceid, policyName); err != nil {
-        return nil, err
-    } else if wlUsage == nil {
-        return nil, fmt.Errorf("Unable to locate workload usage for device: %v, and policy: %v", deviceid, policyName)
-    } else {
-        updated := fn(*wlUsage)
-        return updated, persistUpdatedWorkloadUsage(db, wlUsage.Id, updated)
-    }
+	if wlUsage, err := FindSingleWorkloadUsageByDeviceAndPolicyName(db, deviceid, policyName); err != nil {
+		return nil, err
+	} else if wlUsage == nil {
+		return nil, fmt.Errorf("Unable to locate workload usage for device: %v, and policy: %v", deviceid, policyName)
+	} else {
+		updated := fn(*wlUsage)
+		return updated, persistUpdatedWorkloadUsage(db, wlUsage.Id, updated)
+	}
 }
 
 // does whole-member replacements of values that are legal to change during the course of a workload usage
 func persistUpdatedWorkloadUsage(db *bolt.DB, id uint64, update *WorkloadUsage) error {
-    return db.Update(func(tx *bolt.Tx) error {
-        if b, err := tx.CreateBucketIfNotExists([]byte(wuBucketName())); err != nil {
-            return err
-        } else {
-            pKey := strconv.FormatUint(id, 10)
-            current := b.Get([]byte(pKey))
-            var mod WorkloadUsage
+	return db.Update(func(tx *bolt.Tx) error {
+		if b, err := tx.CreateBucketIfNotExists([]byte(wuBucketName())); err != nil {
+			return err
+		} else {
+			pKey := strconv.FormatUint(id, 10)
+			current := b.Get([]byte(pKey))
+			var mod WorkloadUsage
 
-            if current == nil {
-                return fmt.Errorf("No workload usage with id %v available to update", pKey)
-            } else if err := json.Unmarshal(current, &mod); err != nil {
-                return fmt.Errorf("Failed to unmarshal workload usage DB data: %v", string(current))
-            } else {
+			if current == nil {
+				return fmt.Errorf("No workload usage with id %v available to update", pKey)
+			} else if err := json.Unmarshal(current, &mod); err != nil {
+				return fmt.Errorf("Failed to unmarshal workload usage DB data: %v", string(current))
+			} else {
 
-                // write updates only to the fields we expect should be updateable
-                mod.Priority = update.Priority
-                mod.RetryCount = update.RetryCount
-                mod.RetryDurationS = update.RetryDurationS
-                // This field goes from empty to non-empty to empty, ad infinitum
-                if (mod.CurrentAgreementId == "" && update.CurrentAgreementId != "") || (mod.CurrentAgreementId != "" && update.CurrentAgreementId == "") {
-                    mod.CurrentAgreementId = update.CurrentAgreementId
-                }
-                if mod.FirstTryTime < update.FirstTryTime {     // Always moves forward
-                    mod.FirstTryTime = update.FirstTryTime
-                }
-                if mod.PendingUpgradeTime == 0 {        // 1 transition from zero to non-zero
-                    mod.PendingUpgradeTime = update.PendingUpgradeTime
-                }
-                if mod.LatestRetryTime < update.LatestRetryTime {   // Always moves forward
-                    mod.LatestRetryTime = update.LatestRetryTime
-                }
-                if !mod.DisableRetry {                  // 1 transition from false to true
-                    mod.DisableRetry = update.DisableRetry
-                }
-                if !mod.ReqsNotMet {                    // 1 transition from false to true
-                    mod.ReqsNotMet = update.ReqsNotMet
-                }
-                if mod.Policy == "" {                   // 1 transition from empty to set
-                    mod.Policy = update.Policy
-                }
-                mod.VerifiedDurationS = update.VerifiedDurationS
+				// write updates only to the fields we expect should be updateable
+				mod.Priority = update.Priority
+				mod.RetryCount = update.RetryCount
+				mod.RetryDurationS = update.RetryDurationS
+				// This field goes from empty to non-empty to empty, ad infinitum
+				if (mod.CurrentAgreementId == "" && update.CurrentAgreementId != "") || (mod.CurrentAgreementId != "" && update.CurrentAgreementId == "") {
+					mod.CurrentAgreementId = update.CurrentAgreementId
+				}
+				if mod.FirstTryTime < update.FirstTryTime { // Always moves forward
+					mod.FirstTryTime = update.FirstTryTime
+				}
+				if mod.PendingUpgradeTime == 0 { // 1 transition from zero to non-zero
+					mod.PendingUpgradeTime = update.PendingUpgradeTime
+				}
+				if mod.LatestRetryTime < update.LatestRetryTime { // Always moves forward
+					mod.LatestRetryTime = update.LatestRetryTime
+				}
+				if !mod.DisableRetry { // 1 transition from false to true
+					mod.DisableRetry = update.DisableRetry
+				}
+				if !mod.ReqsNotMet { // 1 transition from false to true
+					mod.ReqsNotMet = update.ReqsNotMet
+				}
+				if mod.Policy == "" { // 1 transition from empty to set
+					mod.Policy = update.Policy
+				}
+				mod.VerifiedDurationS = update.VerifiedDurationS
 
-                if serialized, err := json.Marshal(mod); err != nil {
-                    return fmt.Errorf("Failed to serialize workload usage record: %v", mod)
-                } else if err := b.Put([]byte(pKey), serialized); err != nil {
-                    return fmt.Errorf("Failed to write workload usage record with key: %v", pKey)
-                } else {
-                    glog.V(2).Infof("Succeeded updating workload usage record to %v", mod)
-                }
-            }
-        }
-        return nil
-    })
+				if serialized, err := json.Marshal(mod); err != nil {
+					return fmt.Errorf("Failed to serialize workload usage record: %v", mod)
+				} else if err := b.Put([]byte(pKey), serialized); err != nil {
+					return fmt.Errorf("Failed to write workload usage record with key: %v", pKey)
+				} else {
+					glog.V(2).Infof("Succeeded updating workload usage record to %v", mod)
+				}
+			}
+		}
+		return nil
+	})
 }
 
 func DeleteWorkloadUsage(db *bolt.DB, deviceid string, policyName string) error {
-    if deviceid == "" || policyName == "" {
-        return fmt.Errorf("Missing required arg deviceid or policyName")
-    } else {
+	if deviceid == "" || policyName == "" {
+		return fmt.Errorf("Missing required arg deviceid or policyName")
+	} else {
 
-        if wlUsage, err := FindSingleWorkloadUsageByDeviceAndPolicyName(db, deviceid, policyName); err != nil {
-            return err
-        } else if wlUsage == nil {
-            return fmt.Errorf("Unable to locate workload usage for device: %v, and policy: %v", deviceid, policyName)
-        } else {
+		if wlUsage, err := FindSingleWorkloadUsageByDeviceAndPolicyName(db, deviceid, policyName); err != nil {
+			return err
+		} else if wlUsage == nil {
+			return fmt.Errorf("Unable to locate workload usage for device: %v, and policy: %v", deviceid, policyName)
+		} else {
 
-            pk := wlUsage.Id
-            return db.Update(func(tx *bolt.Tx) error {
-                b := tx.Bucket([]byte(wuBucketName()))
-                if b == nil {
-                    return fmt.Errorf("Unknown bucket: %v", wuBucketName())
-                } else if existing := b.Get([]byte(strconv.FormatUint(pk, 10))); existing == nil {
-                    glog.Errorf("Warning: record deletion requested, but record does not exist: %v", pk)
-                    return nil // handle already-deleted workload usage as success
-                } else {
-                    var record WorkloadUsage
+			pk := wlUsage.Id
+			return db.Update(func(tx *bolt.Tx) error {
+				b := tx.Bucket([]byte(wuBucketName()))
+				if b == nil {
+					return fmt.Errorf("Unknown bucket: %v", wuBucketName())
+				} else if existing := b.Get([]byte(strconv.FormatUint(pk, 10))); existing == nil {
+					glog.Errorf("Warning: record deletion requested, but record does not exist: %v", pk)
+					return nil // handle already-deleted workload usage as success
+				} else {
+					var record WorkloadUsage
 
-                    if err := json.Unmarshal(existing, &record); err != nil {
-                        glog.Errorf("Error deserializing workload usage: %v. This is a pre-deletion warning message function so deletion will still proceed", record)
-                    }
-                }
+					if err := json.Unmarshal(existing, &record); err != nil {
+						glog.Errorf("Error deserializing workload usage: %v. This is a pre-deletion warning message function so deletion will still proceed", record)
+					}
+				}
 
-                glog.V(3).Infof("Deleting workload usage record for %v with policy %v", deviceid, policyName)
-                return b.Delete([]byte(strconv.FormatUint(pk, 10)))
-            })
-        }
-    }
+				glog.V(3).Infof("Deleting workload usage record for %v with policy %v", deviceid, policyName)
+				return b.Delete([]byte(strconv.FormatUint(pk, 10)))
+			})
+		}
+	}
 }
 
 func DaPWUFilter(deviceid string, policyName string) WUFilter {
-    return func(a WorkloadUsage) bool { return a.DeviceId == deviceid && a.PolicyName == policyName }
+	return func(a WorkloadUsage) bool { return a.DeviceId == deviceid && a.PolicyName == policyName }
 }
 
 func DWUFilter(deviceid string) WUFilter {
-    return func(a WorkloadUsage) bool { return a.DeviceId == deviceid }
+	return func(a WorkloadUsage) bool { return a.DeviceId == deviceid }
 }
 
 func PWUFilter(policyName string) WUFilter {
-    return func(a WorkloadUsage) bool { return a.PolicyName == policyName }
+	return func(a WorkloadUsage) bool { return a.PolicyName == policyName }
 }
 
 type WUFilter func(WorkloadUsage) bool
 
 func FindWorkloadUsages(db *bolt.DB, filters []WUFilter) ([]WorkloadUsage, error) {
-    wlUsages := make([]WorkloadUsage, 0)
+	wlUsages := make([]WorkloadUsage, 0)
 
-    readErr := db.View(func(tx *bolt.Tx) error {
+	readErr := db.View(func(tx *bolt.Tx) error {
 
-        if b := tx.Bucket([]byte(wuBucketName())); b != nil {
-            b.ForEach(func(k, v []byte) error {
+		if b := tx.Bucket([]byte(wuBucketName())); b != nil {
+			b.ForEach(func(k, v []byte) error {
 
-                var a WorkloadUsage
+				var a WorkloadUsage
 
-                if err := json.Unmarshal(v, &a); err != nil {
-                    glog.Errorf("Unable to deserialize db record: %v", v)
-                } else {
-                    glog.V(5).Infof("Demarshalled workload usage in DB: %v", a)
-                    exclude := false
-                    for _, filterFn := range filters {
-                        if !filterFn(a) {
-                            exclude = true
-                        }
-                    }
-                    if !exclude {
-                        wlUsages = append(wlUsages, a)
-                    }
-                }
-                return nil
-            })
-        }
+				if err := json.Unmarshal(v, &a); err != nil {
+					glog.Errorf("Unable to deserialize db record: %v", v)
+				} else {
+					glog.V(5).Infof("Demarshalled workload usage in DB: %v", a)
+					exclude := false
+					for _, filterFn := range filters {
+						if !filterFn(a) {
+							exclude = true
+						}
+					}
+					if !exclude {
+						wlUsages = append(wlUsages, a)
+					}
+				}
+				return nil
+			})
+		}
 
-        return nil // end the transaction
-    })
+		return nil // end the transaction
+	})
 
-    if readErr != nil {
-        return nil, readErr
-    } else {
-        return wlUsages, nil
-    }
+	if readErr != nil {
+		return nil, readErr
+	} else {
+		return wlUsages, nil
+	}
 }
 
 // This function allocates the record's primary key from the DB's internal sequence counter. The record
 // being created is updated with this key right before it is written. This function assumes that duplicate
 // record checks have already occurred before it is called.
 func WUPersistNew(db *bolt.DB, bucket string, record *WorkloadUsage) error {
-    if bucket == "" {
-        return fmt.Errorf("Missing required arg bucket")
-    } else {
-        writeErr := db.Update(func(tx *bolt.Tx) error {
+	if bucket == "" {
+		return fmt.Errorf("Missing required arg bucket")
+	} else {
+		writeErr := db.Update(func(tx *bolt.Tx) error {
 
-            if b, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
-                return err
-            } else if nextKey, err := b.NextSequence(); err != nil {
-                return fmt.Errorf("Unable to get sequence key for new record %v. Error: %v", record, err)
-            } else {
-                strKey := strconv.FormatUint(nextKey, 10)
-                record.Id = nextKey
-                if bytes, err := json.Marshal(record); err != nil {
-                    return fmt.Errorf("Unable to serialize record %v. Error: %v", record, err)
-                } else if err := b.Put([]byte(strKey), bytes); err != nil {
-                    return fmt.Errorf("Unable to write record to bucket %v. Primary key of record: %v", bucket, strKey)
-                } else {
-                    glog.V(2).Infof("Succeeded writing workload usage record identified by key %v, record %v in %v", strKey, *record, bucket)
-                    return nil
-                }
-            }
-        })
+			if b, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
+				return err
+			} else if nextKey, err := b.NextSequence(); err != nil {
+				return fmt.Errorf("Unable to get sequence key for new record %v. Error: %v", record, err)
+			} else {
+				strKey := strconv.FormatUint(nextKey, 10)
+				record.Id = nextKey
+				if bytes, err := json.Marshal(record); err != nil {
+					return fmt.Errorf("Unable to serialize record %v. Error: %v", record, err)
+				} else if err := b.Put([]byte(strKey), bytes); err != nil {
+					return fmt.Errorf("Unable to write record to bucket %v. Primary key of record: %v", bucket, strKey)
+				} else {
+					glog.V(2).Infof("Succeeded writing workload usage record identified by key %v, record %v in %v", strKey, *record, bucket)
+					return nil
+				}
+			}
+		})
 
-        return writeErr
-    }
+		return writeErr
+	}
 }
 
 func wuBucketName() string {
-    return WORKLOAD_USAGE
+	return WORKLOAD_USAGE
 }

--- a/agreementbot/wl_persistence_int_test.go
+++ b/agreementbot/wl_persistence_int_test.go
@@ -3,76 +3,76 @@
 package agreementbot
 
 import (
-    "github.com/boltdb/bolt"
-    "io/ioutil"
-    "os"
-    "testing"
-    "time"
+	"github.com/boltdb/bolt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
 )
 
 var testDb *bolt.DB
 
 func TestMain(m *testing.M) {
-    testDbFile, err := ioutil.TempFile("", "agreementbot_test.db")
-    if err != nil {
-        panic(err)
-    }
-    defer os.Remove(testDbFile.Name())
+	testDbFile, err := ioutil.TempFile("", "agreementbot_test.db")
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(testDbFile.Name())
 
-    var dbErr error
-    testDb, dbErr = bolt.Open(testDbFile.Name(), 0600, &bolt.Options{Timeout: 10 * time.Second})
-    if dbErr != nil {
-        panic(err)
-    }
+	var dbErr error
+	testDb, dbErr = bolt.Open(testDbFile.Name(), 0600, &bolt.Options{Timeout: 10 * time.Second})
+	if dbErr != nil {
+		panic(err)
+	}
 
-    m.Run()
+	m.Run()
 }
 
 func Test_SaveNewRecord1(t *testing.T) {
 
-    deviceid := "an12345"
-    pName := "test policy"
+	deviceid := "an12345"
+	pName := "test policy"
 
-    if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 1, 30, 180, "AG1"); err != nil {
-        t.Errorf("Received error creating new workload usage: %v", err)
-    } else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
-        t.Errorf("Received error finding new record: %v", err)
-    } else if wlu.Priority != 1 {
-        t.Errorf("Record received on read does not have the right priority, expecting 1, was %v", wlu.Priority)
-    }
+	if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 1, 30, 180, "AG1"); err != nil {
+		t.Errorf("Received error creating new workload usage: %v", err)
+	} else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
+		t.Errorf("Received error finding new record: %v", err)
+	} else if wlu.Priority != 1 {
+		t.Errorf("Record received on read does not have the right priority, expecting 1, was %v", wlu.Priority)
+	}
 
-    if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 1, 30, 180, "AG1"); err == nil {
-        t.Errorf("Should have received error creating duplicate record")
-    }
+	if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 1, 30, 180, "AG1"); err == nil {
+		t.Errorf("Should have received error creating duplicate record")
+	}
 
-    deviceid = "an54321"
-    if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
-        t.Errorf("Received error finding non-existent record: %v", err)
-    } else if wlu != nil {
-        t.Errorf("Received record %v that should not have been returned.", wlu)
-    }
+	deviceid = "an54321"
+	if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
+		t.Errorf("Received error finding non-existent record: %v", err)
+	} else if wlu != nil {
+		t.Errorf("Received record %v that should not have been returned.", wlu)
+	}
 
 }
 
 func Test_SaveNewRecord2(t *testing.T) {
 
-    deviceid := "an67890"
-    pName := "test policy"
+	deviceid := "an67890"
+	pName := "test policy"
 
-    if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 2, 30, 180, "AG1"); err != nil {
-        t.Errorf("Received error creating new workload usage: %v", err)
-    } else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
-        t.Errorf("Received error finding new record: %v", err)
-    } else if wlu.Priority != 2 {
-        t.Errorf("Record received on read does not have the right priority, expecting 1, was %v", wlu.Priority)
-    }
+	if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 2, 30, 180, "AG1"); err != nil {
+		t.Errorf("Received error creating new workload usage: %v", err)
+	} else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
+		t.Errorf("Received error finding new record: %v", err)
+	} else if wlu.Priority != 2 {
+		t.Errorf("Record received on read does not have the right priority, expecting 1, was %v", wlu.Priority)
+	}
 
-    if err := DeleteWorkloadUsage(testDb, deviceid, pName); err != nil {
-        t.Errorf("Received error deleting workload usage: %v", err)
-    } else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
-        t.Errorf("Received error finding new record: %v", err)
-    } else if wlu != nil {
-        t.Errorf("Received record %v that should not have been returned.", wlu)
-    }
+	if err := DeleteWorkloadUsage(testDb, deviceid, pName); err != nil {
+		t.Errorf("Received error deleting workload usage: %v", err)
+	} else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
+		t.Errorf("Received error finding new record: %v", err)
+	} else if wlu != nil {
+		t.Errorf("Received record %v that should not have been returned.", wlu)
+	}
 
 }

--- a/agreementbot/wl_persistence_int_test.go
+++ b/agreementbot/wl_persistence_int_test.go
@@ -33,7 +33,7 @@ func Test_SaveNewRecord1(t *testing.T) {
 	deviceid := "an12345"
 	pName := "test policy"
 
-	if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 1, 30, 180, "AG1"); err != nil {
+	if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 1, 30, 180, false, "AG1"); err != nil {
 		t.Errorf("Received error creating new workload usage: %v", err)
 	} else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
 		t.Errorf("Received error finding new record: %v", err)
@@ -41,7 +41,7 @@ func Test_SaveNewRecord1(t *testing.T) {
 		t.Errorf("Record received on read does not have the right priority, expecting 1, was %v", wlu.Priority)
 	}
 
-	if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 1, 30, 180, "AG1"); err == nil {
+	if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 1, 30, 180, false, "AG1"); err == nil {
 		t.Errorf("Should have received error creating duplicate record")
 	}
 
@@ -59,7 +59,7 @@ func Test_SaveNewRecord2(t *testing.T) {
 	deviceid := "an67890"
 	pName := "test policy"
 
-	if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 2, 30, 180, "AG1"); err != nil {
+	if err := NewWorkloadUsage(testDb, deviceid, []string{}, "{some json serialized policy file}", pName, 2, 30, 180, false, "AG1"); err != nil {
 		t.Errorf("Received error creating new workload usage: %v", err)
 	} else if wlu, err := FindSingleWorkloadUsageByDeviceAndPolicyName(testDb, deviceid, pName); err != nil {
 		t.Errorf("Received error finding new record: %v", err)

--- a/api/api.go
+++ b/api/api.go
@@ -1477,7 +1477,7 @@ func (a *API) workloadConfig(w http.ResponseWriter, r *http.Request) {
 		workloadDef, err := exchange.GetWorkload(cfg.WorkloadURL, vExp.Get_expression(), cutil.ArchString(), a.Config.Edge.ExchangeURL, existingDevice.Id, existingDevice.Token)
 		if err != nil || workloadDef == nil {
 			glog.Errorf("Unable to find the workload definition using version %v in the exchange: %v", vExp.Get_expression(), err)
-			writeInputErr(w, http.StatusBadRequest, &APIUserInputError{Error: fmt.Sprintf("Unable to find the workload definition using version %v in the exchange.",vExp.Get_expression())})
+			writeInputErr(w, http.StatusBadRequest, &APIUserInputError{Error: fmt.Sprintf("Unable to find the workload definition using version %v in the exchange.", vExp.Get_expression())})
 			return
 		}
 

--- a/api/api.go
+++ b/api/api.go
@@ -566,7 +566,7 @@ func (a *API) service(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// verify with the exchange to make sure the service exists
-			e_msdef, err := exchange.GetMicroservice(*service.SensorUrl, vExp.Get_expression(), cutil.ArchString(), a.Config.Edge.ExchangeURL, existingDevice.Id, existingDevice.Token)
+			e_msdef, err := exchange.GetMicroservice(a.Config.Collaborators.HTTPClientFactory, *service.SensorUrl, vExp.Get_expression(), cutil.ArchString(), a.Config.Edge.ExchangeURL, existingDevice.Id, existingDevice.Token)
 			if err != nil || e_msdef == nil {
 				glog.Errorf("Unable to find the microservice definition in the exchange: %v", err)
 				writeInputErr(w, http.StatusBadRequest, &APIUserInputError{Error: fmt.Sprintf("Unable to find the microservice definition for '%v' on the exchange. Please verify sensor_url and sensor_version.", *service.SensorName)})
@@ -1474,7 +1474,7 @@ func (a *API) workloadConfig(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Get the workload metadata from the exchange and verify the userInput against the variables in the POST body.
-		workloadDef, err := exchange.GetWorkload(cfg.WorkloadURL, vExp.Get_expression(), cutil.ArchString(), a.Config.Edge.ExchangeURL, existingDevice.Id, existingDevice.Token)
+		workloadDef, err := exchange.GetWorkload(a.Config.Collaborators.HTTPClientFactory, cfg.WorkloadURL, vExp.Get_expression(), cutil.ArchString(), a.Config.Edge.ExchangeURL, existingDevice.Id, existingDevice.Token)
 		if err != nil || workloadDef == nil {
 			glog.Errorf("Unable to find the workload definition using version %v in the exchange: %v", vExp.Get_expression(), err)
 			writeInputErr(w, http.StatusBadRequest, &APIUserInputError{Error: fmt.Sprintf("Unable to find the workload definition using version %v in the exchange.", vExp.Get_expression())})

--- a/api/api_output.go
+++ b/api/api_output.go
@@ -46,8 +46,8 @@ func (s WorkloadConfigByWorkloadURLAndVersion) Swap(i, j int) {
 func (s WorkloadConfigByWorkloadURLAndVersion) Less(i, j int) bool {
 
 	// Just compare the starting version in the two ranges
-	first := s[i].VersionExpression[1:strings.Index(s[i].VersionExpression,",")]
-	second := s[j].VersionExpression[1:strings.Index(s[j].VersionExpression,",")]
+	first := s[i].VersionExpression[1:strings.Index(s[i].VersionExpression, ",")]
+	second := s[j].VersionExpression[1:strings.Index(s[j].VersionExpression, ",")]
 
 	return (strings.Compare(s[i].WorkloadURL, s[j].WorkloadURL) == -1) && (strings.Compare(first, second) == -1)
 }

--- a/basicprotocol/protocol.go
+++ b/basicprotocol/protocol.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/abstractprotocol"
-	"github.com/open-horizon/anax/config"
 	"github.com/open-horizon/anax/metering"
 	"github.com/open-horizon/anax/policy"
 	"net/http"
-	"time"
 )
 
 const PROTOCOL_NAME = "Basic"
@@ -20,11 +18,11 @@ type ProtocolHandler struct {
 	*abstractprotocol.BaseProtocolHandler
 }
 
-func NewProtocolHandler(pm *policy.PolicyManager) *ProtocolHandler {
+func NewProtocolHandler(httpClient *http.Client, pm *policy.PolicyManager) *ProtocolHandler {
 
 	bph := abstractprotocol.NewBaseProtocolHandler(PROTOCOL_NAME,
 		PROTOCOL_CURRENT_VERSION,
-		&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
+		httpClient,
 		pm)
 
 	return &ProtocolHandler{

--- a/citizenscientist/protocol.go
+++ b/citizenscientist/protocol.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/abstractprotocol"
-	"github.com/open-horizon/anax/config"
 	"github.com/open-horizon/anax/ethblockchain"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/metering"
@@ -17,7 +16,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"time"
 )
 
 const PROTOCOL_NAME = "Citizen Scientist"
@@ -208,11 +206,11 @@ type ProtocolHandler struct {
 	EthMeterContract     *contract_api.SolidityContract
 }
 
-func NewProtocolHandler(pm *policy.PolicyManager) *ProtocolHandler {
+func NewProtocolHandler(httpClient *http.Client, pm *policy.PolicyManager) *ProtocolHandler {
 
 	bph := abstractprotocol.NewBaseProtocolHandler(PROTOCOL_NAME,
 		PROTOCOL_CURRENT_VERSION,
-		&http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
+		httpClient,
 		pm)
 
 	return &ProtocolHandler{

--- a/citizenscientist/protocol_test.go
+++ b/citizenscientist/protocol_test.go
@@ -1,17 +1,17 @@
 package citizenscientist
 
 import (
-    "testing"
+	"testing"
 )
 
 // Validation tests
 func Test_Proposal_validation(t *testing.T) {
 
-    proposal1 := `{"address":"123456","tsandcs":"abc","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	proposal1 := `{"address":"123456","tsandcs":"abc","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
 
-    ph := new(ProtocolHandler)
-    if _, err := ph.ValidateProposal(proposal1); err != nil {
-        t.Errorf("Error validating %v, error %v", proposal1, err)
-    }
+	ph := new(ProtocolHandler)
+	if _, err := ph.ValidateProposal(proposal1); err != nil {
+		t.Errorf("Error validating %v, error %v", proposal1, err)
+	}
 
 }

--- a/config/collaborators.go
+++ b/config/collaborators.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// This exists to consolidate construction of clients to collaborating
+// systems or other shared resources. We may need to do some poor man's
+// DI here with build flags and selective compilation against varying
+// concrete interfaces here.
+
+type Collaborators struct {
+	HTTPClientFactory *HTTPClientFactory
+}
+
+func NewCollaborators(hConfig HorizonConfig) (*Collaborators, error) {
+	httpClientFactory, err := NewHTTPClientFactory(hConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Collaborators{
+		HTTPClientFactory: httpClientFactory,
+	}, nil
+}
+
+func (c *Collaborators) String() string {
+	return fmt.Sprintf("HTTPClientFactory: %v", c.HTTPClientFactory)
+}
+
+type HTTPClientFactory struct {
+	NewHTTPClient func(overrideTimeoutS *uint) *http.Client
+}
+
+func NewHTTPClientFactory(hConfig HorizonConfig) (*HTTPClientFactory, error) {
+	var caBytes []byte
+
+	if hConfig.Edge.CACertsPath != "" {
+		var err error
+		caBytes, err = ioutil.ReadFile(hConfig.Edge.CACertsPath)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to read CACertsFile: %v", hConfig.Edge.CACertsPath)
+		}
+	}
+
+	var tls tls.Config
+	tls.InsecureSkipVerify = false
+
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(caBytes)
+	tls.RootCAs = certPool
+
+	tls.BuildNameToCertificate()
+
+	clientFunc := func(overrideTimeoutS *uint) *http.Client {
+		var timeoutS uint
+
+		if overrideTimeoutS != nil {
+			timeoutS = *overrideTimeoutS
+		} else {
+			timeoutS = hConfig.Edge.DefaultHTTPClientTimeoutS
+		}
+
+		return &http.Client{
+			Timeout: time.Second * time.Duration(timeoutS),
+			Transport: &http.Transport{
+				TLSClientConfig: &tls,
+			},
+		}
+	}
+
+	return &HTTPClientFactory{
+		NewHTTPClient: clientFunc,
+	}, nil
+}

--- a/config/collaborators.go
+++ b/config/collaborators.go
@@ -87,6 +87,8 @@ func newHTTPClientFactory(hConfig HorizonConfig) (*HTTPClientFactory, error) {
 		return &http.Client{
 			Timeout: time.Second * time.Duration(timeoutS),
 			Transport: &http.Transport{
+				MaxIdleConns:    MaxHTTPIdleConnections,
+				IdleConnTimeout: HTTPIdleConnectionTimeoutS * time.Second,
 				TLSClientConfig: &tls,
 			},
 		}

--- a/config/collaborators_int_test.go
+++ b/config/collaborators_int_test.go
@@ -1,4 +1,5 @@
 // +build integration
+// +build go1.9
 
 package config
 

--- a/config/collaborators_int_test.go
+++ b/config/collaborators_int_test.go
@@ -1,0 +1,235 @@
+// +build integration
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const listenOn = "127.0.0.1"
+
+// generated with: ALTNAME=DNS:localhost,DNS:localhost.localdomain,IP:127.0.0.1 openssl req -newkey rsa:1024 -nodes -keyout collaborators-test-key.pem -x509 -days 36500 -out collaborators-test-cert.pem -subj "/C=US/ST=UT/O=Salt Lake City/CN=localhost.localdomain" -config /etc/ssl/openssl.cnf
+// requires: /etc/ssl/openssl.cnf w/ section '[ v3_ca ]' having keyUsage = digitalSignature, keyEncipherment ; subjectAltName = $ENV::ALTNAME
+
+// verify with: openssl req -in domain.csr -text -noout
+
+const collaboratorsTestCert = `-----BEGIN CERTIFICATE-----
+MIICuzCCAiSgAwIBAgIJAN7JXdbhU4bsMA0GCSqGSIb3DQEBCwUAMFMxCzAJBgNV
+BAYTAlVTMQswCQYDVQQIDAJVVDEXMBUGA1UECgwOU2FsdCBMYWtlIENpdHkxHjAc
+BgNVBAMMFWxvY2FsaG9zdC5sb2NhbGRvbWFpbjAgFw0xNzA5MTAyMjAwNTlaGA8y
+MTE3MDgxNzIyMDA1OVowUzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlVUMRcwFQYD
+VQQKDA5TYWx0IExha2UgQ2l0eTEeMBwGA1UEAwwVbG9jYWxob3N0LmxvY2FsZG9t
+YWluMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCju4NREasdEKNIRB2bghrh
+wcc7A5nW6TN8WG/LuDKzZbodLNbivB3BWeUNi64rn9TB5XhpMom0nOQRo4uKPuJd
+2s8cKeOLpcR7Al6CUZkkrFn+i7BxShnnvR22wBdbfR+nXwNRc8/kq073U6YmLq/l
+G59+b2kWmkNNgTfJbARYPwIDAQABo4GUMIGRMB0GA1UdDgQWBBTrA+IuPqqVJuhH
+muQR5Krpw5GWGDAfBgNVHSMEGDAWgBTrA+IuPqqVJuhHmuQR5Krpw5GWGDAPBgNV
+HRMBAf8EBTADAQH/MAsGA1UdDwQEAwIFoDAxBgNVHREEKjAogglsb2NhbGhvc3SC
+FWxvY2FsaG9zdC5sb2NhbGRvbWFpbocEfwAAATANBgkqhkiG9w0BAQsFAAOBgQAu
+JJZX6caJ31h1hG4X3rWTaX0K/8nNXq3XtYGPP88K0uJMWGrtTs5XLlgTxhYCo6JH
+2D2YUnmSLDfIEhFDUiQGBSfABR0YDAe/3nC8q8Gk5m4VGHmdszY/EbzCdl7Nf/MZ
+vSDcr4UB3UEwhhdfJ+hzPzSSPknSmUczZ9UoVvk48Q==
+-----END CERTIFICATE-----`
+const collaboratorsTestKey = `-----BEGIN PRIVATE KEY-----
+MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAKO7g1ERqx0Qo0hE
+HZuCGuHBxzsDmdbpM3xYb8u4MrNluh0s1uK8HcFZ5Q2Lriuf1MHleGkyibSc5BGj
+i4o+4l3azxwp44ulxHsCXoJRmSSsWf6LsHFKGee9HbbAF1t9H6dfA1Fzz+SrTvdT
+piYur+Ubn35vaRaaQ02BN8lsBFg/AgMBAAECgYBufulMGKRl5QiMiIuCmvcRS/js
+Nq3nf1GjpPstfI2azBgiAFS0h0d9aPFPhuhvwFmQ0Q/FzrloDklMLhbJoU6Z++kz
++RLy3rKX4zv1Sv5R4M0gBNRzr10EzCmJS5rOOrwPABLAfEnlagV4T4sDARY+V0Iz
+N2u50DNoben+cQsywQJBAM9lzhbC0J1I4C17iIIOLsUIQuruWxLJ0iiYXS+zxPeH
+marEe70sh6A7w6H9xZ4vRxdtr1xQYbuFjfqGUSbzeEcCQQDKGiV5ien0SQBGwLTq
+CCR4B52/5VhvG11S3oyKLvlr54D1LcSb7eHe/6XDAMhnbBWFr04+SFMYr3t+5l8t
+gpRJAkAAyBpxvYQ5w4eMxFVsYA9PEMvnxMQ1Guue2YwoXN4WLL2ohhsNSHiuYutG
+1gUDppv2+6PYjjkAEu3JDu6JXguLAkEApLrPFNOu2CiwivsD+0YLw7IhiIo9nMJn
+POadEvza3HLkD/PwL1CkLImf6OQ4dOQKXt7XHbkB0jsmo/bOWV/30QJAHXH3aoKT
+P3RnSaBJcRIbi8VEGBP4DKSV5wky/KpGSRoNVqONuPnUAHOSyNGAqi402aq/tBLk
+3CfGb5vgRdDMJQ==
+-----END PRIVATE KEY-----`
+
+// generated with: ALTNAME=DNS:testo openssl req -newkey rsa:1024 -nodes -keyout collaborators-test-key.pem -x509 -days 36500 -out collaborators-test-cert.pem -subj "/C=US/ST=UT/O=Salt Lake City/CN=testo" -config /etc/ssl/openssl.cnf
+// requires: /etc/ssl/openssl.cnf w/ section '[ v3_ca ]' having keyUsage = digitalSignature, keyEncipherment ; subjectAltName = $ENV::ALTNAME
+
+// verify with: openssl req -in domain.csr -text -noout
+
+const collaboratorsOtherTestCert = `-----BEGIN CERTIFICATE-----
+MIICeDCCAeGgAwIBAgIJALUrEoK32k14MA0GCSqGSIb3DQEBCwUAMEMxCzAJBgNV
+BAYTAlVTMQswCQYDVQQIDAJVVDEXMBUGA1UECgwOU2FsdCBMYWtlIENpdHkxDjAM
+BgNVBAMMBXRlc3RvMCAXDTE3MDkxMDIxNDAzNVoYDzIxMTcwODE3MjE0MDM1WjBD
+MQswCQYDVQQGEwJVUzELMAkGA1UECAwCVVQxFzAVBgNVBAoMDlNhbHQgTGFrZSBD
+aXR5MQ4wDAYDVQQDDAV0ZXN0bzCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA
+2yy2sJu5DSJl6Cbdc78IlrvL9GBJ55sjQPco0Yhqef/5y0I/OMXMPTYTfEOB1boz
+ErbpZYu/O5PLLXC6J6Foqi8IKQm++yv7pzWUHRvgh7B4gv/vVrDF9XtggVmRCZ2G
+q0NLGhI7GU2j5r1gxVlpSsxjJ9Tf9AvLWK4KlWGhhgMCAwEAAaNyMHAwHQYDVR0O
+BBYEFI40iczJUPBB5FLj8SSFgWGI0JC5MB8GA1UdIwQYMBaAFI40iczJUPBB5FLj
+8SSFgWGI0JC5MA8GA1UdEwEB/wQFMAMBAf8wCwYDVR0PBAQDAgWgMBAGA1UdEQQJ
+MAeCBXRlc3RvMA0GCSqGSIb3DQEBCwUAA4GBAF5wX7P8SfGg+KlT4RYybBoXuIHz
+1Z/a6SKdkdOe6UimwH5M2Jievbz7qpISRohIXfd+HRClx15XgqSlXduvBUieqk+a
+BKx9kxNOWtep48m/1caJnsS6GTrtc18jB0CzGeGxeIL1cJftL9N0lUSjehbsYGmz
+XseH1jRdJJGVGJw7
+-----END CERTIFICATE-----`
+const collaboratorsOtherTestKey = `-----BEGIN PRIVATE KEY-----
+MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBANsstrCbuQ0iZegm
+3XO/CJa7y/RgSeebI0D3KNGIann/+ctCPzjFzD02E3xDgdW6MxK26WWLvzuTyy1w
+uiehaKovCCkJvvsr+6c1lB0b4IeweIL/71awxfV7YIFZkQmdhqtDSxoSOxlNo+a9
+YMVZaUrMYyfU3/QLy1iuCpVhoYYDAgMBAAECgYEAxT/fhuAO0cBEYIMhyDqD20xW
+CK/js1oOhzgo9zJDSVrTD1emmEyDPA9/x9Tlc1ko/824DZiQWWjwcQvDrUj5bIxo
+662cdPyEJHAs4nDbZeN6EdMJIEwSmpQOXGwoaUQMKyXKhm43uDGJfGfhYwQ4iFQV
+GDxY35H1cPDt7q/3/VkCQQD/WYW6o6uC5bamBW74dVVQ6h+UkVV4VpAg52c1ZLOr
+kAEIWrxVpkFyyT5GO4pYxTG/MD25riN0lHm51OFmBWLXAkEA27ubSj6v4M+w2e2p
+lh9n+SHP+wVgiMsa9xDJpHDbAHwMYSK9Wh1pVslSpVP2u/7ZNwRBBlfKBj/6O0wN
+p9H8tQJAQabwvSXrqQIKzfDDsVnpj55CdF5RjVkkQXF9lbrIfynNOiqqFZNjbHHV
+cxVH4r8ApVlv5VeiggzSpzbWpPZpjQJBALqjJYnwqQ85GixhVDRxRK017SR4MsC+
+U48bsUp9mWdV9mXjThZm+PyAUDShluej1fiHInwywSSB3xfSx56OHCkCQQDsTAih
+sh5/kd46V/jJbNBiporBuz/kVJTXrvFrZNnKgYv2BVC7jQfgOv6gkkQI4tHvuStE
+DuvdvPhYKonxjjLv
+-----END PRIVATE KEY-----`
+
+func setupTesting(listenerCert string, listenerKey string, t *testing.T) (string, net.Listener) {
+	err := os.Setenv("GODEBUG", "1")
+	if err != nil {
+		t.Error(err)
+	}
+
+	dir, err := ioutil.TempDir("", "config-collaborators-")
+	if err != nil {
+		t.Error(err)
+	}
+
+	keyPath := filepath.Join(dir, "collaborators-test-key.pem")
+	if err := ioutil.WriteFile(keyPath, []byte(collaboratorsTestKey), 0660); err != nil {
+		t.Error(err)
+	}
+
+	// mostly for building up a CA cert path
+	certPath := filepath.Join(dir, "collaborators-test-cert.pem")
+	if err := ioutil.WriteFile(certPath, []byte(collaboratorsTestCert), 0660); err != nil {
+		t.Error(err)
+	}
+
+	config := &HorizonConfig{
+		Edge: Config{
+			TrustSystemCACerts: false,
+			CACertsPath:        certPath,
+		},
+	}
+
+	configBytes, err := json.Marshal(config)
+	if err != nil {
+		t.Error(err)
+	}
+
+	configPath := filepath.Join(dir, "config.json")
+	if err := ioutil.WriteFile(configPath, configBytes, 0660); err != nil {
+		t.Error(err)
+	}
+
+	// write listener key and cert
+	listenerKeyPath := filepath.Join(dir, "listener-key.pem")
+	if err := ioutil.WriteFile(listenerKeyPath, []byte(listenerKey), 0660); err != nil {
+		t.Error(err)
+	}
+
+	listenerCertPath := filepath.Join(dir, "listener-cert.pem")
+	if err := ioutil.WriteFile(listenerCertPath, []byte(listenerCert), 0660); err != nil {
+		t.Error(err)
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/boosh", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("yup"))
+	})
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", listenOn))
+	if err != nil {
+		t.Error(err)
+	}
+
+	// setup https server
+	go func() {
+		err = http.ServeTLS(listener, mux, listenerCertPath, listenerKeyPath)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	return dir, listener
+}
+
+func Test_HTTPClientFactory_Suite(t *testing.T) {
+	timeoutS := uint(2)
+
+	setupForTest := func(listenerCert, listenerKey string) (*HorizonConfig, string) {
+		dir, listener := setupTesting(listenerCert, listenerKey, t)
+
+		t.Logf("listening on %s", listener.Addr().String())
+
+		cfg, err := Read(filepath.Join(dir, "config.json"))
+		if err != nil {
+			t.Error(nil)
+		}
+		return cfg, strings.Split(listener.Addr().String(), ":")[1]
+	}
+
+	cfg, port := setupForTest(collaboratorsTestCert, collaboratorsTestKey)
+	t.Run("HTTP client rejects trusted cert for wrong domain", func(t *testing.T) {
+
+		client := cfg.Collaborators.HTTPClientFactory.NewHTTPClient(&timeoutS)
+		// this'll fail b/c we're making a request to 127.0.1.1 but that isn't the CN or subjectAltName IP in the cert
+		_, err := client.Get(fmt.Sprintf("https://%s:%s/boosh", "127.0.1.1", port))
+		if err == nil {
+			t.Error("Expected TLS error for sending request to wrong domain")
+		}
+	})
+
+	t.Run("HTTP client accepts trusted cert for right domain", func(t *testing.T) {
+
+		client := cfg.Collaborators.HTTPClientFactory.NewHTTPClient(&timeoutS)
+		// all of these should pass b/c they are the subjectAltNames of the cert (either names or IPs) note that Golang doesn't verify the CA of the cert if it's localhost or an IP
+		for _, dom := range []string{listenOn, "localhost", "localhost.localdomain"} {
+
+			resp, err := client.Get(fmt.Sprintf("https://%s:%s/boosh", dom, port))
+
+			if err != nil {
+				t.Error("Unxpected error sending request to trusted domain", err)
+			}
+
+			if resp != nil {
+				if resp.StatusCode != 200 {
+					t.Errorf("Unexpected error from HTTP request (wanted 200). HTTP response status code: %v", resp.StatusCode)
+				}
+
+				content, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Error("Unexpected error reading response from HTTP server", err)
+				}
+
+				if string(content) != "yup" {
+					t.Error("Unexpected returned content from test")
+				}
+			}
+		}
+	})
+
+	t.Run("HTTP client rejects untrusted cert", func(t *testing.T) {
+		// need a new config and setup
+		cfg, port := setupForTest(collaboratorsOtherTestCert, collaboratorsOtherTestKey)
+
+		client := cfg.Collaborators.HTTPClientFactory.NewHTTPClient(&timeoutS)
+		// this should fail b/c even though we're sending a request to a trusted domain, the CA trust doesn't contain the cert
+		_, err := client.Get(fmt.Sprintf("https://%s:%s/boosh", listenOn, port))
+		if err == nil {
+			t.Error("Expected TLS error for sending request to untrusted domain")
+		}
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -11,8 +11,9 @@ import (
 const ExchangeURLEnvvarName = "HZN_EXCHANGE_URL"
 
 type HorizonConfig struct {
-	Edge         Config
-	AgreementBot AGConfig
+	Edge          Config
+	AgreementBot  AGConfig
+	Collaborators Collaborators
 }
 
 // This is the configuration options for Edge component flavor of Anax
@@ -28,6 +29,7 @@ type Config struct {
 	PublicKeyPath                 string
 	CACertsPath                   string
 	ExchangeURL                   string
+	DefaultHTTPClientTimeoutS     uint
 	PolicyPath                    string
 	ExchangeHeartbeat             int    // Seconds between heartbeats
 	AgreementTimeoutS             uint64 // Number of seconds to wait before declaring agreement not finalized in blockchain
@@ -121,6 +123,14 @@ func Read(file string) (*HorizonConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Unable to enrich content of config file with envvars: %v", err)
 		}
+
+		// now make collaborators instance and assign it to member in this config
+		collaborators, err := NewCollaborators(config)
+		if err != nil {
+			return nil, err
+		}
+
+		config.Collaborators = *collaborators
 
 		// success at last!
 		return &config, nil

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,8 @@ type Config struct {
 	DefaultServiceRegistrationRAM int64
 	StaticWebContent              string
 	PublicKeyPath                 string
-	CACertsPath                   string
+	TrustSystemCACerts            bool   // If equal to true, the HTTP client factory will set up clients that trust CA certs provided by a Linux distribution (see https://golang.org/pkg/crypto/x509/#SystemCertPool)
+	CACertsPath                   string // Path to a file containing PEM-encoded x509 certs HTTP clients in Anax will trust (additive to the configuration option "TrustSystemCACerts")
 	ExchangeURL                   string
 	DefaultHTTPClientTimeoutS     uint
 	PolicyPath                    string
@@ -110,8 +111,12 @@ func Read(file string) (*HorizonConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Unable to read config file: %s. Error: %v", file, err)
 	} else {
-		// instantiate empty which will be filled
-		config := HorizonConfig{}
+		// instantiate mostly empty which will be filled. Values here are defaults that can be overridden by the user
+		config := HorizonConfig{
+			Edge: Config{
+				DefaultHTTPClientTimeoutS: 20,
+			},
+		}
 
 		err := json.NewDecoder(path).Decode(&config)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	DefaultServiceRegistrationRAM int64
 	StaticWebContent              string
 	PublicKeyPath                 string
-	TrustSystemCACerts            bool   // If equal to true, the HTTP client factory will set up clients that trust CA certs provided by a Linux distribution (see https://golang.org/pkg/crypto/x509/#SystemCertPool)
+	TrustSystemCACerts            bool   // If equal to true, the HTTP client factory will set up clients that trust CA certs provided by a Linux distribution (see https://golang.org/pkg/crypto/x509/#SystemCertPool and https://golang.org/src/crypto/x509/root_linux.go)
 	CACertsPath                   string // Path to a file containing PEM-encoded x509 certs HTTP clients in Anax will trust (additive to the configuration option "TrustSystemCACerts")
 	ExchangeURL                   string
 	DefaultHTTPClientTimeoutS     uint

--- a/config/constants.go
+++ b/config/constants.go
@@ -1,11 +1,9 @@
 package config
 
+// ENVVAR_PREFIX is used when Anax sets envvars in orchestrated containers
 const ENVVAR_PREFIX = "HZN_"
 
 const USERKEYDIR = "/userkeys"
-
-// HTTP client timeout default in milliseconds
-const HTTPDEFAULTTIMEOUT = 20 * 1000
 
 // container start execution timeout for a microservice upgrade
 const MICROSERVICE_EXEC_TIMEOUT = 180

--- a/config/constants.go
+++ b/config/constants.go
@@ -7,3 +7,9 @@ const USERKEYDIR = "/userkeys"
 
 // container start execution timeout for a microservice upgrade
 const MICROSERVICE_EXEC_TIMEOUT = 180
+
+// MaxHTTPIdleConnections see https://golang.org/pkg/net/http/
+const MaxHTTPIdleConnections = 20
+
+// HTTPIdleConnectionTimeoutS see https://golang.org/pkg/net/http/
+const HTTPIdleConnectionTimeoutS = 120

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -70,23 +70,23 @@ func Test_generatePermittedStringDynamic(t *testing.T) {
 func Test_isValidFor_API(t *testing.T) {
 
 	serv1 := Service{
-		Image: "an image",
-		VariationLabel: "label",
-		Privileged: true,
-		Environment: []string{"a=1","b=2"},
-		CapAdd: []string{"a","b"},
-		Command: []string{"start"},
-		Devices: []string{},
-		Ports: []Port{},
+		Image:            "an image",
+		VariationLabel:   "label",
+		Privileged:       true,
+		Environment:      []string{"a=1", "b=2"},
+		CapAdd:           []string{"a", "b"},
+		Command:          []string{"start"},
+		Devices:          []string{},
+		Ports:            []Port{},
 		NetworkIsolation: NetworkIsolation{},
-		Binds: []string{"/tmp/geth:/root"},
+		Binds:            []string{"/tmp/geth:/root"},
 	}
 
 	services := make(map[string]*Service)
 	services["geth"] = &serv1
 
 	desc := DeploymentDescription{
-		Services: services,
+		Services:       services,
 		ServicePattern: Pattern{},
 	}
 
@@ -97,21 +97,21 @@ func Test_isValidFor_API(t *testing.T) {
 	}
 
 	serv2 := Service{
-		Image: "an image",
-		VariationLabel: "label",
-		Privileged: true,
-		Environment: []string{"a=1","b=2"},
-		CapAdd: []string{"a","b"},
-		Command: []string{"start"},
-		Devices: []string{},
-		Ports: []Port{},
+		Image:            "an image",
+		VariationLabel:   "label",
+		Privileged:       true,
+		Environment:      []string{"a=1", "b=2"},
+		CapAdd:           []string{"a", "b"},
+		Command:          []string{"start"},
+		Devices:          []string{},
+		Ports:            []Port{},
 		NetworkIsolation: NetworkIsolation{},
-		SpecificPorts: []docker.PortBinding{{HostIP:"0.0.0.0", HostPort:"8545"}},
+		SpecificPorts:    []docker.PortBinding{{HostIP: "0.0.0.0", HostPort: "8545"}},
 	}
 
 	services["geth"] = &serv2
 	desc2 := DeploymentDescription{
-		Services: services,
+		Services:       services,
 		ServicePattern: Pattern{},
 	}
 
@@ -128,7 +128,7 @@ func Test_RemoveEnvVar_success1(t *testing.T) {
 	e2 := "c=d"
 	e3 := "e=f"
 
-	eList := []string{e1,e2,e3}
+	eList := []string{e1, e2, e3}
 
 	removeDuplicateVariable(&eList, "c=5")
 	if eList[0] != e1 && eList[1] != e3 {
@@ -143,7 +143,7 @@ func Test_RemoveEnvVar_success2(t *testing.T) {
 	e2 := "c=d"
 	e3 := "e=f"
 
-	eList := []string{e1,e2,e3}
+	eList := []string{e1, e2, e3}
 
 	removeDuplicateVariable(&eList, "a=2")
 	if eList[0] != e2 && eList[1] != e3 {
@@ -158,7 +158,7 @@ func Test_RemoveEnvVar_success3(t *testing.T) {
 	e2 := "c=d"
 	e3 := "e=f"
 
-	eList := []string{e1,e2,e3}
+	eList := []string{e1, e2, e3}
 
 	removeDuplicateVariable(&eList, "e=11")
 	if eList[0] != e1 && eList[1] != e2 {
@@ -173,7 +173,7 @@ func Test_RemoveEnvVar_nothing1(t *testing.T) {
 	e2 := "c=d"
 	e3 := "e=f"
 
-	eList := []string{e1,e2,e3}
+	eList := []string{e1, e2, e3}
 
 	removeDuplicateVariable(&eList, "b=3")
 	if eList[0] != e1 && eList[1] != e2 && eList[2] != e3 {
@@ -199,7 +199,7 @@ func Test_RemoveEnvVar_nothing3(t *testing.T) {
 	e2 := "c=d"
 	e3 := "e=f"
 
-	eList := []string{e1,e2,e3}
+	eList := []string{e1, e2, e3}
 
 	removeDuplicateVariable(&eList, "ab=3")
 	if eList[0] != e1 && eList[1] != e2 && eList[2] != e3 {

--- a/ethblockchain/connection.go
+++ b/ethblockchain/connection.go
@@ -1,84 +1,82 @@
 package ethblockchain
 
 import (
-    "github.com/golang/glog"
-    "net/url"
-    "regexp"
-    "strconv"
-    "strings"
+	"github.com/golang/glog"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
 type RPC_Connection struct {
-    host                  string
-    port                  int
-    fullURL               string
+	host    string
+	port    int
+	fullURL string
 }
 
 func RPC_Connection_Factory(host string, port int, fullURL string) *RPC_Connection {
-    if len(fullURL) != 0 {
-        if parsed_url,err := url.Parse(fullURL); err != nil {
-            glog.Errorf("Input URL %v is not parseable: %v", fullURL, err)
-            return nil
-        } else if len(parsed_url.Host) == 0 || len(parsed_url.Scheme) == 0 {
-            glog.Errorf("Input URL %v is not parseable, host or scheme is empty", fullURL)
-            return nil
-        } else if parsed_url.Scheme != "http" {
-            glog.Errorf("Input URL %v is not parseable, scheme is not http", fullURL)
-            return nil
-        } else {
+	if len(fullURL) != 0 {
+		if parsed_url, err := url.Parse(fullURL); err != nil {
+			glog.Errorf("Input URL %v is not parseable: %v", fullURL, err)
+			return nil
+		} else if len(parsed_url.Host) == 0 || len(parsed_url.Scheme) == 0 {
+			glog.Errorf("Input URL %v is not parseable, host or scheme is empty", fullURL)
+			return nil
+		} else if parsed_url.Scheme != "http" {
+			glog.Errorf("Input URL %v is not parseable, scheme is not http", fullURL)
+			return nil
+		} else {
 
-            err := error(nil)
-            parsed_host := parsed_url.Host
-            parsed_port := 0
-            if strings.Contains(parsed_host, ":") {
-                parsed_host = parsed_url.Host[:strings.Index(parsed_url.Host,":")]
-                if parsed_port,err = strconv.Atoi(parsed_url.Host[strings.Index(parsed_url.Host,":")+1:]); err != nil {
-                    glog.Errorf("Unable to convert port in input URL %v to an integer: %v", fullURL, err)
-                    return nil
-                }
-            }
+			err := error(nil)
+			parsed_host := parsed_url.Host
+			parsed_port := 0
+			if strings.Contains(parsed_host, ":") {
+				parsed_host = parsed_url.Host[:strings.Index(parsed_url.Host, ":")]
+				if parsed_port, err = strconv.Atoi(parsed_url.Host[strings.Index(parsed_url.Host, ":")+1:]); err != nil {
+					glog.Errorf("Unable to convert port in input URL %v to an integer: %v", fullURL, err)
+					return nil
+				}
+			}
 
-            if !validHostName(parsed_host) {
-                glog.Errorf("Input URL %v is not parseable, host name is not valid", fullURL)
-                return nil
-            }
-            return &RPC_Connection{
-                        host: parsed_host,
-                        port: parsed_port,
-                        fullURL: fullURL,
-                    }
-        }
+			if !validHostName(parsed_host) {
+				glog.Errorf("Input URL %v is not parseable, host name is not valid", fullURL)
+				return nil
+			}
+			return &RPC_Connection{
+				host:    parsed_host,
+				port:    parsed_port,
+				fullURL: fullURL,
+			}
+		}
 
-    } else if len(host) == 0 || port == 0 {
-        glog.Errorf("Input host %v is empty or port %v is zero.", host, port)
-        return nil
-    } else if !validHostName(host) {
-        glog.Errorf("Input host %v is not parseable, host name is not valid", host)
-        return nil
-    } else {
-        construct_URL := "http://"+host+":"+strconv.Itoa(port)
-        return &RPC_Connection{
-                        host: host,
-                        port: port,
-                        fullURL: construct_URL,
-                    }
-    }
+	} else if len(host) == 0 || port == 0 {
+		glog.Errorf("Input host %v is empty or port %v is zero.", host, port)
+		return nil
+	} else if !validHostName(host) {
+		glog.Errorf("Input host %v is not parseable, host name is not valid", host)
+		return nil
+	} else {
+		construct_URL := "http://" + host + ":" + strconv.Itoa(port)
+		return &RPC_Connection{
+			host:    host,
+			port:    port,
+			fullURL: construct_URL,
+		}
+	}
 }
 
 func (self *RPC_Connection) Get_fullURL() string {
-    return self.fullURL
+	return self.fullURL
 }
-
 
 // ================ Utility functions =======================================================
 
 func validHostName(host string) bool {
-    host_regex := `^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`
-    if rx,err := regexp.Compile(host_regex); err != nil {
-        glog.Errorf("Unable to compile hostname regex: %v", err)
-        return false
-    } else {
-        return rx.Match([]byte(host))
-    }
+	host_regex := `^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`
+	if rx, err := regexp.Compile(host_regex); err != nil {
+		glog.Errorf("Unable to compile hostname regex: %v", err)
+		return false
+	} else {
+		return rx.Match([]byte(host))
+	}
 }
-

--- a/ethblockchain/connection_test.go
+++ b/ethblockchain/connection_test.go
@@ -1,46 +1,46 @@
 package ethblockchain
 
 import (
-    // "fmt"
-    "testing"
-    )
+	// "fmt"
+	"testing"
+)
 
 func TestConstructor(t *testing.T) {
-    if c := RPC_Connection_Factory("localhost",8545,""); c == nil {
-        t.Errorf("Factory returned nil, but should not.\n")
-    } else if c.Get_fullURL() != "http://localhost:8545" {
-        t.Errorf("Factory did not correctly construct URL, returned %v\n",c.Get_fullURL())
-    } else if c := RPC_Connection_Factory("",0,"http://localhost:8545"); c == nil {
-        t.Errorf("Factory returned nil, but should not.\n")
-    } else if c.Get_fullURL() != "http://localhost:8545" {
-        t.Errorf("Factory did not correctly construct URL, returned %v\n",c.Get_fullURL())
-    }
+	if c := RPC_Connection_Factory("localhost", 8545, ""); c == nil {
+		t.Errorf("Factory returned nil, but should not.\n")
+	} else if c.Get_fullURL() != "http://localhost:8545" {
+		t.Errorf("Factory did not correctly construct URL, returned %v\n", c.Get_fullURL())
+	} else if c := RPC_Connection_Factory("", 0, "http://localhost:8545"); c == nil {
+		t.Errorf("Factory returned nil, but should not.\n")
+	} else if c.Get_fullURL() != "http://localhost:8545" {
+		t.Errorf("Factory did not correctly construct URL, returned %v\n", c.Get_fullURL())
+	}
 }
 
 func TestBadURLConstructor(t *testing.T) {
-    if c := RPC_Connection_Factory("",0,"blah blah"); c != nil {
-        t.Errorf("Factory should have returned nil, but did not.\n")
-    } else if c := RPC_Connection_Factory("",0,"other://host:1234"); c != nil {
-        t.Errorf("Factory should have returned nil, but did not.\n")
-    } else if c := RPC_Connection_Factory("",0,"host:1234"); c != nil {
-        t.Errorf("Factory should have returned nil, but did not.\n")
-    } else if c := RPC_Connection_Factory("",0,"://host:1234"); c != nil {
-        t.Errorf("Factory should have returned nil, but did not.\n")
-    } else if c := RPC_Connection_Factory("",0,"//host:1234"); c != nil {
-        t.Errorf("Factory should have returned nil, but did not.\n")
-    } else if c := RPC_Connection_Factory("",0,"http://local_host:1234"); c != nil {
-        t.Errorf("Factory should have returned nil, but did not.\n")
-    } else if c := RPC_Connection_Factory("",0,"http://host:host"); c != nil {
-        t.Errorf("Factory should have returned nil, but did not.\n")
-    }
+	if c := RPC_Connection_Factory("", 0, "blah blah"); c != nil {
+		t.Errorf("Factory should have returned nil, but did not.\n")
+	} else if c := RPC_Connection_Factory("", 0, "other://host:1234"); c != nil {
+		t.Errorf("Factory should have returned nil, but did not.\n")
+	} else if c := RPC_Connection_Factory("", 0, "host:1234"); c != nil {
+		t.Errorf("Factory should have returned nil, but did not.\n")
+	} else if c := RPC_Connection_Factory("", 0, "://host:1234"); c != nil {
+		t.Errorf("Factory should have returned nil, but did not.\n")
+	} else if c := RPC_Connection_Factory("", 0, "//host:1234"); c != nil {
+		t.Errorf("Factory should have returned nil, but did not.\n")
+	} else if c := RPC_Connection_Factory("", 0, "http://local_host:1234"); c != nil {
+		t.Errorf("Factory should have returned nil, but did not.\n")
+	} else if c := RPC_Connection_Factory("", 0, "http://host:host"); c != nil {
+		t.Errorf("Factory should have returned nil, but did not.\n")
+	}
 }
 
 func TestBadConstructor(t *testing.T) {
-    if c := RPC_Connection_Factory("",0,""); c != nil {
-        t.Errorf("Factory should have returned nil, but did not.\n")
-    } else if c := RPC_Connection_Factory("local_host",0,""); c != nil {
-        t.Errorf("Factory should have returned nil, but did not.\n")
-    } else if c := RPC_Connection_Factory("local_host",1,""); c != nil {
-        t.Errorf("Factory should have returned nil, but did not.\n")
-    }
+	if c := RPC_Connection_Factory("", 0, ""); c != nil {
+		t.Errorf("Factory should have returned nil, but did not.\n")
+	} else if c := RPC_Connection_Factory("local_host", 0, ""); c != nil {
+		t.Errorf("Factory should have returned nil, but did not.\n")
+	} else if c := RPC_Connection_Factory("local_host", 1, ""); c != nil {
+		t.Errorf("Factory should have returned nil, but did not.\n")
+	}
 }

--- a/ethblockchain/event_log.go
+++ b/ethblockchain/event_log.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/golang/glog"
+	"github.com/open-horizon/anax/config"
 	"os"
 	"reflect"
 	"strconv"
@@ -83,7 +84,7 @@ func (self *Event_Log) Get_current_stable_block() string {
 }
 
 // A factory function used to create Event_Log instances
-func Event_Log_Factory(rpcClient *RPC_Client, contractAddress string) *Event_Log {
+func Event_Log_Factory(httpClientFactory *config.HTTPClientFactory, rpcClient *RPC_Client, contractAddress string) *Event_Log {
 
 	var err error
 
@@ -97,7 +98,7 @@ func Event_Log_Factory(rpcClient *RPC_Client, contractAddress string) *Event_Log
 
 	rpcc := rpcClient
 	if rpcc == nil {
-		if rpcc = getRPCClient(); rpcc == nil {
+		if rpcc = getRPCClient(httpClientFactory); rpcc == nil {
 			return nil
 		}
 	}
@@ -290,13 +291,13 @@ func (self *Event_Log) remove_Filter() error {
 	}
 }
 
-func getRPCClient() *RPC_Client {
+func getRPCClient(httpClientFactory *config.HTTPClientFactory) *RPC_Client {
 	var rpcc *RPC_Client
 
 	if con := RPC_Connection_Factory("", 0, "http://localhost:8545"); con == nil {
 		glog.Errorf("RPC Connection not created")
 		return nil
-	} else if rpcc = RPC_Client_Factory(con); rpcc == nil {
+	} else if rpcc = RPC_Client_Factory(httpClientFactory, con); rpcc == nil {
 		glog.Errorf("RPC Client not created")
 		return nil
 	}

--- a/ethblockchain/event_log.go
+++ b/ethblockchain/event_log.go
@@ -1,47 +1,47 @@
 package ethblockchain
 
 import (
-    "encoding/json"
-    "errors"
-    "fmt"
-    "github.com/golang/glog"
-    "os"
-    "reflect"
-    "strconv"
-    "strings"
-    "sync"
-    "time"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/golang/glog"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 )
 
 type Event_Log struct {
-    client              *RPC_Client
-    filterId            string
-    contractAddress     string
-    formatter           func(*Raw_Event)string
-    processor           func(*Event_Log, *Raw_Event, interface{})
-    processorContext    interface{}
-    batchStart          uint64
-    batchEnd            uint64
-    batchSize           uint64
-    anyEvents           bool
+	client           *RPC_Client
+	filterId         string
+	contractAddress  string
+	formatter        func(*Raw_Event) string
+	processor        func(*Event_Log, *Raw_Event, interface{})
+	processorContext interface{}
+	batchStart       uint64
+	batchEnd         uint64
+	batchSize        uint64
+	anyEvents        bool
 }
 
 type Raw_Event struct {
-    LogIndex         string   `json:"logIndex"`
-    TransactionHash  string   `json:"transactionHash"`
-    TransactionIndex string   `json:"transactionIndex"`
-    BlockNumber      string   `json:"blockNumber"`
-    BlockHash        string   `json:"blockHash"`
-    Address          string   `json:"address"`
-    Data             string   `json:"data"`
-    Topics           []string `json:"topics"`
+	LogIndex         string   `json:"logIndex"`
+	TransactionHash  string   `json:"transactionHash"`
+	TransactionIndex string   `json:"transactionIndex"`
+	BlockNumber      string   `json:"blockNumber"`
+	BlockHash        string   `json:"blockHash"`
+	Address          string   `json:"address"`
+	Data             string   `json:"data"`
+	Topics           []string `json:"topics"`
 }
 
 // === global state used to detect when we havent seen a block in a while ===
 type blockSync struct {
-    lastBlockTime  int64    // The unix time in seconds when blockNumber was last updated
-    blockNumber    string   // The last block that was seen, top of the chain
-    blockStable    uint64   // The last block that can be read from
+	lastBlockTime int64  // The unix time in seconds when blockNumber was last updated
+	blockNumber   string // The last block that was seen, top of the chain
+	blockStable   uint64 // The last block that can be read from
 }
 
 var global_block_state_lock sync.Mutex
@@ -51,268 +51,264 @@ var block_read_delay int
 var block_update_delay int
 
 func update_block(blockNumber uint64) {
-    global_block_state_lock.Lock()
-    defer global_block_state_lock.Unlock()
+	global_block_state_lock.Lock()
+	defer global_block_state_lock.Unlock()
 
-    newBlock := fmt.Sprintf("0x%x", blockNumber)
-    if global_block_state.blockNumber == "" || newBlock != global_block_state.blockNumber {
-        global_block_state.lastBlockTime = time.Now().Unix()
-        global_block_state.blockNumber = newBlock
-        global_block_state.blockStable = blockNumber - uint64(block_read_delay)
-    }
+	newBlock := fmt.Sprintf("0x%x", blockNumber)
+	if global_block_state.blockNumber == "" || newBlock != global_block_state.blockNumber {
+		global_block_state.lastBlockTime = time.Now().Unix()
+		global_block_state.blockNumber = newBlock
+		global_block_state.blockStable = blockNumber - uint64(block_read_delay)
+	}
 }
 
 func (self *Event_Log) get_stable_block() uint64 {
-    delta := time.Now().Unix()-global_block_state.lastBlockTime
-    if int(delta) >= block_update_delay {
-        if block, err := self.client.Get_block_number(); err != nil {
-            glog.Errorf("Error getting current block: %v", err)
-        } else {
-            update_block(block)
-        }
-    }
+	delta := time.Now().Unix() - global_block_state.lastBlockTime
+	if int(delta) >= block_update_delay {
+		if block, err := self.client.Get_block_number(); err != nil {
+			glog.Errorf("Error getting current block: %v", err)
+		} else {
+			update_block(block)
+		}
+	}
 
-    return global_block_state.blockStable
+	return global_block_state.blockStable
 }
 
 func (self *Event_Log) Get_current_stable_block() string {
-    global_block_state_lock.Lock()
-    defer global_block_state_lock.Unlock()
-    res := fmt.Sprintf("0x%x", global_block_state.blockStable)
-    return res
+	global_block_state_lock.Lock()
+	defer global_block_state_lock.Unlock()
+	res := fmt.Sprintf("0x%x", global_block_state.blockStable)
+	return res
 }
 
 // A factory function used to create Event_Log instances
 func Event_Log_Factory(rpcClient *RPC_Client, contractAddress string) *Event_Log {
 
-    var err error
+	var err error
 
-    if block_read_delay, err = strconv.Atoi(os.Getenv("mtn_soliditycontract_block_read_delay")); err != nil {
-        block_read_delay = 0
-    }
+	if block_read_delay, err = strconv.Atoi(os.Getenv("mtn_soliditycontract_block_read_delay")); err != nil {
+		block_read_delay = 0
+	}
 
-    if block_update_delay, err = strconv.Atoi(os.Getenv("mtn_soliditycontract_block_update_delay")); err != nil {
-        block_update_delay = 10
-    }
+	if block_update_delay, err = strconv.Atoi(os.Getenv("mtn_soliditycontract_block_update_delay")); err != nil {
+		block_update_delay = 10
+	}
 
-    rpcc := rpcClient
-    if rpcc == nil {
-        if rpcc = getRPCClient(); rpcc == nil {
-            return nil
-        }
-    }
+	rpcc := rpcClient
+	if rpcc == nil {
+		if rpcc = getRPCClient(); rpcc == nil {
+			return nil
+		}
+	}
 
-    if len(contractAddress) == 0 {
-        glog.Errorf("Input contract address is empty")
-        return nil
-    } else {
-        el := &Event_Log{
-                    client:          rpcc,
-                    filterId:        "",
-                    contractAddress: contractAddress,
-                }
-        return el
-    }
+	if len(contractAddress) == 0 {
+		glog.Errorf("Input contract address is empty")
+		return nil
+	} else {
+		el := &Event_Log{
+			client:          rpcc,
+			filterId:        "",
+			contractAddress: contractAddress,
+		}
+		return el
+	}
 }
 
 func (self *Event_Log) Set_formatter(f func(*Raw_Event) string) {
-    self.formatter = f
+	self.formatter = f
 }
 
 func (self *Event_Log) Set_processor(p func(*Event_Log, *Raw_Event, interface{}), c interface{}) {
-    self.processor = p
-    self.processorContext = c
+	self.processor = p
+	self.processorContext = c
 }
-
 
 func (self *Event_Log) Get_Raw_Event_Batch(topics []interface{}, size uint64) ([]Raw_Event, error) {
 
-    self.batchStart = 1
-    if bs, err := strconv.Atoi(os.Getenv("bh_event_log_start")); err == nil {
-        self.batchStart = uint64(bs)
-    }
-    self.batchSize = size
+	self.batchStart = 1
+	if bs, err := strconv.Atoi(os.Getenv("bh_event_log_start")); err == nil {
+		self.batchStart = uint64(bs)
+	}
+	self.batchSize = size
 
-    lastBlock := self.get_stable_block()
+	lastBlock := self.get_stable_block()
 
-    if size == 0 {
-        self.batchEnd = lastBlock
-    } else if lastBlock < (self.batchStart + size - 1) {
-        self.batchEnd = lastBlock
-    } else {
-        self.batchEnd = self.batchStart + size -1
-    }
+	if size == 0 {
+		self.batchEnd = lastBlock
+	} else if lastBlock < (self.batchStart + size - 1) {
+		self.batchEnd = lastBlock
+	} else {
+		self.batchEnd = self.batchStart + size - 1
+	}
 
-    if self.batchEnd < self.batchStart {
-        self.batchEnd = self.batchStart
-    }
+	if self.batchEnd < self.batchStart {
+		self.batchEnd = self.batchStart
+	}
 
-    return self.get_raw_events_in_range(topics, self.batchStart, self.batchEnd)
+	return self.get_raw_events_in_range(topics, self.batchStart, self.batchEnd)
 }
 
 func (self *Event_Log) Get_Next_Raw_Event_Batch(topics []interface{}, size uint64) ([]Raw_Event, bool, error) {
-    reachedEnd := false
+	reachedEnd := false
 
-    events := make([]Raw_Event,0,10)
-    if self.batchEnd == 0 {
-        glog.Warningf("For %v previous batch included the latest blocks.", self.contractAddress)
-        return events, true, nil
-    }
+	events := make([]Raw_Event, 0, 10)
+	if self.batchEnd == 0 {
+		glog.Warningf("For %v previous batch included the latest blocks.", self.contractAddress)
+		return events, true, nil
+	}
 
-    if err := self.remove_Filter(); err != nil {
-        glog.Errorf("For %v could not remove filter: %v", self.contractAddress, err)
-    }
+	if err := self.remove_Filter(); err != nil {
+		glog.Errorf("For %v could not remove filter: %v", self.contractAddress, err)
+	}
 
-    lastBlock := self.get_stable_block()
+	lastBlock := self.get_stable_block()
 
-    start := self.batchEnd + 1
-    end := start + size - 1
-    if lastBlock <= start {
-        return events, true, nil
-    } else if size == 0 {
-        end = lastBlock
-        reachedEnd = true
-    } else if lastBlock < (start + size - 1) {
-        end = lastBlock
-        reachedEnd = true
-    }
+	start := self.batchEnd + 1
+	end := start + size - 1
+	if lastBlock <= start {
+		return events, true, nil
+	} else if size == 0 {
+		end = lastBlock
+		reachedEnd = true
+	} else if lastBlock < (start + size - 1) {
+		end = lastBlock
+		reachedEnd = true
+	}
 
-    if end < start {
-        end = start
-        reachedEnd = true
-    }
+	if end < start {
+		end = start
+		reachedEnd = true
+	}
 
-    if events, err := self.get_raw_events_in_range(topics, start, end); err != nil {
-        return events, true, err
-    } else {
-        self.batchStart = start
-        self.batchSize = size
-        self.batchEnd = end
-        return events, reachedEnd, nil
-    }
+	if events, err := self.get_raw_events_in_range(topics, start, end); err != nil {
+		return events, true, err
+	} else {
+		self.batchStart = start
+		self.batchSize = size
+		self.batchEnd = end
+		return events, reachedEnd, nil
+	}
 
 }
 
 func (self *Event_Log) get_raw_events_in_range(topics []interface{}, start uint64, end uint64) ([]Raw_Event, error) {
-    events := make([]Raw_Event,0,10)
+	events := make([]Raw_Event, 0, 10)
 
-    glog.V(3).Infof("EventLog looking for events from %v to %v", start, end)
-    if err := self.establish_Filter(start, end, topics); err != nil {
-        glog.Errorf("For %v could not establish filter: %v", self.contractAddress, err)
-        return events, err
-    }
+	glog.V(3).Infof("EventLog looking for events from %v to %v", start, end)
+	if err := self.establish_Filter(start, end, topics); err != nil {
+		glog.Errorf("For %v could not establish filter: %v", self.contractAddress, err)
+		return events, err
+	}
 
-    rpcEventResp := rpcGetEventsResponse{}
+	rpcEventResp := rpcGetEventsResponse{}
 
-    glog.V(5).Infof("Filter %v for %v using client %v ", self.filterId, self.contractAddress, self.client)
-    if out, err := self.client.Invoke("eth_getFilterLogs", self.filterId); err != nil {
-        glog.Errorf("Error occurred getting events for contract %v, error: %v", self.contractAddress , err)
-        return events, errors.New(err.Msg)
-    } else if err := json.Unmarshal([]byte(out), &rpcEventResp); err != nil {
-        glog.Errorf("Error occurred umarshalling getFilterLogs for %v, response: %v", self.contractAddress, err)
-        return events, err
-    } else if rpcEventResp.Error.Message != "" {
-        glog.Errorf("For %v eth_getFilterLogs returned an error: %v", self.contractAddress, rpcEventResp.Error.Message)
-        return events, err
-    } else {
-        events = rpcEventResp.Result
-        if len(events) != 0 {
-            self.anyEvents = true
-        }
-    }
+	glog.V(5).Infof("Filter %v for %v using client %v ", self.filterId, self.contractAddress, self.client)
+	if out, err := self.client.Invoke("eth_getFilterLogs", self.filterId); err != nil {
+		glog.Errorf("Error occurred getting events for contract %v, error: %v", self.contractAddress, err)
+		return events, errors.New(err.Msg)
+	} else if err := json.Unmarshal([]byte(out), &rpcEventResp); err != nil {
+		glog.Errorf("Error occurred umarshalling getFilterLogs for %v, response: %v", self.contractAddress, err)
+		return events, err
+	} else if rpcEventResp.Error.Message != "" {
+		glog.Errorf("For %v eth_getFilterLogs returned an error: %v", self.contractAddress, rpcEventResp.Error.Message)
+		return events, err
+	} else {
+		events = rpcEventResp.Result
+		if len(events) != 0 {
+			self.anyEvents = true
+		}
+	}
 
-    return events, nil
+	return events, nil
 }
 
 func (self *Event_Log) clear_Filter() {
-    self.filterId = ""
+	self.filterId = ""
 }
 
 func (self *Event_Log) establish_Filter(startBlock uint64, endBlock uint64, topics []interface{}) error {
-    if self.filterId == "" {
-        rpcResp := RPC_Response{}
-        params := make(map[string]interface{})
-        params["address"] = self.contractAddress
-        params["fromBlock"] = fmt.Sprintf("0x%x", startBlock)
-        if endBlock != 0 {
-            params["toBlock"] = fmt.Sprintf("0x%x", endBlock)
-        } else {
-            params["toBlock"] = "latest"
-        }
-        theTopics := topics
+	if self.filterId == "" {
+		rpcResp := RPC_Response{}
+		params := make(map[string]interface{})
+		params["address"] = self.contractAddress
+		params["fromBlock"] = fmt.Sprintf("0x%x", startBlock)
+		if endBlock != 0 {
+			params["toBlock"] = fmt.Sprintf("0x%x", endBlock)
+		} else {
+			params["toBlock"] = "latest"
+		}
+		theTopics := topics
 
-        for ix, val := range theTopics {
-            switch val.(type) {
-                case string:
-                    v := val.(string)
-                    if len(v) < 66 && !strings.HasPrefix(v, "0x") {
-                        v = "0x" + v
-                    }
-                    if len(v) < 66 {
-                        v = v[:2] + strings.Repeat("0", 66-len(v)) + v[2:]
-                    }
-                    theTopics[ix] = v
-                case nil:
-                default:
-                    return errors.New(fmt.Sprintf("Cannot establish filter, topics must be string or nil, type was %v", reflect.TypeOf(val).String()))
-            }
-        }
-        params["topics"] = theTopics
-        glog.V(5).Infof("For %v creating event filter with params: %v", self.contractAddress, params)
+		for ix, val := range theTopics {
+			switch val.(type) {
+			case string:
+				v := val.(string)
+				if len(v) < 66 && !strings.HasPrefix(v, "0x") {
+					v = "0x" + v
+				}
+				if len(v) < 66 {
+					v = v[:2] + strings.Repeat("0", 66-len(v)) + v[2:]
+				}
+				theTopics[ix] = v
+			case nil:
+			default:
+				return errors.New(fmt.Sprintf("Cannot establish filter, topics must be string or nil, type was %v", reflect.TypeOf(val).String()))
+			}
+		}
+		params["topics"] = theTopics
+		glog.V(5).Infof("For %v creating event filter with params: %v", self.contractAddress, params)
 
-        if out,err := self.client.Invoke("eth_newFilter",params); err != nil {
-            return errors.New(err.Msg)
-        } else if err := json.Unmarshal([]byte(out), &rpcResp); err != nil {
-            return err
-        } else if rpcResp.Error.Message != "" {
-            return errors.New(fmt.Sprintf("Creating event filter returned an error: %v.", rpcResp.Error.Message))
-        } else {
-            self.filterId = rpcResp.Result.(string)
-        }
-    }
-    return nil
+		if out, err := self.client.Invoke("eth_newFilter", params); err != nil {
+			return errors.New(err.Msg)
+		} else if err := json.Unmarshal([]byte(out), &rpcResp); err != nil {
+			return err
+		} else if rpcResp.Error.Message != "" {
+			return errors.New(fmt.Sprintf("Creating event filter returned an error: %v.", rpcResp.Error.Message))
+		} else {
+			self.filterId = rpcResp.Result.(string)
+		}
+	}
+	return nil
 }
 
 func (self *Event_Log) remove_Filter() error {
-    if self.filterId != "" {
-        rpcResp := RPC_Response{}
-        if out,err := self.client.Invoke("eth_uninstallFilter", self.filterId); err != nil {
-            return errors.New(err.Msg)
-        } else if err := json.Unmarshal([]byte(out), &rpcResp); err != nil {
-            return err
-        } else if rpcResp.Error.Message != "" {
-            return errors.New(fmt.Sprintf("Removing event filter returned an error: %v.", rpcResp.Error.Message))
-        } else {
-            self.clear_Filter()
-            return nil
-        }
-    } else {
-        return nil
-    }
+	if self.filterId != "" {
+		rpcResp := RPC_Response{}
+		if out, err := self.client.Invoke("eth_uninstallFilter", self.filterId); err != nil {
+			return errors.New(err.Msg)
+		} else if err := json.Unmarshal([]byte(out), &rpcResp); err != nil {
+			return err
+		} else if rpcResp.Error.Message != "" {
+			return errors.New(fmt.Sprintf("Removing event filter returned an error: %v.", rpcResp.Error.Message))
+		} else {
+			self.clear_Filter()
+			return nil
+		}
+	} else {
+		return nil
+	}
 }
 
 func getRPCClient() *RPC_Client {
-    var rpcc *RPC_Client
+	var rpcc *RPC_Client
 
-    if con := RPC_Connection_Factory("", 0, "http://localhost:8545"); con == nil {
-        glog.Errorf("RPC Connection not created")
-        return nil
-    } else if rpcc = RPC_Client_Factory(con); rpcc == nil {
-        glog.Errorf("RPC Client not created")
-        return nil
-    }
-    return rpcc
+	if con := RPC_Connection_Factory("", 0, "http://localhost:8545"); con == nil {
+		glog.Errorf("RPC Connection not created")
+		return nil
+	} else if rpcc = RPC_Client_Factory(con); rpcc == nil {
+		glog.Errorf("RPC Client not created")
+		return nil
+	}
+	return rpcc
 }
-
 
 type rpcGetEventsResponse struct {
-    Id      string             `json:"id"`
-    Version string             `json:"jsonrpc"`
-    Result  []Raw_Event        `json:"result"`
-    Error   struct {
-        Code    int    `json:"code"`
-        Message string `json:"message"`
-    } `json:"error"`
+	Id      string      `json:"id"`
+	Version string      `json:"jsonrpc"`
+	Result  []Raw_Event `json:"result"`
+	Error   struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
 }
-
-

--- a/ethblockchain/event_log_test.go
+++ b/ethblockchain/event_log_test.go
@@ -5,8 +5,7 @@ import (
 )
 
 func TestClientConstructor(t *testing.T) {
-    if event_log := Event_Log_Factory(nil,"0x0123456789012345678901234567890123456789"); event_log == nil {
-        t.Errorf("Factory returned nil, but should not.\n")
-    }
+	if event_log := Event_Log_Factory(nil, "0x0123456789012345678901234567890123456789"); event_log == nil {
+		t.Errorf("Factory returned nil, but should not.\n")
+	}
 }
-

--- a/ethblockchain/event_log_test.go
+++ b/ethblockchain/event_log_test.go
@@ -1,11 +1,21 @@
 package ethblockchain
 
 import (
+	"github.com/open-horizon/anax/config"
 	"testing"
 )
 
+func httpClientFactory(t *testing.T) *config.HTTPClientFactory {
+	collab, err := config.NewCollaborators(config.HorizonConfig{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	return collab.HTTPClientFactory
+}
+
 func TestClientConstructor(t *testing.T) {
-	if event_log := Event_Log_Factory(nil, "0x0123456789012345678901234567890123456789"); event_log == nil {
+	if event_log := Event_Log_Factory(httpClientFactory(t), nil, "0x0123456789012345678901234567890123456789"); event_log == nil {
 		t.Errorf("Factory returned nil, but should not.\n")
 	}
 }

--- a/ethblockchain/rpc.go
+++ b/ethblockchain/rpc.go
@@ -1,182 +1,179 @@
 package ethblockchain
 
 import (
-    "bytes"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "github.com/golang/glog"
-    "github.com/open-horizon/anax/config"
-    "io/ioutil"
-    "math/big"
-    "net/http"
-    "os"
-    "strconv"
-    "time"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/open-horizon/anax/config"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
 )
 
 type RPC_Client struct {
-    connection *RPC_Connection
-    body       map[string]interface{}
-    httpClient * http.Client
+	connection *RPC_Connection
+	body       map[string]interface{}
+	httpClient *http.Client
 }
 
 func RPC_Client_Factory(connection *RPC_Connection) *RPC_Client {
-    if connection == nil {
-        glog.Errorf("Input connection is nil")
-        return nil
-    } else {
-        rpcc := &RPC_Client{
-                    connection: connection,
-                    body:       make(map[string]interface{}),
-                }
-        rpcc.body["jsonrpc"] = "2.0"
-        rpcc.body["id"] = "1"
+	if connection == nil {
+		glog.Errorf("Input connection is nil")
+		return nil
+	} else {
+		rpcc := &RPC_Client{
+			connection: connection,
+			body:       make(map[string]interface{}),
+		}
+		rpcc.body["jsonrpc"] = "2.0"
+		rpcc.body["id"] = "1"
 
-        var rpc_timeout time.Duration
-        if rpc_t, err := strconv.Atoi(os.Getenv("bh_rpc_timeout")); err != nil || rpc_t == 0 {
-            rpc_timeout = time.Duration(config.HTTPDEFAULTTIMEOUT*time.Millisecond)
-        } else {
-            rpc_timeout = time.Duration(time.Duration(rpc_t)*time.Second)
-        }
+		var rpc_timeout time.Duration
+		if rpc_t, err := strconv.Atoi(os.Getenv("bh_rpc_timeout")); err != nil || rpc_t == 0 {
+			rpc_timeout = time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)
+		} else {
+			rpc_timeout = time.Duration(time.Duration(rpc_t) * time.Second)
+		}
 
-        rpcc.httpClient = &http.Client{
-            Timeout: time.Duration(rpc_timeout),
-        }
-        return rpcc
-    }
+		rpcc.httpClient = &http.Client{
+			Timeout: time.Duration(rpc_timeout),
+		}
+		return rpcc
+	}
 }
 
 func (self *RPC_Client) Get_connection() *RPC_Connection {
-    return self.connection
+	return self.connection
 }
 
-func (self *RPC_Client) Get_block_number() (uint64,error) {
+func (self *RPC_Client) Get_block_number() (uint64, error) {
 
-    if out,err := self.Invoke("eth_blockNumber",nil); err != nil {
-        return 0, errors.New(err.Msg)
-    } else if rpcResp, err := self.decodeResponse([]byte(out)); err != nil {
-        return 0, err
-    } else if block,err := strconv.ParseUint(rpcResp.Result.(string)[2:], 16, 64); err != nil {
-        return 0, err
-    } else {
-        return block, nil
-    }
+	if out, err := self.Invoke("eth_blockNumber", nil); err != nil {
+		return 0, errors.New(err.Msg)
+	} else if rpcResp, err := self.decodeResponse([]byte(out)); err != nil {
+		return 0, err
+	} else if block, err := strconv.ParseUint(rpcResp.Result.(string)[2:], 16, 64); err != nil {
+		return 0, err
+	} else {
+		return block, nil
+	}
 
-    return 0, nil
+	return 0, nil
 }
 
-func (self *RPC_Client) Get_balance(address string) (*big.Int,error) {
+func (self *RPC_Client) Get_balance(address string) (*big.Int, error) {
 
-    bal := big.NewInt(0)
-    p := make([]interface{},0,2)
-    p = append(p,address)
-    p = append(p,"latest")
+	bal := big.NewInt(0)
+	p := make([]interface{}, 0, 2)
+	p = append(p, address)
+	p = append(p, "latest")
 
-    if out,err := self.Invoke("eth_getBalance",p); err != nil {
-        return bal, errors.New(err.Msg)
-    } else if rpcResp, err := self.decodeResponse([]byte(out)); err != nil {
-        return bal, err
-    } else {
-        bal_hex_str := rpcResp.Result.(string)
-        // the math/big library doesn't like leading "0x" on hex strings
-        bal.SetString(bal_hex_str[2:],16)
-    }
+	if out, err := self.Invoke("eth_getBalance", p); err != nil {
+		return bal, errors.New(err.Msg)
+	} else if rpcResp, err := self.decodeResponse([]byte(out)); err != nil {
+		return bal, err
+	} else {
+		bal_hex_str := rpcResp.Result.(string)
+		// the math/big library doesn't like leading "0x" on hex strings
+		bal.SetString(bal_hex_str[2:], 16)
+	}
 
-    return bal,nil
+	return bal, nil
 }
 
-func (self *RPC_Client) Get_first_account() (string,error) {
+func (self *RPC_Client) Get_first_account() (string, error) {
 
-    if out,err := self.Invoke("eth_accounts",nil); err != nil {
-        return "", errors.New(err.Msg)
-    } else if rpcResp, err := self.decodeResponse([]byte(out)); err != nil {
-        return "", err
-    } else {
-        var resp []interface{}
-        resp = rpcResp.Result.([]interface{})
-        if len(resp) == 0 {
-            return "", errors.New("No accounts returned")
-        } else {
-            acct := resp[0].(string)
-            return acct, nil
-        }
-    }
+	if out, err := self.Invoke("eth_accounts", nil); err != nil {
+		return "", errors.New(err.Msg)
+	} else if rpcResp, err := self.decodeResponse([]byte(out)); err != nil {
+		return "", err
+	} else {
+		var resp []interface{}
+		resp = rpcResp.Result.([]interface{})
+		if len(resp) == 0 {
+			return "", errors.New("No accounts returned")
+		} else {
+			acct := resp[0].(string)
+			return acct, nil
+		}
+	}
 }
 
-func (self *RPC_Client) Invoke(method string, params interface{}) (string,*RPCError) {
+func (self *RPC_Client) Invoke(method string, params interface{}) (string, *RPCError) {
 
-    out := ""
-    var err *RPCError
+	out := ""
+	var err *RPCError
 
-    if len(method) == 0 {
-        err = &RPCError{fmt.Sprintf("RPC method name must be non-empty")}
-        glog.Errorf("Error: %v", err.Msg)
-        return out,err
-    }
+	if len(method) == 0 {
+		err = &RPCError{fmt.Sprintf("RPC method name must be non-empty")}
+		glog.Errorf("Error: %v", err.Msg)
+		return out, err
+	}
 
-    self.body["method"] = method
+	self.body["method"] = method
 
-    switch params.(type) {
-    case []interface{}:
-        self.body["params"] = params
-    default:
-        the_params := make([]interface{}, 0, 5)
-        self.body["params"] = append(the_params,params)
-    }
-    
-    glog.V(5).Infof("Invoking %v with %v", method, self.body)
+	switch params.(type) {
+	case []interface{}:
+		self.body["params"] = params
+	default:
+		the_params := make([]interface{}, 0, 5)
+		self.body["params"] = append(the_params, params)
+	}
 
-    if jsonBytes, e := json.Marshal(self.body); e != nil {
-        err = &RPCError{fmt.Sprintf("RPC invocation of %v failed creating JSON body %v, error: %v", method, self.body, e.Error())}
-    } else if req, e := http.NewRequest("POST", self.connection.Get_fullURL(), bytes.NewBuffer(jsonBytes)); e != nil {
-        err = &RPCError{fmt.Sprintf("RPC invocation of %v failed creating http request, error: %v", method, e.Error())}
-    } else {
-        req.Close = true            // work around to ensure that Go doesn't get connections confused. Supposed to be fixed in Go 1.6.
-        if resp, e := self.httpClient.Do(req); e != nil {
-            err = &RPCError{fmt.Sprintf("RPC http invocation of %v with %v returned error: %v", method, self.body, e.Error())}
-        } else {
-            defer resp.Body.Close()
-            if outBytes, e := ioutil.ReadAll(resp.Body); e != nil {
-                err = &RPCError{fmt.Sprintf("RPC invocation of %v failed reading response message, error: %v", method, outBytes, e.Error())}
-            } else {
-                out = string(outBytes)
-                glog.V(5).Infof("Response to %v is %v", self.body, out)
-            }
-        }
-    }
+	glog.V(5).Infof("Invoking %v with %v", method, self.body)
 
-    if err != nil {
-        glog.Errorf("Error: %v", err.Msg)
-    }
+	if jsonBytes, e := json.Marshal(self.body); e != nil {
+		err = &RPCError{fmt.Sprintf("RPC invocation of %v failed creating JSON body %v, error: %v", method, self.body, e.Error())}
+	} else if req, e := http.NewRequest("POST", self.connection.Get_fullURL(), bytes.NewBuffer(jsonBytes)); e != nil {
+		err = &RPCError{fmt.Sprintf("RPC invocation of %v failed creating http request, error: %v", method, e.Error())}
+	} else {
+		req.Close = true // work around to ensure that Go doesn't get connections confused. Supposed to be fixed in Go 1.6.
+		if resp, e := self.httpClient.Do(req); e != nil {
+			err = &RPCError{fmt.Sprintf("RPC http invocation of %v with %v returned error: %v", method, self.body, e.Error())}
+		} else {
+			defer resp.Body.Close()
+			if outBytes, e := ioutil.ReadAll(resp.Body); e != nil {
+				err = &RPCError{fmt.Sprintf("RPC invocation of %v failed reading response message, error: %v", method, outBytes, e.Error())}
+			} else {
+				out = string(outBytes)
+				glog.V(5).Infof("Response to %v is %v", self.body, out)
+			}
+		}
+	}
 
-    return out, err
+	if err != nil {
+		glog.Errorf("Error: %v", err.Msg)
+	}
+
+	return out, err
 }
 
-func (self *RPC_Client) decodeResponse(out []byte) (*RPC_Response,error) {
-    rpcResp := RPC_Response{}
-    if err := json.Unmarshal(out, &rpcResp); err != nil {
-        return nil, err
-    } else if rpcResp.Error.Message != "" {
-        return nil, errors.New(rpcResp.Error.Message)
-    } else {
-        return &rpcResp, nil
-    }
-} 
-
-
+func (self *RPC_Client) decodeResponse(out []byte) (*RPC_Response, error) {
+	rpcResp := RPC_Response{}
+	if err := json.Unmarshal(out, &rpcResp); err != nil {
+		return nil, err
+	} else if rpcResp.Error.Message != "" {
+		return nil, errors.New(rpcResp.Error.Message)
+	} else {
+		return &rpcResp, nil
+	}
+}
 
 type RPC_Response struct {
-    Id      string      `json:"id"`
-    Version string      `json:"jsonrpc"`
-    Result  interface{} `json:"result"`
-    Error   struct {
-        Code    int    `json:"code"`
-        Message string `json:"message"`
-    } `json:"error"`
+	Id      string      `json:"id"`
+	Version string      `json:"jsonrpc"`
+	Result  interface{} `json:"result"`
+	Error   struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
 }
 
 type RPCError struct {
-    Msg string
+	Msg string
 }
-

--- a/ethblockchain/rpc_test.go
+++ b/ethblockchain/rpc_test.go
@@ -1,13 +1,13 @@
 package ethblockchain
 
 import (
-	// "fmt"
 	"testing"
 )
 
 func TestClient_Constructor(t *testing.T) {
-	rpc_client := RPC_Connection_Factory("localhost", 8545, "")
-	if c := RPC_Client_Factory(rpc_client); c == nil {
+	rpcClient := RPC_Connection_Factory("localhost", 8545, "")
+
+	if c := RPC_Client_Factory(httpClientFactory(t), rpcClient); c == nil {
 		t.Errorf("Factory returned nil, but should not.\n")
 	} else if c.Get_connection().Get_fullURL() != "http://localhost:8545" {
 		t.Errorf("Factory returned a client that does not point to the right connection URL: %v\n", c.Get_connection().Get_fullURL())
@@ -15,7 +15,8 @@ func TestClient_Constructor(t *testing.T) {
 }
 
 func TestBadClientConstructor(t *testing.T) {
-	if c := RPC_Client_Factory(nil); c != nil {
+
+	if c := RPC_Client_Factory(httpClientFactory(t), nil); c != nil {
 		t.Errorf("Factory did not return nil, but should have.\n")
 	}
 }

--- a/ethblockchain/rpc_test.go
+++ b/ethblockchain/rpc_test.go
@@ -1,21 +1,21 @@
 package ethblockchain
 
 import (
-    // "fmt"
-    "testing"
-    )
+	// "fmt"
+	"testing"
+)
 
 func TestClient_Constructor(t *testing.T) {
-    rpc_client := RPC_Connection_Factory("localhost",8545,"")
-    if c := RPC_Client_Factory(rpc_client); c == nil {
-        t.Errorf("Factory returned nil, but should not.\n")
-    } else if c.Get_connection().Get_fullURL() != "http://localhost:8545" {
-        t.Errorf("Factory returned a client that does not point to the right connection URL: %v\n", c.Get_connection().Get_fullURL())
-    }
+	rpc_client := RPC_Connection_Factory("localhost", 8545, "")
+	if c := RPC_Client_Factory(rpc_client); c == nil {
+		t.Errorf("Factory returned nil, but should not.\n")
+	} else if c.Get_connection().Get_fullURL() != "http://localhost:8545" {
+		t.Errorf("Factory returned a client that does not point to the right connection URL: %v\n", c.Get_connection().Get_fullURL())
+	}
 }
 
 func TestBadClientConstructor(t *testing.T) {
-    if c := RPC_Client_Factory(nil); c != nil {
-        t.Errorf("Factory did not return nil, but should have.\n")
-    }
+	if c := RPC_Client_Factory(nil); c != nil {
+		t.Errorf("Factory did not return nil, but should have.\n")
+	}
 }

--- a/events/events.go
+++ b/events/events.go
@@ -87,9 +87,9 @@ type LaunchContext interface {
 }
 
 type MicroserviceSpec struct {
-	SpecRef  string
-	Version  string
-	MsdefId  string
+	SpecRef string
+	Version string
+	MsdefId string
 }
 
 type AgreementLaunchContext struct {

--- a/exchange/message_worker.go
+++ b/exchange/message_worker.go
@@ -45,7 +45,7 @@ func NewExchangeMessageWorker(cfg *config.HorizonConfig, db *bolt.DB) *ExchangeM
 			Commands: commands,
 		},
 		db:         db,
-		httpClient: &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT*time.Millisecond)},
+		httpClient: &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
 		id:         id,
 		token:      token,
 	}

--- a/exchange/message_worker.go
+++ b/exchange/message_worker.go
@@ -45,7 +45,7 @@ func NewExchangeMessageWorker(cfg *config.HorizonConfig, db *bolt.DB) *ExchangeM
 			Commands: commands,
 		},
 		db:         db,
-		httpClient: &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
+		httpClient: cfg.Collaborators.HTTPClientFactory.NewHTTPClient(nil),
 		id:         id,
 		token:      token,
 	}

--- a/exchange/messaging.go
+++ b/exchange/messaging.go
@@ -14,8 +14,8 @@ import (
 	"github.com/golang/glog"
 	"golang.org/x/crypto/sha3"
 	"io/ioutil"
-	"path"
 	"os"
+	"path"
 )
 
 // This module is used to construct a message that can be sent over an insecure transport
@@ -27,7 +27,7 @@ import (
 // Horizon Exchange Message Broker. The APIs in this module are used to create and deconstruct
 // ExchangeMessages.
 
-type EncryptedWrappedMessage  []byte
+type EncryptedWrappedMessage []byte
 type EncryptedSymmetricValues []byte
 
 type ExchangeMessage struct {
@@ -49,9 +49,9 @@ func (self ExchangeMessage) String() string {
 }
 
 type WrappedMessage struct {
-	Msg             []byte `json:"msg"`
-	Signature       []byte `json:"signature"`
-	SignerPubKey    []byte `json:"signerPubkey"`
+	Msg          []byte `json:"msg"`
+	Signature    []byte `json:"signature"`
+	SignerPubKey []byte `json:"signerPubkey"`
 }
 
 type SymmetricValues struct {
@@ -90,7 +90,7 @@ func ConstructExchangeMessage(message []byte, senderPublicKey *rsa.PublicKey, se
 
 	// 2. Sign the hash (digest).
 	// Signing the message gives the sender the assurance that its message cannot be altered
-	// by a third party. 
+	// by a third party.
 	var signature []byte
 	if signature, err = rsa.SignPSS(rand.Reader, senderPrivateKey, crypto.SHA3_256, digest[:], &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthAuto}); err != nil {
 		return nil, errors.New(fmt.Sprintf("Error signing the message, error: %v", err))
@@ -182,7 +182,7 @@ func ConstructExchangeMessage(message []byte, senderPublicKey *rsa.PublicKey, se
 }
 
 // Here is an overview of what happens in order to deconstruct a secure ExchangeMessage. To more deeply
-// understand message security implemented here, read the ConstructExchangeMessage function. The 
+// understand message security implemented here, read the ConstructExchangeMessage function. The
 // Deconstruct function is just the reverse operations. Here is the sequence:
 // 1. receive the encrypted WrappedMessage and SymmetricValues
 // 2. decrypt the symmetric values using the receiver's private key
@@ -380,7 +380,6 @@ func GetKeys(keyPath string) (*rsa.PublicKey, *rsa.PrivateKey, error) {
 		return gPublicKey, gPrivateKey, nil
 	}
 
-
 	privFileName := "privateMessagingKey.pem"
 	pubFileName := "publicMessagingKey.pem"
 
@@ -416,9 +415,9 @@ func GetKeys(keyPath string) (*rsa.PublicKey, *rsa.PrivateKey, error) {
 			}
 
 			privEnc := &pem.Block{
-					Type:    "RSA PRIVATE KEY",
-					Headers: nil,
-					Bytes:   x509.MarshalPKCS1PrivateKey(privateKey)}
+				Type:    "RSA PRIVATE KEY",
+				Headers: nil,
+				Bytes:   x509.MarshalPKCS1PrivateKey(privateKey)}
 			if err := pem.Encode(privFile, privEnc); err != nil {
 				return nil, nil, errors.New(fmt.Sprintf("Could not encode private key to file, error %v", err))
 			} else {

--- a/exchange/messaging_test.go
+++ b/exchange/messaging_test.go
@@ -982,7 +982,7 @@ func TestKeySaving_success1(t *testing.T) {
 		os.Remove("/tmp/publicMessagingKey.pem")
 	}
 
-	_ = os.Setenv("SNAP_COMMON","/tmp")
+	_ = os.Setenv("SNAP_COMMON", "/tmp")
 
 	// Test the initial start of a new anax
 	if priv, pub, err := GetKeys(""); err != nil {

--- a/exchange/rpc.go
+++ b/exchange/rpc.go
@@ -548,7 +548,6 @@ func (w *WorkloadDefinition) GetUserInputName(name string) *UserInput {
 	return nil
 }
 
-
 type GetWorkloadsResponse struct {
 	Workloads map[string]WorkloadDefinition `json:"workloads"`
 	LastIndex int                           `json:"lastIndex"`
@@ -751,7 +750,6 @@ func GetMicroservice(mURL string, mVersion string, mArch string, exURL string, i
 		}
 	}
 }
-
 
 // The purpose of this function is to verify that a given workload URL, version and architecture, is defined in the exchange
 // as well as all of its API spec dependencies. This function also returns the API dependencies converted into

--- a/exchange/rpc_test.go
+++ b/exchange/rpc_test.go
@@ -1,25 +1,25 @@
 package exchange
 
 import (
-    "encoding/json"
-    "testing"
+	"encoding/json"
+	"testing"
 )
 
 func Test_Blockchain_Demarshal(t *testing.T) {
-    // Simulate the detail string that we get from the exchange on a call to get details for a given blockchain type and name
-    details := `{"chains":[{"arch":"amd64","deployment_description":{"deployment":"{\"services\":{\"geth\":{\"environment\":[\"CHAIN=bluehorizon\"],\"image\":\"summit.hovitos.engineering/x86_64/geth:1.5.7\",\"command\":[\"start.sh\"]}}}","deployment_signature":"abcdefg","deployment_user_info":"","torrent":{"url":"https://images.bluehorizon.network/f27f762cef632af1a19cd8a761ac4c3da4f9ef7d.torrent","images":[{"file":"f27f762cef632af1a19cd8a761ac4c3da4f9ef7d.tar.gz","signature":"123456"}]}}}]}`
+	// Simulate the detail string that we get from the exchange on a call to get details for a given blockchain type and name
+	details := `{"chains":[{"arch":"amd64","deployment_description":{"deployment":"{\"services\":{\"geth\":{\"environment\":[\"CHAIN=bluehorizon\"],\"image\":\"summit.hovitos.engineering/x86_64/geth:1.5.7\",\"command\":[\"start.sh\"]}}}","deployment_signature":"abcdefg","deployment_user_info":"","torrent":{"url":"https://images.bluehorizon.network/f27f762cef632af1a19cd8a761ac4c3da4f9ef7d.torrent","images":[{"file":"f27f762cef632af1a19cd8a761ac4c3da4f9ef7d.tar.gz","signature":"123456"}]}}}]}`
 
-    detailsObj := new(BlockchainDetails)
-    if err := json.Unmarshal([]byte(details), detailsObj); err != nil {
-        t.Errorf("Could not unmarshal details, error %v\n", err)
-    } else {
-        for _, chain := range detailsObj.Chains {
-            if chain.Arch != "amd64" {
-                t.Errorf("Could not find amd64 arch in the array.\n")
-            } else if chain.DeploymentDesc.Deployment[:6] != `{"serv` {
-                t.Errorf("Could not find deployment string %v in %v.\n", `{"serv`, chain.DeploymentDesc.Deployment[:6])
-            }
-        }
-    }
+	detailsObj := new(BlockchainDetails)
+	if err := json.Unmarshal([]byte(details), detailsObj); err != nil {
+		t.Errorf("Could not unmarshal details, error %v\n", err)
+	} else {
+		for _, chain := range detailsObj.Chains {
+			if chain.Arch != "amd64" {
+				t.Errorf("Could not find amd64 arch in the array.\n")
+			} else if chain.DeploymentDesc.Deployment[:6] != `{"serv` {
+				t.Errorf("Could not find deployment string %v in %v.\n", `{"serv`, chain.DeploymentDesc.Deployment[:6])
+			}
+		}
+	}
 
 }

--- a/governance/commands.go
+++ b/governance/commands.go
@@ -130,4 +130,3 @@ func (w *GovernanceWorker) NewUpdateMicroserviceCommand(key string, started bool
 		ExecutionFailureDesc: failure_desc,
 	}
 }
-

--- a/metering/metering.go
+++ b/metering/metering.go
@@ -1,15 +1,15 @@
 package metering
 
 import (
-    "errors"
-    "encoding/hex"
-    "encoding/json"
-    "fmt"
-    "github.com/golang/glog"
-    "github.com/open-horizon/anax/persistence"
-    "github.com/open-horizon/anax/policy"
-    "golang.org/x/crypto/sha3"
-    "time"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/open-horizon/anax/persistence"
+	"github.com/open-horizon/anax/policy"
+	"golang.org/x/crypto/sha3"
+	"time"
 )
 
 // The purpose of this module is to encapsulate the metering notification object as much as possible. This
@@ -18,59 +18,59 @@ import (
 // on the blockchain.
 
 type MeteringNotification struct {
-    Amount                 uint64 `json:"amount"` // The number of tokens granted by this notification, rounded to the nearest minute
-    StartTime              uint64 `json:"start_time"` // The time when the agreement started, in seconds since 1970.
-    CurrentTime            uint64 `json:"current_time"` // The time when the notification was sent, in seconds since 1970.
-    MissedTime             uint64 `json:"missed_time"`  // The amount of time in seconds that the consumer detected missing data
-    AgreementId            string `json:"agreement_id"` // Hex encoded string of a 32 byte number indicating the agreement that this notification is related to.
-    meterHash              string                       // Not serialized in the message, just saved for efficiency
-    ConsumerMeterSignature string `json:"consumer_meter_signature"` // The consumer's signature of the meter (amount, current time, agreement Id)
-    AgreementHash          string `json:"agreement_hash"` // The 32 byte SHA3 FIPS 202 hash of the proposal for the agreement.
-    ConsumerSignature      string `json:"consumer_agreement_signature"` // The consumer's signature of the agreement hash.
-    ConsumerAddress        string `json:"consumer_address"` // The consumer's blockchain account/address.
-    ProducerSignature      string `json:"producer_agreement_signature"` // The producer's signature of the agreement
-    BlockchainType         string `json:"blockchain_type"` // The type of the blockchain that this notification is intended to work with
+	Amount                 uint64 `json:"amount"`       // The number of tokens granted by this notification, rounded to the nearest minute
+	StartTime              uint64 `json:"start_time"`   // The time when the agreement started, in seconds since 1970.
+	CurrentTime            uint64 `json:"current_time"` // The time when the notification was sent, in seconds since 1970.
+	MissedTime             uint64 `json:"missed_time"`  // The amount of time in seconds that the consumer detected missing data
+	AgreementId            string `json:"agreement_id"` // Hex encoded string of a 32 byte number indicating the agreement that this notification is related to.
+	meterHash              string // Not serialized in the message, just saved for efficiency
+	ConsumerMeterSignature string `json:"consumer_meter_signature"`     // The consumer's signature of the meter (amount, current time, agreement Id)
+	AgreementHash          string `json:"agreement_hash"`               // The 32 byte SHA3 FIPS 202 hash of the proposal for the agreement.
+	ConsumerSignature      string `json:"consumer_agreement_signature"` // The consumer's signature of the agreement hash.
+	ConsumerAddress        string `json:"consumer_address"`             // The consumer's blockchain account/address.
+	ProducerSignature      string `json:"producer_agreement_signature"` // The producer's signature of the agreement
+	BlockchainType         string `json:"blockchain_type"`              // The type of the blockchain that this notification is intended to work with
 }
 
 func (m MeteringNotification) String() string {
-    return fmt.Sprintf("Amount: %v, " +
-        "StartTime: %v, " +
-        "CurrentTime: %v, " +
-        "Missed Time: %v, " +
-        "AgreementId: %v, " +
-        "Meter Hash: %v, " +
-        "ConsumerMeterSignature: %v, " +
-        "AgreementHash: %v, " +
-        "ConsumerSignature: %v, " +
-        "ConsumerAddress: %v, " +
-        "ProducerSignature: %v, " +
-        "BlockchainType: %v",
-        m.Amount, m.StartTime, m.CurrentTime, m.MissedTime, m.AgreementId, m.meterHash, m.ConsumerMeterSignature,
-        m.AgreementHash, m.ConsumerSignature, m.ConsumerAddress, m.ProducerSignature,
-        m.BlockchainType)
+	return fmt.Sprintf("Amount: %v, "+
+		"StartTime: %v, "+
+		"CurrentTime: %v, "+
+		"Missed Time: %v, "+
+		"AgreementId: %v, "+
+		"Meter Hash: %v, "+
+		"ConsumerMeterSignature: %v, "+
+		"AgreementHash: %v, "+
+		"ConsumerSignature: %v, "+
+		"ConsumerAddress: %v, "+
+		"ProducerSignature: %v, "+
+		"BlockchainType: %v",
+		m.Amount, m.StartTime, m.CurrentTime, m.MissedTime, m.AgreementId, m.meterHash, m.ConsumerMeterSignature,
+		m.AgreementHash, m.ConsumerSignature, m.ConsumerAddress, m.ProducerSignature,
+		m.BlockchainType)
 }
 
 func (m MeteringNotification) IsValid() (bool, error) {
-    if m.StartTime == 0 {
-        return false, errors.New(fmt.Sprintf("start time must be non-zero"))
-    } else if m.CurrentTime == 0 {
-        return false, errors.New(fmt.Sprintf("current time must be non-zero"))
-    } else if len(m.AgreementId) == 0 {
-        return false, errors.New(fmt.Sprintf("agreement id is empty"))
-    } else if len(m.ConsumerMeterSignature) == 0 {
-        return false, errors.New(fmt.Sprintf("consumer signature of meter is empty"))
-    } else if len(m.AgreementHash) == 0 {
-        return false, errors.New(fmt.Sprintf("agreement hash is empty"))
-    } else if len(m.ConsumerSignature) == 0 {
-        return false, errors.New(fmt.Sprintf("consumer signature of agreement is empty"))
-    } else if len(m.ConsumerAddress) == 0 {
-        return false, errors.New(fmt.Sprintf("consumer address is empty"))
-    } else if len(m.ProducerSignature) == 0 {
-        return false, errors.New(fmt.Sprintf("producer signature of agreement is empty"))
-    } else if len(m.BlockchainType) == 0 {
-        return false, errors.New(fmt.Sprintf("block chain type is empty"))
-    }
-    return true, nil
+	if m.StartTime == 0 {
+		return false, errors.New(fmt.Sprintf("start time must be non-zero"))
+	} else if m.CurrentTime == 0 {
+		return false, errors.New(fmt.Sprintf("current time must be non-zero"))
+	} else if len(m.AgreementId) == 0 {
+		return false, errors.New(fmt.Sprintf("agreement id is empty"))
+	} else if len(m.ConsumerMeterSignature) == 0 {
+		return false, errors.New(fmt.Sprintf("consumer signature of meter is empty"))
+	} else if len(m.AgreementHash) == 0 {
+		return false, errors.New(fmt.Sprintf("agreement hash is empty"))
+	} else if len(m.ConsumerSignature) == 0 {
+		return false, errors.New(fmt.Sprintf("consumer signature of agreement is empty"))
+	} else if len(m.ConsumerAddress) == 0 {
+		return false, errors.New(fmt.Sprintf("consumer address is empty"))
+	} else if len(m.ProducerSignature) == 0 {
+		return false, errors.New(fmt.Sprintf("producer signature of agreement is empty"))
+	} else if len(m.BlockchainType) == 0 {
+		return false, errors.New(fmt.Sprintf("block chain type is empty"))
+	}
+	return true, nil
 
 }
 
@@ -78,76 +78,76 @@ func (m MeteringNotification) IsValid() (bool, error) {
 // Once this object is created, the meter hash can be signed and set into the object.
 func NewMeteringNotification(meterPolicy policy.Meter, startTime uint64, checkRate uint64, missedChecks uint64, agId string, agHash string, cSig string, cAddr string, pSig string, bcType string) (*MeteringNotification, error) {
 
-    m := new(MeteringNotification)
-    m.CurrentTime = uint64(time.Now().Unix())
-    m.StartTime = startTime
-    m.AgreementId = agId
-    m.AgreementHash = agHash
-    m.ConsumerSignature = cSig
-    m.ConsumerAddress = cAddr
-    m.ProducerSignature = pSig
-    m.BlockchainType = bcType
-    if err := m.calculateAmount(meterPolicy, startTime, checkRate, missedChecks); err != nil {
-        return nil, err
-    }
-    m.meterHash = m.GetMeterHash()
+	m := new(MeteringNotification)
+	m.CurrentTime = uint64(time.Now().Unix())
+	m.StartTime = startTime
+	m.AgreementId = agId
+	m.AgreementHash = agHash
+	m.ConsumerSignature = cSig
+	m.ConsumerAddress = cAddr
+	m.ProducerSignature = pSig
+	m.BlockchainType = bcType
+	if err := m.calculateAmount(meterPolicy, startTime, checkRate, missedChecks); err != nil {
+		return nil, err
+	}
+	m.meterHash = m.GetMeterHash()
 
-    glog.V(5).Infof("Created Metering Notification: %v", m)
+	glog.V(5).Infof("Created Metering Notification: %v", m)
 
-    return m, nil
+	return m, nil
 
 }
 
 func (m *MeteringNotification) SetConsumerMeterSignature(sig string) {
-    m.ConsumerMeterSignature = sig
+	m.ConsumerMeterSignature = sig
 }
 
 // The persistent form of the Metering notification is nearly identical to the wire form. In fact,
 // it is a subset of the wire form, so it should be possible to just unmarshal the wire form
 // directly to the persistent form.
 func ConvertToPersistent(mnString string) (*persistence.MeteringNotification, error) {
-    m := new(persistence.MeteringNotification)
-    if err := json.Unmarshal([]byte(mnString), m); err != nil {
-        return nil, err
-    }
-    return m, nil
+	m := new(persistence.MeteringNotification)
+	if err := json.Unmarshal([]byte(mnString), m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 // The persistent form of the metering notification is a subset of the wire form, so the conversion
 // to wire form only requires the addition of a few fields.
 func ConvertFromPersistent(mn persistence.MeteringNotification, agId string) *MeteringNotification {
-    m := new(MeteringNotification)
-    m.Amount = mn.Amount
-    m.StartTime = mn.StartTime
-    m.CurrentTime = mn.CurrentTime
-    m.MissedTime = mn.MissedTime
-    m.AgreementId = agId
-    m.ConsumerMeterSignature = mn.ConsumerMeterSignature
-    m.AgreementHash = mn.AgreementHash
-    m.ConsumerSignature = mn.ConsumerSignature
-    m.ConsumerAddress = mn.ConsumerAddress
-    m.ProducerSignature = mn.ProducerSignature
-    m.BlockchainType = mn.BlockchainType
-    return m
+	m := new(MeteringNotification)
+	m.Amount = mn.Amount
+	m.StartTime = mn.StartTime
+	m.CurrentTime = mn.CurrentTime
+	m.MissedTime = mn.MissedTime
+	m.AgreementId = agId
+	m.ConsumerMeterSignature = mn.ConsumerMeterSignature
+	m.AgreementHash = mn.AgreementHash
+	m.ConsumerSignature = mn.ConsumerSignature
+	m.ConsumerAddress = mn.ConsumerAddress
+	m.ProducerSignature = mn.ProducerSignature
+	m.BlockchainType = mn.BlockchainType
+	return m
 }
 
 // This function returns the stringified hash of the meter notification. This is the thing that
 // the consumer signs to produce the consumer meter signature.
 func (m *MeteringNotification) GetMeterHash() string {
 
-    if len(m.meterHash) != 0 {
-        return m.meterHash
-    } else {
-        binaryAgreementId, _ := hex.DecodeString(m.AgreementId)
+	if len(m.meterHash) != 0 {
+		return m.meterHash
+	} else {
+		binaryAgreementId, _ := hex.DecodeString(m.AgreementId)
 
-        theMeter := make([]byte, 0, 96)
-        theMeter = append(theMeter, toBuffer(m.Amount)...)
-        theMeter = append(theMeter, toBuffer(m.CurrentTime)...)
-        theMeter = append(theMeter, binaryAgreementId...)
+		theMeter := make([]byte, 0, 96)
+		theMeter = append(theMeter, toBuffer(m.Amount)...)
+		theMeter = append(theMeter, toBuffer(m.CurrentTime)...)
+		theMeter = append(theMeter, binaryAgreementId...)
 
-        hash := sha3.Sum256(theMeter)
-        return "0x" + hex.EncodeToString(hash[:])
-    }
+		hash := sha3.Sum256(theMeter)
+		return "0x" + hex.EncodeToString(hash[:])
+	}
 }
 
 // This is an internal function used to calculate the amount of tokens to send in the notification message. The
@@ -157,33 +157,33 @@ func (m *MeteringNotification) GetMeterHash() string {
 //
 func (m *MeteringNotification) calculateAmount(meterPolicy policy.Meter, startTime uint64, checkRate uint64, missedChecks uint64) error {
 
-    normalize := map[string]float64 {"min":1.0, "hour":60.0, "day":1440.0}
+	normalize := map[string]float64{"min": 1.0, "hour": 60.0, "day": 1440.0}
 
-    // Find the number of mins per check for data
-    minPerCheck := float64(checkRate) / 60.0
+	// Find the number of mins per check for data
+	minPerCheck := float64(checkRate) / 60.0
 
-    // Find the amount of missed time
-    missedDataMin := float64(missedChecks) * minPerCheck
+	// Find the amount of missed time
+	missedDataMin := float64(missedChecks) * minPerCheck
 
-    // Find the number of mins since the agreement was made minus the missed data time
-    agreementDurationMins := (float64(m.CurrentTime - startTime) / 60.0) - missedDataMin
+	// Find the number of mins since the agreement was made minus the missed data time
+	agreementDurationMins := (float64(m.CurrentTime-startTime) / 60.0) - missedDataMin
 
-    // Find the payment rate per minute
-    paymentPerMin := float64(meterPolicy.Tokens) / normalize[meterPolicy.PerTimeUnit]
+	// Find the payment rate per minute
+	paymentPerMin := float64(meterPolicy.Tokens) / normalize[meterPolicy.PerTimeUnit]
 
-    // Find the total number of tokens to be given
-    m.Amount = uint64(agreementDurationMins * paymentPerMin)
-    m.MissedTime = uint64(missedDataMin * 60)
+	// Find the total number of tokens to be given
+	m.Amount = uint64(agreementDurationMins * paymentPerMin)
+	m.MissedTime = uint64(missedDataMin * 60)
 
-    return nil
+	return nil
 
 }
 
 func toBuffer(seq uint64) []byte {
-    buf := make([]byte, 32)
-    for i := len(buf) - 1; seq != 0; i-- {
-        buf[i] = byte(seq & 0xff)
-        seq >>= 8
-    }
-    return buf
+	buf := make([]byte, 32)
+	for i := len(buf) - 1; seq != 0; i-- {
+		buf[i] = byte(seq & 0xff)
+		seq >>= 8
+	}
+	return buf
 }

--- a/metering/metering_test.go
+++ b/metering/metering_test.go
@@ -1,386 +1,386 @@
 package metering
 
 import (
-    "fmt"
-    "github.com/open-horizon/anax/policy"
-    "testing"
-    "time"
+	"fmt"
+	"github.com/open-horizon/anax/policy"
+	"testing"
+	"time"
 )
 
 // AgreementProtocolList Tests
 // First, some tests where the lists intersect
 func Test_IsValid(t *testing.T) {
 
-    m1 := MeteringNotification{
-        Amount: 0, StartTime: 1, CurrentTime: 1, AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "",
-    }
+	m1 := MeteringNotification{
+		Amount: 0, StartTime: 1, CurrentTime: 1, AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "",
+	}
 
-    if ok, _ := m1.IsValid(); ok {
-        t.Errorf("Metering Notification %v is not valid.", m1)
-    }
+	if ok, _ := m1.IsValid(); ok {
+		t.Errorf("Metering Notification %v is not valid.", m1)
+	}
 
-    m2 := MeteringNotification{
-        Amount: 1, StartTime: 1, CurrentTime: 1, AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
+	m2 := MeteringNotification{
+		Amount: 1, StartTime: 1, CurrentTime: 1, AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
 
-    if ok, _ := m2.IsValid(); !ok {
-        t.Errorf("Metering Notification %v is valid.", m2)
-    }
+	if ok, _ := m2.IsValid(); !ok {
+		t.Errorf("Metering Notification %v is valid.", m2)
+	}
 
 }
 
 func Test_GetMeterHash(t *testing.T) {
 
-    m1 := MeteringNotification{
-        Amount: 6, StartTime: 1, CurrentTime: 1, AgreementId: "00000000000000000000000000000000", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "",
-    }
-    if hash := m1.GetMeterHash(); hash != "0x6b431419f352bf9646f469f0afe927cfe0df5b224a0e508c5426b168b2b755f9" {
-        t.Errorf("Metering Notification hash %v is incorrect, should be %v.", hash, "0x6b431419f352bf9646f469f0afe927cfe0df5b224a0e508c5426b168b2b755f9")
-    }
+	m1 := MeteringNotification{
+		Amount: 6, StartTime: 1, CurrentTime: 1, AgreementId: "00000000000000000000000000000000", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "",
+	}
+	if hash := m1.GetMeterHash(); hash != "0x6b431419f352bf9646f469f0afe927cfe0df5b224a0e508c5426b168b2b755f9" {
+		t.Errorf("Metering Notification hash %v is incorrect, should be %v.", hash, "0x6b431419f352bf9646f469f0afe927cfe0df5b224a0e508c5426b168b2b755f9")
+	}
 
 }
 
 func Test_newMeteringNotification(t *testing.T) {
 
-    m := policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
-    now := uint64(time.Now().Unix())
-    past := now - 300
-    if mn, err := NewMeteringNotification(m, past, 0, 0, "00000000000000000000000000000000", "agHash", "cSig", "cAddr", "pSig", "ethereum"); err != nil {
-        t.Errorf("error creating new metering notification: %v", err)
-    } else if mn.Amount != 15 {
-        t.Errorf("should have calculated 15, but calculated %v", mn.Amount)
-    } else if mn.MissedTime != 0 {
-        t.Errorf("should have calculated 0, missed time but calculated %v", mn.MissedTime)
-    } else if mn, err := NewMeteringNotification(m, past, 15, 4, "agId", "agHash", "cSig", "cAddr", "pSig", "ethereum"); err != nil {
-        t.Errorf("error creating new metering notification: %v", err)
-    } else if mn.Amount != 12 {
-        t.Errorf("should have calculated 12, but calculated %v", mn.Amount)
-    } else if mn.MissedTime != 60 {
-        t.Errorf("should have calculated 60, missed time but calculated %v", mn.MissedTime)
-    } else if mn, err := NewMeteringNotification(m, past, 15, 3, "0000000000000000000000000000000000000000000000000000000000000000", "agHash", "cSig", "cAddr", "pSig", "ethereum"); err != nil {
-        t.Errorf("error creating new metering notification: %v", err)
-    } else if mn.Amount != 12 {
-        t.Errorf("should have calculated 12, but calculated %v", mn.Amount)
-    } else if mn.MissedTime != 45 {
-        t.Errorf("should have calculated 45, missed time but calculated %v", mn.MissedTime)
-    }
+	m := policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
+	now := uint64(time.Now().Unix())
+	past := now - 300
+	if mn, err := NewMeteringNotification(m, past, 0, 0, "00000000000000000000000000000000", "agHash", "cSig", "cAddr", "pSig", "ethereum"); err != nil {
+		t.Errorf("error creating new metering notification: %v", err)
+	} else if mn.Amount != 15 {
+		t.Errorf("should have calculated 15, but calculated %v", mn.Amount)
+	} else if mn.MissedTime != 0 {
+		t.Errorf("should have calculated 0, missed time but calculated %v", mn.MissedTime)
+	} else if mn, err := NewMeteringNotification(m, past, 15, 4, "agId", "agHash", "cSig", "cAddr", "pSig", "ethereum"); err != nil {
+		t.Errorf("error creating new metering notification: %v", err)
+	} else if mn.Amount != 12 {
+		t.Errorf("should have calculated 12, but calculated %v", mn.Amount)
+	} else if mn.MissedTime != 60 {
+		t.Errorf("should have calculated 60, missed time but calculated %v", mn.MissedTime)
+	} else if mn, err := NewMeteringNotification(m, past, 15, 3, "0000000000000000000000000000000000000000000000000000000000000000", "agHash", "cSig", "cAddr", "pSig", "ethereum"); err != nil {
+		t.Errorf("error creating new metering notification: %v", err)
+	} else if mn.Amount != 12 {
+		t.Errorf("should have calculated 12, but calculated %v", mn.Amount)
+	} else if mn.MissedTime != 45 {
+		t.Errorf("should have calculated 45, missed time but calculated %v", mn.MissedTime)
+	}
 
 }
 
 func Test_calcAmount(t *testing.T) {
 
-    // start with an easy test
-    m := policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
-    past := uint64(time.Now().Unix()) - 300
-    m1 := MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans := uint64(15)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// start with an easy test
+	m := policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
+	past := uint64(time.Now().Unix()) - 300
+	m1 := MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans := uint64(15)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // less than 1 token in mins
-    m = policy.Meter{Tokens: 2, PerTimeUnit: "min", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (15)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(0)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// less than 1 token in mins
+	m = policy.Meter{Tokens: 2, PerTimeUnit: "min", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (15)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(0)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // less than 1 token in hours
-    m = policy.Meter{Tokens: 2, PerTimeUnit: "hour", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*25)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(0)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// less than 1 token in hours
+	m = policy.Meter{Tokens: 2, PerTimeUnit: "hour", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 25)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(0)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // less than 1 token in days
-    m = policy.Meter{Tokens: 2, PerTimeUnit: "day", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*60*1)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(0)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// less than 1 token in days
+	m = policy.Meter{Tokens: 2, PerTimeUnit: "day", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 60 * 1)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(0)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // 1 token in mins
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (25)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(1)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// 1 token in mins
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (25)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(1)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // 1 token in hours
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*25)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(1)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// 1 token in hours
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 25)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(1)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // 1 token in days
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*60*9)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(1)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// 1 token in days
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 60 * 9)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(1)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // 2 token in mins
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (45)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(2)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// 2 token in mins
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (45)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(2)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // 2 token in hours
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*45)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(2)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// 2 token in hours
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 45)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(2)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // 2 token in days
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*60*17)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(2)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// 2 token in days
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 60 * 17)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(2)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // many tokens in mins
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*4) - 25
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(13)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// many tokens in mins
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 4) - 25
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(13)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // many tokens in hours
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*60*3) - (60*25)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(10)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// many tokens in hours
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 60 * 3) - (60 * 25)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(10)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // many tokens in days
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*60*24) - (60*60*9)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(4)
-    if err := m1.calculateAmount(m, past, 0, 0); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// many tokens in days
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 60 * 24) - (60 * 60 * 9)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(4)
+	if err := m1.calculateAmount(m, past, 0, 0); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
 }
 
 func Test_calcAmount_withmisses(t *testing.T) {
 
-    // miss 1 min of data
-    m := policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
-    past := uint64(time.Now().Unix()) - 300
-    m1 := MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans := uint64(12)
-    if err := m1.calculateAmount(m, past, 15, 4); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// miss 1 min of data
+	m := policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
+	past := uint64(time.Now().Unix()) - 300
+	m1 := MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans := uint64(12)
+	if err := m1.calculateAmount(m, past, 15, 4); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // miss 30 secs of data
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - 300
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(13)
-    if err := m1.calculateAmount(m, past, 15, 2); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// miss 30 secs of data
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - 300
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(13)
+	if err := m1.calculateAmount(m, past, 15, 2); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // miss 2:30 secs of data
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - 300
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(7)
-    if err := m1.calculateAmount(m, past, 15, 10); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// miss 2:30 secs of data
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - 300
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(7)
+	if err := m1.calculateAmount(m, past, 15, 10); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // miss 2:30 secs of data
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*60)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(2)
-    if err := m1.calculateAmount(m, past, 15, 10); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// miss 2:30 secs of data
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 60)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(2)
+	if err := m1.calculateAmount(m, past, 15, 10); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // miss 2:30 secs of data
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - (60*60*24)
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(2)
-    if err := m1.calculateAmount(m, past, 15, 10); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// miss 2:30 secs of data
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - (60 * 60 * 24)
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(2)
+	if err := m1.calculateAmount(m, past, 15, 10); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
-    // miss 2:30 secs of data
-    m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
-    past = uint64(time.Now().Unix()) - 300
-    m1 = MeteringNotification{
-        Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
-        AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
-        BlockchainType: "ethereum",
-    }
-    ans = uint64(8)
-    if err := m1.calculateAmount(m, past, 25, 5); err != nil {
-        t.Errorf(err.Error())
-    } else if m1.Amount != ans {
-        fmt.Println(m1)
-        t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
-    }
+	// miss 2:30 secs of data
+	m = policy.Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 300}
+	past = uint64(time.Now().Unix()) - 300
+	m1 = MeteringNotification{
+		Amount: 0, StartTime: past, CurrentTime: uint64(time.Now().Unix()), AgreementId: "abc", ConsumerMeterSignature: "1234",
+		AgreementHash: "abcdef", ConsumerSignature: "fdebca", ConsumerAddress: "1234", ProducerSignature: "bcdefa",
+		BlockchainType: "ethereum",
+	}
+	ans = uint64(8)
+	if err := m1.calculateAmount(m, past, 25, 5); err != nil {
+		t.Errorf(err.Error())
+	} else if m1.Amount != ans {
+		fmt.Println(m1)
+		t.Errorf("Token calculation was incorrect, calculated %v should have been %v", m1.Amount, ans)
+	}
 
 }

--- a/persistence/device.go
+++ b/persistence/device.go
@@ -44,7 +44,7 @@ func (e ExchangeDevice) String() string {
 }
 
 // TODO: removed check for email set temporarily until the new account mgmt. stuff is released
-func newExchangeDevice(token string, name string, tokenLastValidTime uint64, ha bool,  account *ExchangeAccount) (*ExchangeDevice, error) {
+func newExchangeDevice(token string, name string, tokenLastValidTime uint64, ha bool, account *ExchangeAccount) (*ExchangeDevice, error) {
 	if token == "" || name == "" || tokenLastValidTime == 0 || account == nil || account.Id == "" {
 		return nil, errors.New("Cannot create exchange account, illegal arguments")
 	}

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -26,7 +26,7 @@ type EstablishedAgreement struct {
 	CounterPartyAddress             string                   `json:"counterparty_address"`
 	AgreementCreationTime           uint64                   `json:"agreement_creation_time"`
 	AgreementAcceptedTime           uint64                   `json:"agreement_accepted_time"`
-	AgreementBCUpdateAckTime        uint64                   `json:"agreement_bc_update_ack_time"`  // V2 protocol - time when consumer acks our blockchain update
+	AgreementBCUpdateAckTime        uint64                   `json:"agreement_bc_update_ack_time"` // V2 protocol - time when consumer acks our blockchain update
 	AgreementFinalizedTime          uint64                   `json:"agreement_finalized_time"`
 	AgreementTerminatedTime         uint64                   `json:"agreement_terminated_time"`
 	AgreementForceTerminatedTime    uint64                   `json:"agreement_force_terminated_time"`
@@ -41,37 +41,37 @@ type EstablishedAgreement struct {
 	TerminatedDescription           string                   `json:"terminated_description"` // a string form of the reason that the agreement was terminated
 	AgreementProtocolTerminatedTime uint64                   `json:"agreement_protocol_terminated_time"`
 	WorkloadTerminatedTime          uint64                   `json:"workload_terminated_time"`
-	MeteringNotificationMsg         MeteringNotification     `json:"metering_notification,omitempty"`  // the most recent metering notification received
-	BlockchainType                  string                   `json:"blockchain_type,omitempty"` // the name of the type of the blockchain
-	BlockchainName                  string                   `json:"blockchain_name,omitempty"` // the name of the blockchain instance
+	MeteringNotificationMsg         MeteringNotification     `json:"metering_notification,omitempty"` // the most recent metering notification received
+	BlockchainType                  string                   `json:"blockchain_type,omitempty"`       // the name of the type of the blockchain
+	BlockchainName                  string                   `json:"blockchain_name,omitempty"`       // the name of the blockchain instance
 }
 
 func (c EstablishedAgreement) String() string {
 
-	return fmt.Sprintf("Name: %v, " +
-		"SensorUrl: %v, " +
-		"Archived: %v, " +
-		"CurrentAgreementId: %v, " +
-		"ConsumerId: %v, " +
-		"CounterPartyAddress: %v, " +
-		"CurrentDeployment (service names): %v, " +
-		"Proposal Signature: %v, " +
-		"AgreementCreationTime: %v, " +
-		"AgreementExecutionStartTime: %v, " +
-		"AgreementAcceptedTime: %v, " +
-		"AgreementBCUpdateAckTime: %v, " +
-		"AgreementFinalizedTime: %v, " +
-		"AgreementDataReceivedTime: %v, " +
-		"AgreementTerminatedTime: %v, " +
-		"AgreementForceTerminatedTime: %v, " +
-		"TerminatedReason: %v, " +
-		"TerminatedDescription: %v, " +
-		"Agreement Protocol: %v, " +
-		"Agreement ProtocolVersion: %v, " +
-		"AgreementProtocolTerminatedTime : %v, " +
-		"WorkloadTerminatedTime: %v, " +
-		"MeteringNotificationMsg: %v, " +
-		"BlockchainType: %v, " +
+	return fmt.Sprintf("Name: %v, "+
+		"SensorUrl: %v, "+
+		"Archived: %v, "+
+		"CurrentAgreementId: %v, "+
+		"ConsumerId: %v, "+
+		"CounterPartyAddress: %v, "+
+		"CurrentDeployment (service names): %v, "+
+		"Proposal Signature: %v, "+
+		"AgreementCreationTime: %v, "+
+		"AgreementExecutionStartTime: %v, "+
+		"AgreementAcceptedTime: %v, "+
+		"AgreementBCUpdateAckTime: %v, "+
+		"AgreementFinalizedTime: %v, "+
+		"AgreementDataReceivedTime: %v, "+
+		"AgreementTerminatedTime: %v, "+
+		"AgreementForceTerminatedTime: %v, "+
+		"TerminatedReason: %v, "+
+		"TerminatedDescription: %v, "+
+		"Agreement Protocol: %v, "+
+		"Agreement ProtocolVersion: %v, "+
+		"AgreementProtocolTerminatedTime : %v, "+
+		"WorkloadTerminatedTime: %v, "+
+		"MeteringNotificationMsg: %v, "+
+		"BlockchainType: %v, "+
 		"BlockchainName: %v",
 		c.Name, c.SensorUrl, c.Archived, c.CurrentAgreementId, c.ConsumerId, c.CounterPartyAddress, ServiceConfigNames(&c.CurrentDeployment),
 		c.ProposalSig,
@@ -337,28 +337,28 @@ func persistUpdatedAgreement(db *bolt.DB, dbAgreementId string, protocol string,
 				// This code is running in a database transaction. Within the tx, the current record is
 				// read and then updated according to the updates within the input update record. It is critical
 				// to check for correct data transitions within the tx.
-				if !mod.Archived {				// 1 transition from false to true
+				if !mod.Archived { // 1 transition from false to true
 					mod.Archived = update.Archived
 				}
 				if len(mod.CounterPartyAddress) == 0 { // 1 transition from empty to non-empty
 					mod.CounterPartyAddress = update.CounterPartyAddress
 				}
-				if mod.AgreementAcceptedTime == 0 {		// 1 transition from zero to non-zero
+				if mod.AgreementAcceptedTime == 0 { // 1 transition from zero to non-zero
 					mod.AgreementAcceptedTime = update.AgreementAcceptedTime
 				}
-				if mod.AgreementBCUpdateAckTime == 0 {       // 1 transition from zero to non-zero
+				if mod.AgreementBCUpdateAckTime == 0 { // 1 transition from zero to non-zero
 					mod.AgreementBCUpdateAckTime = update.AgreementBCUpdateAckTime
 				}
-				if mod.AgreementFinalizedTime == 0 { 	// 1 transition from zero to non-zero
+				if mod.AgreementFinalizedTime == 0 { // 1 transition from zero to non-zero
 					mod.AgreementFinalizedTime = update.AgreementFinalizedTime
 				}
-				if mod.AgreementTerminatedTime == 0 {	// 1 transition from zero to non-zero
+				if mod.AgreementTerminatedTime == 0 { // 1 transition from zero to non-zero
 					mod.AgreementTerminatedTime = update.AgreementTerminatedTime
 				}
 				if mod.AgreementForceTerminatedTime < update.AgreementForceTerminatedTime { // always moves forward
 					mod.AgreementForceTerminatedTime = update.AgreementForceTerminatedTime
 				}
-				if mod.AgreementExecutionStartTime == 0 {	// 1 transition from zero to non-zero
+				if mod.AgreementExecutionStartTime == 0 { // 1 transition from zero to non-zero
 					mod.AgreementExecutionStartTime = update.AgreementExecutionStartTime
 				}
 				if mod.AgreementDataReceivedTime < update.AgreementDataReceivedTime { // always moves forward
@@ -368,28 +368,28 @@ func persistUpdatedAgreement(db *bolt.DB, dbAgreementId string, protocol string,
 				if (len(mod.CurrentDeployment) == 0 && len(update.CurrentDeployment) != 0) || (len(mod.CurrentDeployment) != 0 && len(update.CurrentDeployment) == 0) {
 					mod.CurrentDeployment = update.CurrentDeployment
 				}
-				if mod.TerminatedReason == 0 {			// 1 transition from zero to non-zero
+				if mod.TerminatedReason == 0 { // 1 transition from zero to non-zero
 					mod.TerminatedReason = update.TerminatedReason
 				}
-				if mod.TerminatedDescription == "" {	// 1 transition from empty to non-empty
+				if mod.TerminatedDescription == "" { // 1 transition from empty to non-empty
 					mod.TerminatedDescription = update.TerminatedDescription
 				}
-				if mod.AgreementProtocolTerminatedTime == 0 {	// 1 transition from zero to non-zero
+				if mod.AgreementProtocolTerminatedTime == 0 { // 1 transition from zero to non-zero
 					mod.AgreementProtocolTerminatedTime = update.AgreementProtocolTerminatedTime
 				}
-				if mod.WorkloadTerminatedTime == 0 {			// 1 transition from zero to non-zero
+				if mod.WorkloadTerminatedTime == 0 { // 1 transition from zero to non-zero
 					mod.WorkloadTerminatedTime = update.WorkloadTerminatedTime
 				}
 				if update.MeteringNotificationMsg != (MeteringNotification{}) { // only save non-empty values
 					mod.MeteringNotificationMsg = update.MeteringNotificationMsg
 				}
-				if mod.BlockchainType == "" {	// 1 transition from empty to non-empty
+				if mod.BlockchainType == "" { // 1 transition from empty to non-empty
 					mod.BlockchainType = update.BlockchainType
 				}
-				if mod.BlockchainName == "" {	// 1 transition from empty to non-empty
+				if mod.BlockchainName == "" { // 1 transition from empty to non-empty
 					mod.BlockchainName = update.BlockchainName
 				}
-				if mod.ProposalSig == "" {		// 1 transition from empty to non-empty
+				if mod.ProposalSig == "" { // 1 transition from empty to non-empty
 					mod.ProposalSig = update.ProposalSig
 				}
 
@@ -477,30 +477,30 @@ func FindEstablishedAgreementsAllProtocols(db *bolt.DB, protocols []string, filt
 //
 
 type MeteringNotification struct {
-    Amount                 uint64 `json:"amount"` // The number of tokens granted by this notification, rounded to the nearest minute
-    StartTime              uint64 `json:"start_time"` // The time when the agreement started, in seconds since 1970.
-    CurrentTime            uint64 `json:"current_time"` // The time when the notification was sent, in seconds since 1970.
-    MissedTime             uint64 `json:"missed_time"`  // The amount of time in seconds that the consumer detected missing data
-    ConsumerMeterSignature string `json:"consumer_meter_signature"` // The consumer's signature of the meter (amount, current time, agreement Id)
-    AgreementHash          string `json:"agreement_hash"` // The 32 byte SHA3 FIPS 202 hash of the proposal for the agreement.
-    ConsumerSignature      string `json:"consumer_agreement_signature"` // The consumer's signature of the agreement hash.
-    ConsumerAddress        string `json:"consumer_address"` // The consumer's blockchain account/address.
-    ProducerSignature      string `json:"producer_agreement_signature"` // The producer's signature of the agreement
-    BlockchainType         string `json:"blockchain_type"` // The type of the blockchain that this notification is intended to work with
+	Amount                 uint64 `json:"amount"`                       // The number of tokens granted by this notification, rounded to the nearest minute
+	StartTime              uint64 `json:"start_time"`                   // The time when the agreement started, in seconds since 1970.
+	CurrentTime            uint64 `json:"current_time"`                 // The time when the notification was sent, in seconds since 1970.
+	MissedTime             uint64 `json:"missed_time"`                  // The amount of time in seconds that the consumer detected missing data
+	ConsumerMeterSignature string `json:"consumer_meter_signature"`     // The consumer's signature of the meter (amount, current time, agreement Id)
+	AgreementHash          string `json:"agreement_hash"`               // The 32 byte SHA3 FIPS 202 hash of the proposal for the agreement.
+	ConsumerSignature      string `json:"consumer_agreement_signature"` // The consumer's signature of the agreement hash.
+	ConsumerAddress        string `json:"consumer_address"`             // The consumer's blockchain account/address.
+	ProducerSignature      string `json:"producer_agreement_signature"` // The producer's signature of the agreement
+	BlockchainType         string `json:"blockchain_type"`              // The type of the blockchain that this notification is intended to work with
 }
 
 func (m MeteringNotification) String() string {
-    return fmt.Sprintf("Amount: %v, " +
-        "StartTime: %v, " +
-        "CurrentTime: %v, " +
-        "Missed Time: %v, " +
-        "ConsumerMeterSignature: %v, " +
-        "AgreementHash: %v, " +
-        "ConsumerSignature: %v, " +
-        "ConsumerAddress: %v, " +
-        "ProducerSignature: %v, " +
-        "BlockchainType: %v",
-        m.Amount, m.StartTime, m.CurrentTime, m.MissedTime, m.ConsumerMeterSignature,
-        m.AgreementHash, m.ConsumerSignature, m.ConsumerAddress, m.ProducerSignature,
-        m.BlockchainType)
+	return fmt.Sprintf("Amount: %v, "+
+		"StartTime: %v, "+
+		"CurrentTime: %v, "+
+		"Missed Time: %v, "+
+		"ConsumerMeterSignature: %v, "+
+		"AgreementHash: %v, "+
+		"ConsumerSignature: %v, "+
+		"ConsumerAddress: %v, "+
+		"ProducerSignature: %v, "+
+		"BlockchainType: %v",
+		m.Amount, m.StartTime, m.CurrentTime, m.MissedTime, m.ConsumerMeterSignature,
+		m.AgreementHash, m.ConsumerSignature, m.ConsumerAddress, m.ProducerSignature,
+		m.BlockchainType)
 }

--- a/persistence/services.go
+++ b/persistence/services.go
@@ -217,7 +217,7 @@ func (a MappedAttributes) GetGenericMappings() map[string]interface{} {
 
 type AgreementProtocolAttributes struct {
 	Meta      *AttributeMeta `json:"meta"`
-	Protocols interface{}  `json:"protocols"`
+	Protocols interface{}    `json:"protocols"`
 }
 
 func (a AgreementProtocolAttributes) GetMeta() *AttributeMeta {
@@ -397,7 +397,7 @@ func AttributesToEnvvarMap(attributes []ServiceAttribute, prefix string) (map[st
 
 		case HAAttributes:
 			s := serv.(HAAttributes)
-			writePrefix("HA_PARTNERS", strings.Join(s.Partners,","))
+			writePrefix("HA_PARTNERS", strings.Join(s.Partners, ","))
 
 		case MeteringAttributes:
 			// Nothing to do

--- a/persistence/workload_config.go
+++ b/persistence/workload_config.go
@@ -203,8 +203,8 @@ func (s WorkloadConfigByVersion) Swap(i, j int) {
 func (s WorkloadConfigByVersion) Less(i, j int) bool {
 
 	// Just compare the starting version in the two ranges
-	first := s[i].VersionExpression[1:strings.Index(s[i].VersionExpression,",")]
-	second := s[j].VersionExpression[1:strings.Index(s[j].VersionExpression,",")]
+	first := s[i].VersionExpression[1:strings.Index(s[i].VersionExpression, ",")]
+	second := s[j].VersionExpression[1:strings.Index(s[j].VersionExpression, ",")]
 	return strings.Compare(first, second) == -1
 }
 

--- a/policy/agreement_protocol.go
+++ b/policy/agreement_protocol.go
@@ -11,19 +11,19 @@ const BasicProtocol = "Basic"
 
 var AllProtocols = []string{CitizenScientist, BasicProtocol}
 
-var RequiresBCType = map[string]string{CitizenScientist:Ethereum_bc}
+var RequiresBCType = map[string]string{CitizenScientist: Ethereum_bc}
 
-func SupportedAgreementProtocol(name string)  bool {
-    for _, p := range AllProtocols {
-        if p == name {
-            return true
-        }
-    }
-    return false
+func SupportedAgreementProtocol(name string) bool {
+	for _, p := range AllProtocols {
+		if p == name {
+			return true
+		}
+	}
+	return false
 }
 
 func AllAgreementProtocols() []string {
-    return AllProtocols
+	return AllProtocols
 }
 
 func RequiresBlockchainType(protocolName string) string {
@@ -99,9 +99,9 @@ func ConvertToAgreementProtocolList(list []interface{}) (*[]AgreementProtocol, e
 }
 
 type AgreementProtocol struct {
-	Name            string         `json:"name"` // The name of the agreement protocol to be used
+	Name            string         `json:"name"`                      // The name of the agreement protocol to be used
 	ProtocolVersion int            `json:"protocolVersion,omitempty"` // The max protocol version supported
-	Blockchains     BlockchainList `json:"blockchains,omitempty"` // The blockchain to be used if the protocol requires one.
+	Blockchains     BlockchainList `json:"blockchains,omitempty"`     // The blockchain to be used if the protocol requires one.
 }
 
 func (a AgreementProtocol) IsSame(compare AgreementProtocol) bool {
@@ -148,14 +148,14 @@ func (a *AgreementProtocol) IsValid() error {
 // messages MUST use the same protocol version. Anax will store the protocol version of the initial
 // message for the agreement and will use the stored version for all future messages.
 func (a *AgreementProtocol) MinimumProtocolVersion(other *AgreementProtocol, maxSupportedVersion int) int {
-	if a.ProtocolVersion == 0 { 	// old Anax, before it always exported a protocol version in policy files.
+	if a.ProtocolVersion == 0 { // old Anax, before it always exported a protocol version in policy files.
 		return 1
-	} else if other.ProtocolVersion != 0 && other.ProtocolVersion <= a.ProtocolVersion { 	// Agbot policy file specified something lower than what device supports
+	} else if other.ProtocolVersion != 0 && other.ProtocolVersion <= a.ProtocolVersion { // Agbot policy file specified something lower than what device supports
 		return other.ProtocolVersion
-	} else if other.ProtocolVersion == 0 && maxSupportedVersion < a.ProtocolVersion { 	// For agbot policy files that dont specify a protocol version
+	} else if other.ProtocolVersion == 0 && maxSupportedVersion < a.ProtocolVersion { // For agbot policy files that dont specify a protocol version
 		return maxSupportedVersion
 	} else {
-		return a.ProtocolVersion 	// Producer always exports a protocol version at 2 or higher.
+		return a.ProtocolVersion // Producer always exports a protocol version at 2 or higher.
 	}
 }
 
@@ -167,7 +167,7 @@ func AgreementProtocol_Factory(name string) *AgreementProtocol {
 	if name == CitizenScientist {
 		a.ProtocolVersion = 2
 	} else {
-		a.ProtocolVersion = 1 	// this might have to be zero
+		a.ProtocolVersion = 1 // this might have to be zero
 	}
 	return a
 }

--- a/policy/agreement_protocol_test.go
+++ b/policy/agreement_protocol_test.go
@@ -310,7 +310,7 @@ func Test_AgreementProtocolList_no_intersect(t *testing.T) {
 func Test_AgreementProtocolList_single_element(t *testing.T) {
 	var pl1 *AgreementProtocolList
 
-	pb := `[{"name":"`+BasicProtocol+`"}]`
+	pb := `[{"name":"` + BasicProtocol + `"}]`
 	if pb1 := create_AgreementProtocolList(pb, t); pb1 == nil || len(*pb1) != 1 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pb1, pb)
 	} else {
@@ -364,7 +364,7 @@ func Test_AgreementProtocol_isvalid(t *testing.T) {
 
 	p1 := `[{"name":"Basic","blockchains":[]},{"name":"Basic"},{"name":"Citizen Scientist"},{"name":"Citizen Scientist","blockchains":[]},{"name":"Citizen Scientist","blockchains":[{}]},{"name":"Citizen Scientist","blockchains":[{"name":"fred"}]},{"name":"Citizen Scientist","blockchains":[{"name":"fred","type":"ethereum"}]}]`
 	if pl1 := create_AgreementProtocolList(p1, t); pl1 != nil {
-		for _, agp := range (*pl1) {
+		for _, agp := range *pl1 {
 			if err := agp.IsValid(); err != nil {
 				t.Errorf("Error: agreement protocol object is valid %v\n", agp)
 			}
@@ -376,7 +376,7 @@ func Test_AgreementProtocol_is_notvalid(t *testing.T) {
 
 	p1 := `[{"name":"Basic","blockchains":[{"type":"ethereum"}]}]`
 	if pl1 := create_AgreementProtocolList(p1, t); pl1 != nil {
-		for _, agp := range (*pl1) {
+		for _, agp := range *pl1 {
 			if err := agp.IsValid(); err == nil {
 				t.Errorf("Error: agreement protocol object is not valid %v\n", agp)
 			}
@@ -385,7 +385,7 @@ func Test_AgreementProtocol_is_notvalid(t *testing.T) {
 
 	p1 = `[{"name":"Basic","blockchains":[{"type":"fred"}]}]`
 	if pl1 := create_AgreementProtocolList(p1, t); pl1 != nil {
-		for _, agp := range (*pl1) {
+		for _, agp := range *pl1 {
 			if err := agp.IsValid(); err == nil {
 				t.Errorf("Error: agreement protocol object is not valid %v\n", agp)
 			}
@@ -394,7 +394,7 @@ func Test_AgreementProtocol_is_notvalid(t *testing.T) {
 
 	p1 = `[{"name":"fred","blockchains":[{"type":"ethereum"}]}]`
 	if pl1 := create_AgreementProtocolList(p1, t); pl1 != nil {
-		for _, agp := range (*pl1) {
+		for _, agp := range *pl1 {
 			if err := agp.IsValid(); err == nil {
 				t.Errorf("Error: agreement protocol object is not valid %v\n", agp)
 			}
@@ -403,7 +403,7 @@ func Test_AgreementProtocol_is_notvalid(t *testing.T) {
 
 	p1 = `[{"name":"Citizen Scientist","blockchains":[{"type":"fred"}]}]`
 	if pl1 := create_AgreementProtocolList(p1, t); pl1 != nil {
-		for _, agp := range (*pl1) {
+		for _, agp := range *pl1 {
 			if err := agp.IsValid(); err == nil {
 				t.Errorf("Error: agreement protocol object is not valid %v\n", agp)
 			}
@@ -413,9 +413,9 @@ func Test_AgreementProtocol_is_notvalid(t *testing.T) {
 
 func Test_AgreementProtocol_convert1(t *testing.T) {
 
-	bc := map[string]interface{}{"name":"blue"}
+	bc := map[string]interface{}{"name": "blue"}
 	bcList := []interface{}{bc}
-	agp := map[string]interface{}{"name":"blue","blockchains":bcList}
+	agp := map[string]interface{}{"name": "blue", "blockchains": bcList}
 	agpList := []interface{}{agp}
 
 	if cList, err := ConvertToAgreementProtocolList(agpList); err != nil {
@@ -432,14 +432,14 @@ func Test_AgreementProtocol_convert1(t *testing.T) {
 
 func Test_AgreementProtocol_convert2(t *testing.T) {
 
-	bc1 := map[string]interface{}{"name":"blue"}
-	bc2 := map[string]interface{}{"name":"red","type":"hyper"}
+	bc1 := map[string]interface{}{"name": "blue"}
+	bc2 := map[string]interface{}{"name": "red", "type": "hyper"}
 	bcList1 := []interface{}{bc1, bc2}
-	agp1 := map[string]interface{}{"name":"colors","blockchains":bcList1}
+	agp1 := map[string]interface{}{"name": "colors", "blockchains": bcList1}
 
-	bc3 := map[string]interface{}{"name":"one","type":"arthimetic"}
+	bc3 := map[string]interface{}{"name": "one", "type": "arthimetic"}
 	bcList2 := []interface{}{bc3}
-	agp2 := map[string]interface{}{"name":"numbers","blockchains":bcList2}
+	agp2 := map[string]interface{}{"name": "numbers", "blockchains": bcList2}
 	agpList := []interface{}{agp1, agp2}
 
 	if cList, err := ConvertToAgreementProtocolList(agpList); err != nil {
@@ -461,8 +461,8 @@ func Test_AgreementProtocolList_isSame(t *testing.T) {
 	var pl1 *AgreementProtocolList
 	var pl2 *AgreementProtocolList
 
-	pa := `[{"name":"`+BasicProtocol+`"}]`
-	pb := `[{"name":"`+BasicProtocol+`"}]`
+	pa := `[{"name":"` + BasicProtocol + `"}]`
+	pb := `[{"name":"` + BasicProtocol + `"}]`
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil || len(*pl1) != 1 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)
 	} else if pl2 = create_AgreementProtocolList(pb, t); pl2 == nil || len(*pl2) != 1 {
@@ -488,8 +488,8 @@ func Test_AgreementProtocolList_is_not_Same(t *testing.T) {
 	var pl1 *AgreementProtocolList
 	var pl2 *AgreementProtocolList
 
-	pa := `[{"name":"`+CitizenScientist+`"}]`
-	pb := `[{"name":"`+BasicProtocol+`"}]`
+	pa := `[{"name":"` + CitizenScientist + `"}]`
+	pb := `[{"name":"` + BasicProtocol + `"}]`
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil || len(*pl1) != 1 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)
 	} else if pl2 = create_AgreementProtocolList(pb, t); pl2 == nil || len(*pl2) != 1 {
@@ -499,7 +499,7 @@ func Test_AgreementProtocolList_is_not_Same(t *testing.T) {
 	}
 
 	pa = `[]`
-	pb = `[{"name":"`+BasicProtocol+`"}]`
+	pb = `[{"name":"` + BasicProtocol + `"}]`
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)
 	} else if pl2 = create_AgreementProtocolList(pb, t); pl2 == nil || len(*pl2) != 1 {
@@ -508,7 +508,7 @@ func Test_AgreementProtocolList_is_not_Same(t *testing.T) {
 		t.Errorf("Error: the lists are not the same: %v %v\n", pl1, pl2)
 	}
 
-	pa = `[{"name":"`+BasicProtocol+`"}]`
+	pa = `[{"name":"` + BasicProtocol + `"}]`
 	pb = `[]`
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil || len(*pl1) != 1 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)
@@ -518,8 +518,8 @@ func Test_AgreementProtocolList_is_not_Same(t *testing.T) {
 		t.Errorf("Error: the lists are not the same: %v %v\n", pl1, pl2)
 	}
 
-	pa = `[{"name":"`+BasicProtocol+`"}]`
-	pb = `[{"name":"`+BasicProtocol+`"},{"name":"`+CitizenScientist+`"}]`
+	pa = `[{"name":"` + BasicProtocol + `"}]`
+	pb = `[{"name":"` + BasicProtocol + `"},{"name":"` + CitizenScientist + `"}]`
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil || len(*pl1) != 1 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)
 	} else if pl2 = create_AgreementProtocolList(pb, t); pl2 == nil || len(*pl2) != 2 {
@@ -534,7 +534,7 @@ func Test_AgreementProtocolList_FindByName(t *testing.T) {
 
 	var pl1 *AgreementProtocolList
 
-	pa := `[{"name":"`+CitizenScientist+`","blockchains":[{"name":"fred"}]}]`
+	pa := `[{"name":"` + CitizenScientist + `","blockchains":[{"name":"fred"}]}]`
 
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil || len(*pl1) != 1 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)
@@ -544,7 +544,7 @@ func Test_AgreementProtocolList_FindByName(t *testing.T) {
 		t.Errorf("Error: lost the blockchain list, should have 1 element, is %v", agp.Blockchains)
 	}
 
-	pa = `[{"name":"`+CitizenScientist+`","blockchains":[{"name":"fred"}]},{"name":"fred","blockchains":[{"name":"fred"}]}]`
+	pa = `[{"name":"` + CitizenScientist + `","blockchains":[{"name":"fred"}]},{"name":"fred","blockchains":[{"name":"fred"}]}]`
 
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil || len(*pl1) != 2 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)
@@ -554,7 +554,7 @@ func Test_AgreementProtocolList_FindByName(t *testing.T) {
 		t.Errorf("Error: lost the blockchain list, should have 1 element, is %v", agp.Blockchains)
 	}
 
-	pa = `[{"name":"ethel","blockchains":[{"name":"fred"}]},{"name":"`+CitizenScientist+`","blockchains":[{"name":"fred"}]},{"name":"fred","blockchains":[{"name":"fred"}]}]`
+	pa = `[{"name":"ethel","blockchains":[{"name":"fred"}]},{"name":"` + CitizenScientist + `","blockchains":[{"name":"fred"}]},{"name":"fred","blockchains":[{"name":"fred"}]}]`
 
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil || len(*pl1) != 3 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)
@@ -564,7 +564,7 @@ func Test_AgreementProtocolList_FindByName(t *testing.T) {
 		t.Errorf("Error: lost the blockchain list, should have 1 element, is %v", agp.Blockchains)
 	}
 
-	pa = `[{"name":"ethel","blockchains":[{"name":"fred"}]},{"name":"`+CitizenScientist+`","blockchains":[{"name":"fred"}]}]`
+	pa = `[{"name":"ethel","blockchains":[{"name":"fred"}]},{"name":"` + CitizenScientist + `","blockchains":[{"name":"fred"}]}]`
 
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil || len(*pl1) != 2 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)
@@ -580,7 +580,7 @@ func Test_AgreementProtocolList_not_FindByName(t *testing.T) {
 
 	var pl1 *AgreementProtocolList
 
-	pa := `[{"name":"`+CitizenScientist+`","blockchains":[{"name":"fred"}]}]`
+	pa := `[{"name":"` + CitizenScientist + `","blockchains":[{"name":"fred"}]}]`
 
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil || len(*pl1) != 1 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)
@@ -596,7 +596,7 @@ func Test_AgreementProtocolList_not_FindByName(t *testing.T) {
 		t.Errorf("Error: the list does not contain AGP %v that we searched for in %v\n", "fred", pl1)
 	}
 
-	pa = `[{"name":"`+CitizenScientist+`","blockchains":[{"name":"fred"}]},{"name":"`+CitizenScientist+`","blockchains":[{"name":"fred"}]}]`
+	pa = `[{"name":"` + CitizenScientist + `","blockchains":[{"name":"fred"}]},{"name":"` + CitizenScientist + `","blockchains":[{"name":"fred"}]}]`
 
 	if pl1 = create_AgreementProtocolList(pa, t); pl1 == nil || len(*pl1) != 2 {
 		t.Errorf("Error: returned %v, should have returned %v\n", pl1, pa)

--- a/policy/api_spec_list.go
+++ b/policy/api_spec_list.go
@@ -31,9 +31,9 @@ func (a APISpecList) IsSame(compare APISpecList, checkVersion bool) bool {
 }
 
 type APISpecification struct {
-	SpecRef          string `json:"specRef"`          // A URL pointing to the definition of the API spec
-	Version          string `json:"version"`          // The version of the API spec in OSGI version format
-	ExclusiveAccess  bool   `json:"exclusiveAccess"`  // Whether or not exclusive access to this API spec is required
+	SpecRef         string `json:"specRef"`         // A URL pointing to the definition of the API spec
+	Version         string `json:"version"`         // The version of the API spec in OSGI version format
+	ExclusiveAccess bool   `json:"exclusiveAccess"` // Whether or not exclusive access to this API spec is required
 	// API will allow. For a Consumer (agbot), this is likely to be 1.
 	// For a Producer, if this is zero, then no agreements, if 1 then
 	// then it's essentially exclusive access. For more than 1, then it's
@@ -165,7 +165,7 @@ func (self *APISpecList) MergeWith(other *APISpecList) APISpecList {
 // This function extracts the APISpec URLs from a list of API Specs and returns the URLs in an array.
 func (self *APISpecList) AsStringArray() []string {
 	res := make([]string, 0, 10)
-	for _, apiSpec := range (*self) {
+	for _, apiSpec := range *self {
 		res = append(res, apiSpec.SpecRef)
 	}
 	return res

--- a/policy/api_spec_list_test.go
+++ b/policy/api_spec_list_test.go
@@ -23,21 +23,21 @@ func Test_APISpecification_contains_specref(t *testing.T) {
 
 	searchURL = "http://mycompany.com/dm/net"
 	if as1 = create_APISpecification(asString, t); as1 != nil {
-		if !(*as1).ContainsSpecRef(searchURL,"1.0.0") {
+		if !(*as1).ContainsSpecRef(searchURL, "1.0.0") {
 			t.Errorf("Error: %v is in %v.\n", searchURL, *as1)
 		}
 	}
 
 	searchURL = "http://mycompany.com/dm/gps"
 	if as1 = create_APISpecification(asString, t); as1 != nil {
-		if !(*as1).ContainsSpecRef(searchURL,"1.0.0") {
+		if !(*as1).ContainsSpecRef(searchURL, "1.0.0") {
 			t.Errorf("Error: %v is in %v.\n", searchURL, *as1)
 		}
 	}
 
 	searchURL = "http://mycompany.com/dm/cpu"
 	if as1 = create_APISpecification(asString, t); as1 != nil {
-		if !(*as1).ContainsSpecRef(searchURL,"1.0.0") {
+		if !(*as1).ContainsSpecRef(searchURL, "1.0.0") {
 			t.Errorf("Error: %v is in %v.\n", searchURL, *as1)
 		}
 	}
@@ -50,7 +50,7 @@ func Test_APISpecification_not_contains_specref(t *testing.T) {
 
 	searchURL := "http://mycompany.com/dm/net"
 	if as1 = create_APISpecification(asString, t); as1 != nil {
-		if (*as1).ContainsSpecRef(searchURL,"1.0.0") {
+		if (*as1).ContainsSpecRef(searchURL, "1.0.0") {
 			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
 		}
 	}
@@ -61,21 +61,21 @@ func Test_APISpecification_not_contains_specref(t *testing.T) {
 
 	searchURL = "http://mycompany.com/dm/nit"
 	if as1 = create_APISpecification(asString, t); as1 != nil {
-		if (*as1).ContainsSpecRef(searchURL,"1.0.0") {
+		if (*as1).ContainsSpecRef(searchURL, "1.0.0") {
 			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
 		}
 	}
 
 	searchURL = "http://mycompany.com/dm/gps"
 	if as1 = create_APISpecification(asString, t); as1 != nil {
-		if (*as1).ContainsSpecRef(searchURL,"2.0.0") {
+		if (*as1).ContainsSpecRef(searchURL, "2.0.0") {
 			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
 		}
 	}
 
 	searchURL = ""
 	if as1 = create_APISpecification(asString, t); as1 != nil {
-		if (*as1).ContainsSpecRef(searchURL,"1.0.0") {
+		if (*as1).ContainsSpecRef(searchURL, "1.0.0") {
 			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
 		}
 	}
@@ -84,7 +84,7 @@ func Test_APISpecification_not_contains_specref(t *testing.T) {
 
 	searchURL = "http://mycompany.com/dm/nit"
 	if as1 = create_APISpecification(asString, t); as1 != nil {
-		if (*as1).ContainsSpecRef(searchURL,"1.0.0") {
+		if (*as1).ContainsSpecRef(searchURL, "1.0.0") {
 			t.Errorf("Error: %v is not in %v.\n", searchURL, *as1)
 		}
 	}

--- a/policy/blockchain_test.go
+++ b/policy/blockchain_test.go
@@ -171,7 +171,6 @@ func Test_IntersectsWith(t *testing.T) {
 		}
 	}
 
-
 }
 
 func Test_NonIntersectsWith(t *testing.T) {

--- a/policy/data_verification.go
+++ b/policy/data_verification.go
@@ -20,11 +20,11 @@ func (m Meter) IsValid() bool {
 	if (m.Tokens != 0 && m.PerTimeUnit == "") || (m.Tokens == 0 && m.PerTimeUnit != "") {
 		return false
 
-	// Notification interval requires both Token and PerTimeUnit to be specified
+		// Notification interval requires both Token and PerTimeUnit to be specified
 	} else if m.NotificationIntervalS != 0 && (m.Tokens == 0 || m.PerTimeUnit == "") {
 		return false
 
-	// PerTimeUnit must be a valid value
+		// PerTimeUnit must be a valid value
 	} else if m.PerTimeUnit != "min" && m.PerTimeUnit != "hour" && m.PerTimeUnit != "day" && m.PerTimeUnit != "" {
 		return false
 	}
@@ -99,7 +99,7 @@ func (m Meter) MergeWith(otherMeter Meter, dvCheckRate int) Meter {
 	}
 
 	// Convert tokens back to the chosen time unit.
-	divisors := map[string]uint64{"min":1440, "hour":24, "day":1}
+	divisors := map[string]uint64{"min": 1440, "hour": 24, "day": 1}
 	ret.Tokens = ret.Tokens / divisors[chosenTimeUnit]
 
 	// Choose the notification interval, shorter of both or the default
@@ -155,7 +155,7 @@ func (m *Meter) ProducerMergeWith(otherMeter *Meter, dvCheckRate int) Meter {
 	ret.Tokens = maxOfUint64(myTokens, otherTokens)
 
 	// Convert tokens back to the chosen time unit.
-	divisors := map[string]uint64{"min":1440, "hour":24, "day":1}
+	divisors := map[string]uint64{"min": 1440, "hour": 24, "day": 1}
 	ret.Tokens = ret.Tokens / divisors[chosenTimeUnit]
 
 	// Choose the notification interval, shorter of both or the default
@@ -192,7 +192,7 @@ func (m Meter) IsCompatibleWith(otherMeter Meter) bool {
 
 // Convert tokens per x time into tokens per day
 func normalizeTokens(amt uint64, timeUnit string) uint64 {
-	multipliers := map[string]uint64{"min":1440, "hour":24, "day":1}
+	multipliers := map[string]uint64{"min": 1440, "hour": 24, "day": 1}
 	return amt * multipliers[timeUnit]
 }
 
@@ -221,26 +221,26 @@ func maxOfUint64(x uint64, y uint64) uint64 {
 }
 
 type DataVerification struct {
-	Enabled     bool   `json:"enabled,omitempty"`            // Whether or not data verification is enabled
-	URL         string `json:"URL,omitempty"`                // The URL to be used for data receipt verification
-	URLUser     string `json:"URLUser,omitempty"`            // The user id to use when calling the verification URL
-	URLPassword string `json:"URLPassword,omitempty"`        // The password to use when calling the verification URL
-	Interval    int    `json:"interval,omitempty"`           // The number of seconds to check for data before deciding there isnt any data
-	CheckRate   int    `json:"check_rate,omitempty"`         // The number of seconds between checks for valid data being received
-	Metering    Meter  `json:"metering,omitempty"` // The metering configuration
+	Enabled     bool   `json:"enabled,omitempty"`     // Whether or not data verification is enabled
+	URL         string `json:"URL,omitempty"`         // The URL to be used for data receipt verification
+	URLUser     string `json:"URLUser,omitempty"`     // The user id to use when calling the verification URL
+	URLPassword string `json:"URLPassword,omitempty"` // The password to use when calling the verification URL
+	Interval    int    `json:"interval,omitempty"`    // The number of seconds to check for data before deciding there isnt any data
+	CheckRate   int    `json:"check_rate,omitempty"`  // The number of seconds between checks for valid data being received
+	Metering    Meter  `json:"metering,omitempty"`    // The metering configuration
 }
 
 func DataVerification_Factory(url string, urluser string, urlpw string, interval int, checkRate int, meterPolicy Meter) *DataVerification {
-    d := new(DataVerification)
-    d.Enabled = true
-    d.URL = url
-    d.URLUser = urluser
-    d.URLPassword = urlpw
-    d.Interval = interval
-    d.CheckRate = checkRate
-    d.Metering = meterPolicy
+	d := new(DataVerification)
+	d.Enabled = true
+	d.URL = url
+	d.URLUser = urluser
+	d.URLPassword = urlpw
+	d.Interval = interval
+	d.CheckRate = checkRate
+	d.Metering = meterPolicy
 
-    return d
+	return d
 }
 
 func (d DataVerification) IsValid() (bool, error) {
@@ -254,11 +254,11 @@ func (d DataVerification) IsValid() (bool, error) {
 
 func (d DataVerification) IsSame(compare DataVerification) bool {
 	return d.Enabled == compare.Enabled &&
-			d.URL == compare.URL &&
-			d.URLUser == compare.URLUser &&
-			d.Interval == compare.Interval &&
-			d.CheckRate == compare.CheckRate &&
-			d.Metering.IsSame(compare.Metering)
+		d.URL == compare.URL &&
+		d.URLUser == compare.URLUser &&
+		d.Interval == compare.Interval &&
+		d.CheckRate == compare.CheckRate &&
+		d.Metering.IsSame(compare.Metering)
 }
 
 func (d DataVerification) String() string {
@@ -286,7 +286,7 @@ func (d *DataVerification) internalCompatibleWith(compare *DataVerification) boo
 	// enabled they want to use different URLs and/or Users to verify. That difference
 	// cannot be reconciled and therefore the sections are incompatible.
 	if (d.Enabled && compare.Enabled && d.URL != "" && compare.URL != "" && d.URL != compare.URL) ||
-	   (d.Enabled && compare.Enabled && d.URLUser != "" && compare.URLUser != "" && d.URLUser != compare.URLUser) {
+		(d.Enabled && compare.Enabled && d.URLUser != "" && compare.URLUser != "" && d.URLUser != compare.URLUser) {
 		return false
 	}
 	return true

--- a/policy/data_verification_test.go
+++ b/policy/data_verification_test.go
@@ -1,811 +1,811 @@
 package policy
 
 import (
-    "encoding/json"
+	"encoding/json"
 	"testing"
 )
 
 func Test_data_verification_section_success(t *testing.T) {
 
-    dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":50,"check_rate":10}`
-    dv2 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":50,"check_rate":10}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if !dva.IsSame(*dvb) {
-                t.Errorf("DV section %v is the same as %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":50,"check_rate":10}`
+	dv2 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":50,"check_rate":10}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if !dva.IsSame(*dvb) {
+				t.Errorf("DV section %v is the same as %v\n", dva, dvb)
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"my2secret","interval":0,"check_rate":10}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"check_rate":10}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if !dva.IsSame(*dvb) {
-                t.Errorf("DV section %v is the same as %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"my2secret","interval":0,"check_rate":10}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"check_rate":10}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if !dva.IsSame(*dvb) {
+				t.Errorf("DV section %v is the same as %v\n", dva, dvb)
+			}
+		}
+	}
 
 }
 
 func Test_data_verification_section_failure(t *testing.T) {
 
-    dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"check_rate":10}`
-    dv2 := `{"enabled":true,"URL":"http://othercompany.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"check_rate":10}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dva.IsSame(*dvb) {
-                t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"check_rate":10}`
+	dv2 := `{"enabled":true,"URL":"http://othercompany.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"check_rate":10}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dva.IsSame(*dvb) {
+				t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me2","URLPassword":"mysecret","interval":0,"check_rate":10}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"check_rate":10}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dva.IsSame(*dvb) {
-                t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me2","URLPassword":"mysecret","interval":0,"check_rate":10}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"check_rate":10}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dva.IsSame(*dvb) {
+				t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":50,"check_rate":10}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"check_rate":10}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dva.IsSame(*dvb) {
-                t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":50,"check_rate":10}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"check_rate":10}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dva.IsSame(*dvb) {
+				t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":50,"check_rate":5}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":50,"check_rate":10}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dva.IsSame(*dvb) {
-                t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":50,"check_rate":5}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":50,"check_rate":10}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dva.IsSame(*dvb) {
+				t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
+			}
+		}
+	}
 
 }
 
 func Test_data_verification_obscure(t *testing.T) {
 
-    dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
-    dv2 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        upb4 := dva.URLPassword
-        dva.Obscure()
-        if dva.URLPassword == upb4 || dva.URLPassword != "********" {
-            t.Errorf("DV section %v was not obscured correctly\n", dva)
-        } else if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if !dva.IsSame(*dvb) {
-                t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
+	dv2 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		upb4 := dva.URLPassword
+		dva.Obscure()
+		if dva.URLPassword == upb4 || dva.URLPassword != "********" {
+			t.Errorf("DV section %v was not obscured correctly\n", dva)
+		} else if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if !dva.IsSame(*dvb) {
+				t.Errorf("DV section %v is not the same as %v\n", dva, dvb)
+			}
+		}
+	}
 
 }
 
 func Test_dv_compatwith(t *testing.T) {
 
-    dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
-    dv2 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if !dva.IsCompatibleWith(*dvb) {
-                t.Errorf("DV section %v is compatible with %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
+	dv2 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if !dva.IsCompatibleWith(*dvb) {
+				t.Errorf("DV section %v is compatible with %v\n", dva, dvb)
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify2","URLUser":"me","URLPassword":"mysecret","interval":0}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dva.IsCompatibleWith(*dvb) {
-                t.Errorf("DV section %v is not compatible with %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify2","URLUser":"me","URLPassword":"mysecret","interval":0}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dva.IsCompatibleWith(*dvb) {
+				t.Errorf("DV section %v is not compatible with %v\n", dva, dvb)
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me2","URLPassword":"mysecret","interval":0}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dva.IsCompatibleWith(*dvb) {
-                t.Errorf("DV section %v is not compatible with %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me2","URLPassword":"mysecret","interval":0}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dva.IsCompatibleWith(*dvb) {
+				t.Errorf("DV section %v is not compatible with %v\n", dva, dvb)
+			}
+		}
+	}
 
-    dv1 = `{"enabled":false,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
-    dv2 = `{"enabled":false,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"mysecret","interval":0}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if !dva.IsCompatibleWith(*dvb) {
-                t.Errorf("DV section %v is compatible with %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 = `{"enabled":false,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0}`
+	dv2 = `{"enabled":false,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"mysecret","interval":0}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if !dva.IsCompatibleWith(*dvb) {
+				t.Errorf("DV section %v is compatible with %v\n", dva, dvb)
+			}
+		}
+	}
 
-    dv1 = `{"enabled":false,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"metering":{"tokens":3,"per_time_unit":"min"}}`
-    dv2 = `{"enabled":false,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"mysecret","interval":0,"metering":{"tokens":4,"per_time_unit":"min"}}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if !dva.IsCompatibleWith(*dvb) {
-                t.Errorf("DV section %v is compatible with %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 = `{"enabled":false,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"metering":{"tokens":3,"per_time_unit":"min"}}`
+	dv2 = `{"enabled":false,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"mysecret","interval":0,"metering":{"tokens":4,"per_time_unit":"min"}}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if !dva.IsCompatibleWith(*dvb) {
+				t.Errorf("DV section %v is compatible with %v\n", dva, dvb)
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"","URLUser":"me","URLPassword":"mysecret","interval":0,"metering":{"tokens":3,"per_time_unit":"min"}}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify2","URLUser":"","URLPassword":"mysecret","interval":0,"metering":{"tokens":4,"per_time_unit":"min"}}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if !dva.IsCompatibleWith(*dvb) {
-                t.Errorf("DV section %v is compatible with %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 = `{"enabled":true,"URL":"","URLUser":"me","URLPassword":"mysecret","interval":0,"metering":{"tokens":3,"per_time_unit":"min"}}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify2","URLUser":"","URLPassword":"mysecret","interval":0,"metering":{"tokens":4,"per_time_unit":"min"}}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if !dva.IsCompatibleWith(*dvb) {
+				t.Errorf("DV section %v is compatible with %v\n", dva, dvb)
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"","URLUser":"me","URLPassword":"mysecret","interval":0,"metering":{"tokens":3,"per_time_unit":"min"}}`
-    dv2 = `{"enabled":false,"URL":"http://company.com/verify2","URLUser":"","URLPassword":"mysecret","interval":0,"metering":{"tokens":4,"per_time_unit":"min"}}`
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if !dva.IsCompatibleWith(*dvb) {
-                t.Errorf("DV section %v is compatible with %v\n", dva, dvb)
-            }
-        }
-    }
+	dv1 = `{"enabled":true,"URL":"","URLUser":"me","URLPassword":"mysecret","interval":0,"metering":{"tokens":3,"per_time_unit":"min"}}`
+	dv2 = `{"enabled":false,"URL":"http://company.com/verify2","URLUser":"","URLPassword":"mysecret","interval":0,"metering":{"tokens":4,"per_time_unit":"min"}}`
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if !dva.IsCompatibleWith(*dvb) {
+				t.Errorf("DV section %v is compatible with %v\n", dva, dvb)
+			}
+		}
+	}
 
 }
 
 func Test_dv_mergewith(t *testing.T) {
 
-    dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
-    dv2 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
-    dv3 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
+	dv1 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
+	dv2 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
+	dv3 := `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min"}}`
-    dv2 = `{"enabled":false,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"mysecret","interval":40,"metering":{"tokens":4,"per_time_unit":"min"}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min"}}`
+	dv2 = `{"enabled":false,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"mysecret","interval":40,"metering":{"tokens":4,"per_time_unit":"min"}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":false,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min"}}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"mysecret","interval":40,"check_rate":10,"metering":{"tokens":4,"per_time_unit":"min"}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"********","interval":40,"check_rate":10,"metering":{"tokens":4,"per_time_unit":"min","notification_interval":10}}`
+	dv1 = `{"enabled":false,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min"}}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"mysecret","interval":40,"check_rate":10,"metering":{"tokens":4,"per_time_unit":"min"}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"********","interval":40,"check_rate":10,"metering":{"tokens":4,"per_time_unit":"min","notification_interval":10}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":false,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min"}}`
-    dv2 = `{"enabled":false,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"mysecret","interval":40,"metering":{"tokens":4,"per_time_unit":"min"}}`
-    dv3 = `{"enabled":false,"URL":"","URLUser":"","URLPassword":"","interval":0,"check_rate":0,"metering":{"tokens":0,"per_time_unit":"","notification_interval":0}}`
+	dv1 = `{"enabled":false,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min"}}`
+	dv2 = `{"enabled":false,"URL":"http://company.com/verify2","URLUser":"me2","URLPassword":"mysecret","interval":40,"metering":{"tokens":4,"per_time_unit":"min"}}`
+	dv3 = `{"enabled":false,"URL":"","URLUser":"","URLPassword":"","interval":0,"check_rate":0,"metering":{"tokens":0,"per_time_unit":"","notification_interval":0}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
-    dv2 = `{"enabled":true,"URL":"","URLUser":"","URLPassword":"","interval":0,"metering":{"tokens":0,"per_time_unit":"","notification_interval":0}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
+	dv2 = `{"enabled":true,"URL":"","URLUser":"","URLPassword":"","interval":0,"metering":{"tokens":0,"per_time_unit":"","notification_interval":0}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"","URLUser":"","URLPassword":"","interval":0,"metering":{"tokens":0,"per_time_unit":"","notification_interval":0}}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
+	dv1 = `{"enabled":true,"URL":"","URLUser":"","URLPassword":"","interval":0,"metering":{"tokens":0,"per_time_unit":"","notification_interval":0}}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":25}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":60,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":0,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":60,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    // check rate tests
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
+	// check rate tests
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":15,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":15,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":15,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":15,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":0,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":0,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
-    dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":0,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
-    dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
+	dv1 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv2 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"mysecret","interval":30,"check_rate":0,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":0}}`
+	dv3 = `{"enabled":true,"URL":"http://company.com/verify","URLUser":"me","URLPassword":"********","interval":30,"check_rate":10,"metering":{"tokens":3,"per_time_unit":"min","notification_interval":10}}`
 
-    if dva := create_DataVerification(dv1, t); dva != nil {
-        if dvb := create_DataVerification(dv2, t); dvb != nil {
-            if dvc := create_DataVerification(dv3, t); dvc != nil {
-                if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
-                    t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
-                }
-            }
-        }
-    }
+	if dva := create_DataVerification(dv1, t); dva != nil {
+		if dvb := create_DataVerification(dv2, t); dvb != nil {
+			if dvc := create_DataVerification(dv3, t); dvc != nil {
+				if dvm := dva.MergeWith(*dvb, 60); !dvm.IsSame(*dvc) {
+					t.Errorf("Merged DV section %v should be the same as %v\n", dvm, dvc)
+				}
+			}
+		}
+	}
 
 }
 
 func Test_min_max(t *testing.T) {
 
-    if minOf(0,8) == 8 {
-        t.Errorf("0 is min of 8\n")
-    } else if minOf(5,9) == 9 {
-        t.Errorf("5 is min of 9\n")
-    } else if minOf(8,0) == 8 {
-        t.Errorf("0 is min of 8\n")
-    } else if minOf(9,5) == 9 {
-        t.Errorf("5 is min of 9\n")
-    }
+	if minOf(0, 8) == 8 {
+		t.Errorf("0 is min of 8\n")
+	} else if minOf(5, 9) == 9 {
+		t.Errorf("5 is min of 9\n")
+	} else if minOf(8, 0) == 8 {
+		t.Errorf("0 is min of 8\n")
+	} else if minOf(9, 5) == 9 {
+		t.Errorf("5 is min of 9\n")
+	}
 
-    if maxOf(0,8) == 0 {
-        t.Errorf("8 is max of 0\n")
-    } else if maxOf(5,9) == 5 {
-        t.Errorf("9 is max of 5\n")
-    } else if maxOf(8,0) == 0 {
-        t.Errorf("8 is max of 0\n")
-    } else if maxOf(9,5) == 5 {
-        t.Errorf("9 is max of 5\n")
-    }
+	if maxOf(0, 8) == 0 {
+		t.Errorf("8 is max of 0\n")
+	} else if maxOf(5, 9) == 5 {
+		t.Errorf("9 is max of 5\n")
+	} else if maxOf(8, 0) == 0 {
+		t.Errorf("8 is max of 0\n")
+	} else if maxOf(9, 5) == 5 {
+		t.Errorf("9 is max of 5\n")
+	}
 
-    if minOf(0,8) != 0 {
-        t.Errorf("0 is min of 8\n")
-    } else if minOf(5,9) != 5 {
-        t.Errorf("5 is min of 9\n")
-    } else if minOf(8,0) != 0 {
-        t.Errorf("0 is min of 8\n")
-    } else if minOf(9,5) != 5 {
-        t.Errorf("5 is min of 9\n")
-    }
+	if minOf(0, 8) != 0 {
+		t.Errorf("0 is min of 8\n")
+	} else if minOf(5, 9) != 5 {
+		t.Errorf("5 is min of 9\n")
+	} else if minOf(8, 0) != 0 {
+		t.Errorf("0 is min of 8\n")
+	} else if minOf(9, 5) != 5 {
+		t.Errorf("5 is min of 9\n")
+	}
 
-    if maxOf(0,8) != 8 {
-        t.Errorf("8 is max of 0\n")
-    } else if maxOf(5,9) != 9 {
-        t.Errorf("9 is max of 5\n")
-    } else if maxOf(8,0) != 8 {
-        t.Errorf("8 is max of 0\n")
-    } else if maxOf(9,5) != 9 {
-        t.Errorf("9 is max of 5\n")
-    }
+	if maxOf(0, 8) != 8 {
+		t.Errorf("8 is max of 0\n")
+	} else if maxOf(5, 9) != 9 {
+		t.Errorf("9 is max of 5\n")
+	} else if maxOf(8, 0) != 8 {
+		t.Errorf("8 is max of 0\n")
+	} else if maxOf(9, 5) != 9 {
+		t.Errorf("9 is max of 5\n")
+	}
 }
 
 func Test_normalize_tokens(t *testing.T) {
-    if a := normalizeTokens(2, "day"); a != 2 {
-        t.Errorf("Should be 2, was %v\n", a)
-    } else if a := normalizeTokens(2, "hour"); a != 2*24 {
-        t.Errorf("Should be %v, was %v\n", 2*24, a)
-    } else if a := normalizeTokens(2, "min"); a != 2*1440 {
-        t.Errorf("Should be %v, was %v\n", 2*1440, a)
-    }
+	if a := normalizeTokens(2, "day"); a != 2 {
+		t.Errorf("Should be 2, was %v\n", a)
+	} else if a := normalizeTokens(2, "hour"); a != 2*24 {
+		t.Errorf("Should be %v, was %v\n", 2*24, a)
+	} else if a := normalizeTokens(2, "min"); a != 2*1440 {
+		t.Errorf("Should be %v, was %v\n", 2*1440, a)
+	}
 }
 
 func Test_isvalid_meter(t *testing.T) {
 
-    // Valid Tests
-    m1 := Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 300}
-    if !m1.IsValid() {
-        t.Errorf("Meter %v is valid\n", m1)
-    }
+	// Valid Tests
+	m1 := Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 300}
+	if !m1.IsValid() {
+		t.Errorf("Meter %v is valid\n", m1)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 0}
-    if !m1.IsValid() {
-        t.Errorf("Meter %v is valid\n", m1)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 0}
+	if !m1.IsValid() {
+		t.Errorf("Meter %v is valid\n", m1)
+	}
 
-    m1 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    if !m1.IsValid() {
-        t.Errorf("Meter %v is valid\n", m1)
-    }
+	m1 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	if !m1.IsValid() {
+		t.Errorf("Meter %v is valid\n", m1)
+	}
 
-    // Invalid tests
-    m1 = Meter{Tokens: 3, PerTimeUnit: "", NotificationIntervalS: 300}
-    if m1.IsValid() {
-        t.Errorf("Meter %v is not valid\n", m1)
-    }
+	// Invalid tests
+	m1 = Meter{Tokens: 3, PerTimeUnit: "", NotificationIntervalS: 300}
+	if m1.IsValid() {
+		t.Errorf("Meter %v is not valid\n", m1)
+	}
 
-    m1 = Meter{Tokens: 0, PerTimeUnit: "day", NotificationIntervalS: 300}
-    if m1.IsValid() {
-        t.Errorf("Meter %v is not valid\n", m1)
-    }
+	m1 = Meter{Tokens: 0, PerTimeUnit: "day", NotificationIntervalS: 300}
+	if m1.IsValid() {
+		t.Errorf("Meter %v is not valid\n", m1)
+	}
 
-    m1 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 300}
-    if m1.IsValid() {
-        t.Errorf("Meter %v is not valid\n", m1)
-    }
+	m1 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 300}
+	if m1.IsValid() {
+		t.Errorf("Meter %v is not valid\n", m1)
+	}
 
-    m1 = Meter{Tokens: 0, PerTimeUnit: "fred", NotificationIntervalS: 0}
-    if m1.IsValid() {
-        t.Errorf("Meter %v is not valid\n", m1)
-    }
+	m1 = Meter{Tokens: 0, PerTimeUnit: "fred", NotificationIntervalS: 0}
+	if m1.IsValid() {
+		t.Errorf("Meter %v is not valid\n", m1)
+	}
 
 }
 
 func Test_isempty_meter(t *testing.T) {
 
-    m1 := Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    if !m1.IsEmpty() {
-        t.Errorf("Meter %v is empty\n", m1)
-    }
+	m1 := Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	if !m1.IsEmpty() {
+		t.Errorf("Meter %v is empty\n", m1)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 10}
-    if m1.IsEmpty() {
-        t.Errorf("Meter %v is not empty\n", m1)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 10}
+	if m1.IsEmpty() {
+		t.Errorf("Meter %v is not empty\n", m1)
+	}
 
-    m1 = Meter{Tokens: 0, PerTimeUnit: "min", NotificationIntervalS: 10}
-    if m1.IsEmpty() {
-        t.Errorf("Meter %v is not empty\n", m1)
-    }
+	m1 = Meter{Tokens: 0, PerTimeUnit: "min", NotificationIntervalS: 10}
+	if m1.IsEmpty() {
+		t.Errorf("Meter %v is not empty\n", m1)
+	}
 
-    m1 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 10}
-    if m1.IsEmpty() {
-        t.Errorf("Meter %v is not empty\n", m1)
-    }
+	m1 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 10}
+	if m1.IsEmpty() {
+		t.Errorf("Meter %v is not empty\n", m1)
+	}
 
 }
 
 func Test_issame_meter(t *testing.T) {
 
-    // The same
-    m1 := Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    m2 := Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    if !m1.IsSame(m2) {
-        t.Errorf("Meters %v and %v are the same\n", m1, m2)
-    }
+	// The same
+	m1 := Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	m2 := Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	if !m1.IsSame(m2) {
+		t.Errorf("Meters %v and %v are the same\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "", NotificationIntervalS: 0}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "", NotificationIntervalS: 0}
-    if !m1.IsSame(m2) {
-        t.Errorf("Meters %v and %v are the same\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "", NotificationIntervalS: 0}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "", NotificationIntervalS: 0}
+	if !m1.IsSame(m2) {
+		t.Errorf("Meters %v and %v are the same\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 0}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 0}
-    if !m1.IsSame(m2) {
-        t.Errorf("Meters %v and %v are the same\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 0}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 0}
+	if !m1.IsSame(m2) {
+		t.Errorf("Meters %v and %v are the same\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if !m1.IsSame(m2) {
-        t.Errorf("Meters %v and %v are the same\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if !m1.IsSame(m2) {
+		t.Errorf("Meters %v and %v are the same\n", m1, m2)
+	}
 
-    // Not the same
-    m1 = Meter{Tokens: 0, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if m1.IsSame(m2) {
-        t.Errorf("Meters %v and %v are the same\n", m1, m2)
-    }
+	// Not the same
+	m1 = Meter{Tokens: 0, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if m1.IsSame(m2) {
+		t.Errorf("Meters %v and %v are the same\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    if m1.IsSame(m2) {
-        t.Errorf("Meters %v and %v are the same\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	if m1.IsSame(m2) {
+		t.Errorf("Meters %v and %v are the same\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 0}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if m1.IsSame(m2) {
-        t.Errorf("Meters %v and %v are the same\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 0}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if m1.IsSame(m2) {
+		t.Errorf("Meters %v and %v are the same\n", m1, m2)
+	}
 
 }
 
 func Test_isSatisfiedBy_meter(t *testing.T) {
 
-    // Satisfied
-    m1 := Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    m2 := Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	// Satisfied
+	m1 := Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	m2 := Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 4, PerTimeUnit: "min", NotificationIntervalS: 100}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 4, PerTimeUnit: "min", NotificationIntervalS: 100}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 10, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 4, PerTimeUnit: "min", NotificationIntervalS: 100}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 10, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 4, PerTimeUnit: "min", NotificationIntervalS: 100}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 10, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 4, PerTimeUnit: "min", NotificationIntervalS: 100}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 10, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 4, PerTimeUnit: "min", NotificationIntervalS: 100}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 4, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 4, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 10, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 4, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 10, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 4, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 4, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if !m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 4, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if !m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is satisfied by %v.\n", m1, m2)
+	}
 
-    // Not satisfied
-    m1 = Meter{Tokens: 4, PerTimeUnit: "min", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    if m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
-    }
+	// Not satisfied
+	m1 = Meter{Tokens: 4, PerTimeUnit: "min", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	if m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 200, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    if m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 200, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	if m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 4800, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    if m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 4800, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	if m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 4, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    if m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 4, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	if m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 73, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    if m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 73, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	if m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
+	}
 
-    m1 = Meter{Tokens: 4, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if m1.IsSatisfiedBy(m2) {
-        t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
-    }
+	m1 = Meter{Tokens: 4, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if m1.IsSatisfiedBy(m2) {
+		t.Errorf("Meters %v is not satisfied by %v.\n", m1, m2)
+	}
 
 }
 
 // Tests for merging a producer and consumer metering section
 func Test_merge_with_meter(t *testing.T) {
 
-    // Time unit and token calculations
-    m1 := Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    m2 := Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(m1)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, m1)
-    }
+	// Time unit and token calculations
+	m1 := Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	m2 := Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(m1) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, m1)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(m1)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, m1)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(m1) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, m1)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(m1)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, m1)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(m1) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, m1)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    mm := Meter{Tokens: 180, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	mm := Meter{Tokens: 180, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    mm = Meter{Tokens: 4320, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	mm = Meter{Tokens: 4320, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    mm = Meter{Tokens: 72, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "day", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	mm = Meter{Tokens: 72, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 200, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    mm = Meter{Tokens: 200, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 200, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	mm = Meter{Tokens: 200, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 4321, PerTimeUnit: "day", NotificationIntervalS: 100}
-    mm = Meter{Tokens: 4321, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 4321, PerTimeUnit: "day", NotificationIntervalS: 100}
+	mm = Meter{Tokens: 4321, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
-    m2 = Meter{Tokens: 73, PerTimeUnit: "day", NotificationIntervalS: 100}
-    mm = Meter{Tokens: 73, PerTimeUnit: "day", NotificationIntervalS: 100}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "hour", NotificationIntervalS: 100}
+	m2 = Meter{Tokens: 73, PerTimeUnit: "day", NotificationIntervalS: 100}
+	mm = Meter{Tokens: 73, PerTimeUnit: "day", NotificationIntervalS: 100}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    // Notification interval time
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 90}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(m1)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, m1)
-    }
+	// Notification interval time
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 90}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 100}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(m1) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, m1)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
-    mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 10}
-    if am := m1.MergeWith(m2, 0); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
+	mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 10}
+	if am := m1.MergeWith(m2, 0); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
-    mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 10}
-    if am := m1.MergeWith(m2, 10); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
+	mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 10}
+	if am := m1.MergeWith(m2, 10); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
-    mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 30}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
+	mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 30}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
-    mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 0}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
+	mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
-    mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	m2 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
+	mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
-    m2 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
+	m2 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    m2 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    mm = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
-    if am := m1.MergeWith(m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	m2 = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	mm = Meter{Tokens: 0, PerTimeUnit: "", NotificationIntervalS: 0}
+	if am := m1.MergeWith(m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
 }
 
 // Tests for merging 2 producer metering sections.
 func Test_merge_with_meter2(t *testing.T) {
 
-    m1 := Meter{Tokens: 2, PerTimeUnit: "min", NotificationIntervalS: 60}
-    m2 := Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
-    mm := Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
-    if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 := Meter{Tokens: 2, PerTimeUnit: "min", NotificationIntervalS: 60}
+	m2 := Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
+	mm := Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
+	if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
-    m2 = Meter{Tokens: 2, PerTimeUnit: "min", NotificationIntervalS: 60}
-    mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
-    if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
+	m2 = Meter{Tokens: 2, PerTimeUnit: "min", NotificationIntervalS: 60}
+	mm = Meter{Tokens: 3, PerTimeUnit: "min", NotificationIntervalS: 40}
+	if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 0, PerTimeUnit: "min", NotificationIntervalS: 40}
-    m2 = Meter{Tokens: 0, PerTimeUnit: "min", NotificationIntervalS: 60}
-    mm = Meter{Tokens: 0, PerTimeUnit: "min", NotificationIntervalS: 40}
-    if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 0, PerTimeUnit: "min", NotificationIntervalS: 40}
+	m2 = Meter{Tokens: 0, PerTimeUnit: "min", NotificationIntervalS: 60}
+	mm = Meter{Tokens: 0, PerTimeUnit: "min", NotificationIntervalS: 40}
+	if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{}
-    m2 = Meter{}
-    mm = Meter{}
-    if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{}
+	m2 = Meter{}
+	mm = Meter{}
+	if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{}
-    m2 = Meter{Tokens: 1, PerTimeUnit: "min", NotificationIntervalS: 60}
-    mm = Meter{Tokens: 1, PerTimeUnit: "min", NotificationIntervalS: 60}
-    if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{}
+	m2 = Meter{Tokens: 1, PerTimeUnit: "min", NotificationIntervalS: 60}
+	mm = Meter{Tokens: 1, PerTimeUnit: "min", NotificationIntervalS: 60}
+	if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 1, PerTimeUnit: "min", NotificationIntervalS: 60}
-    m2 = Meter{}
-    mm = Meter{Tokens: 1, PerTimeUnit: "min", NotificationIntervalS: 60}
-    if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 1, PerTimeUnit: "min", NotificationIntervalS: 60}
+	m2 = Meter{}
+	mm = Meter{Tokens: 1, PerTimeUnit: "min", NotificationIntervalS: 60}
+	if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 1, PerTimeUnit: "min", NotificationIntervalS: 80}
-    m2 = Meter{Tokens: 1, PerTimeUnit: "hour", NotificationIntervalS: 60}
-    mm = Meter{Tokens: 60, PerTimeUnit: "hour", NotificationIntervalS: 60}
-    if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 1, PerTimeUnit: "min", NotificationIntervalS: 80}
+	m2 = Meter{Tokens: 1, PerTimeUnit: "hour", NotificationIntervalS: 60}
+	mm = Meter{Tokens: 60, PerTimeUnit: "hour", NotificationIntervalS: 60}
+	if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
-    m1 = Meter{Tokens: 1, PerTimeUnit: "day", NotificationIntervalS: 40}
-    m2 = Meter{Tokens: 1, PerTimeUnit: "hour", NotificationIntervalS: 60}
-    mm = Meter{Tokens: 24, PerTimeUnit: "day", NotificationIntervalS: 40}
-    if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm)  {
-        t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
-    }
+	m1 = Meter{Tokens: 1, PerTimeUnit: "day", NotificationIntervalS: 40}
+	m2 = Meter{Tokens: 1, PerTimeUnit: "hour", NotificationIntervalS: 60}
+	mm = Meter{Tokens: 24, PerTimeUnit: "day", NotificationIntervalS: 40}
+	if am := m1.ProducerMergeWith(&m2, 30); !am.IsSame(mm) {
+		t.Errorf("Meter %v was not merged correclty, expecting %v\n", am, mm)
+	}
 
 }
 

--- a/policy/ha_group.go
+++ b/policy/ha_group.go
@@ -1,18 +1,17 @@
 package policy
 
-import (
-)
+import ()
 
 // The purpose of this file is to abstract the operations on the HA Group type.
 
 type HighAvailabilityGroup struct {
-    Partners []string `json:"partners,omitempty"`
+	Partners []string `json:"partners,omitempty"`
 }
 
 // This function creates HAGroup objects
 func HAGroup_Factory(partners []string) *HighAvailabilityGroup {
-    g := new(HighAvailabilityGroup)
-    g.Partners = partners
+	g := new(HighAvailabilityGroup)
+	g.Partners = partners
 
-    return g
+	return g
 }

--- a/policy/policy_file.go
+++ b/policy/policy_file.go
@@ -428,7 +428,7 @@ func (self *Policy) NextHighestPriorityWorkload(currentPriority int, retryCount 
 			// If/when we find the workload entry at the same priority as the input priority, check to see if the
 			// retry count and time since first try indicate that we should stay with the current priority workload.
 			if wl.Priority.PriorityValue == currentPriority {
-				if wl.Priority.Retries > retryCount || now - retryStartTime > uint64(wl.Priority.RetryDurationS) {
+				if wl.Priority.Retries > retryCount || now-retryStartTime > uint64(wl.Priority.RetryDurationS) {
 					nextWorkload = ix
 					foundSomething = true
 					break
@@ -443,7 +443,7 @@ func (self *Policy) NextHighestPriorityWorkload(currentPriority int, retryCount 
 			}
 
 			// If this workload is possibly the next highest priority workload, then remember it.
-			if smallestDelta == 0 || wl.Priority.PriorityValue - currentPriority < smallestDelta {
+			if smallestDelta == 0 || wl.Priority.PriorityValue-currentPriority < smallestDelta {
 				smallestDelta = wl.Priority.PriorityValue - currentPriority
 				nextWorkload = ix
 				foundSomething = true
@@ -465,9 +465,9 @@ func (self *Policy) NextHighestPriorityWorkload(currentPriority int, retryCount 
 
 func (p *Policy) MinimumProtocolVersion(name string, other *Policy, maxSupportedVersion int) int {
 	pv := maxSupportedVersion
-	if prodAGP := p.AgreementProtocols.FindByName(name); prodAGP == nil { 	// This should never happen
+	if prodAGP := p.AgreementProtocols.FindByName(name); prodAGP == nil { // This should never happen
 		return pv
-	} else if conAGP := other.AgreementProtocols.FindByName(name); conAGP == nil { 	// This should never happen
+	} else if conAGP := other.AgreementProtocols.FindByName(name); conAGP == nil { // This should never happen
 		return pv
 	} else {
 		return prodAGP.MinimumProtocolVersion(conAGP, maxSupportedVersion)
@@ -476,7 +476,9 @@ func (p *Policy) MinimumProtocolVersion(name string, other *Policy, maxSupported
 }
 
 func (p *Policy) RequiresDefaultBC(protocol string) bool {
-	if protocol != CitizenScientist { return false }
+	if protocol != CitizenScientist {
+		return false
+	}
 
 	if prodAGP := p.AgreementProtocols.FindByName(protocol); prodAGP == nil {
 		return false
@@ -487,7 +489,9 @@ func (p *Policy) RequiresDefaultBC(protocol string) bool {
 }
 
 func (p *Policy) RequiresKnownBC(protocol string) (string, string) {
-	if protocol != CitizenScientist { return "", "" }
+	if protocol != CitizenScientist {
+		return "", ""
+	}
 
 	if prodAGP := p.AgreementProtocols.FindByName(protocol); prodAGP == nil {
 		return "", ""
@@ -558,12 +562,12 @@ func newWatchEntry(fi os.FileInfo, p *Policy) *WatchEntry {
 // - fileError is called when an error occurs trying to demarshal a file into a policy object
 
 func PolicyFileChangeWatcher(homePath string,
-		contents map[string]*WatchEntry,
-		fileChanged func(fileName string, policy *Policy),
-		fileDeleted func(fileName string, policy *Policy),
-		fileError func(fileName string, err error),
-		workloadResolver func(wURL string, wVersion string, wArch string) (*APISpecList, error),
-		checkInterval int) (map[string]*WatchEntry, error) {
+	contents map[string]*WatchEntry,
+	fileChanged func(fileName string, policy *Policy),
+	fileDeleted func(fileName string, policy *Policy),
+	fileError func(fileName string, err error),
+	workloadResolver func(wURL string, wVersion string, wArch string) (*APISpecList, error),
+	checkInterval int) (map[string]*WatchEntry, error) {
 
 	// contents is the map that holds info on every policy file in the policy directory
 
@@ -607,7 +611,7 @@ func PolicyFileChangeWatcher(homePath string,
 						break
 					}
 				}
-				// If there is another file with our policy in it, then we can skip the delete event but we still have to 
+				// If there is another file with our policy in it, then we can skip the delete event but we still have to
 				// remove the file entry from the contents map.
 				if !found {
 					fileDeleted(homePath+we.FInfo.Name(), we.Pol)

--- a/policy/policy_file_test.go
+++ b/policy/policy_file_test.go
@@ -365,7 +365,7 @@ func Test_Policy_Workload_obscure1(t *testing.T) {
 		t.Error(err)
 	} else {
 		pf_prod1.Workloads[0].WorkloadPassword = "abcdefg"
-		if err := pf_prod1.ObscureWorkloadPWs("123456",""); err != nil {
+		if err := pf_prod1.ObscureWorkloadPWs("123456", ""); err != nil {
 			t.Error(err)
 		} else if pf_prod1.Workloads[0].WorkloadPassword == "abcdefg" {
 			t.Errorf("Password was not obscured in %v", pf_prod1.Workloads[0])
@@ -378,7 +378,7 @@ func Test_Policy_Workload_obscure2(t *testing.T) {
 		t.Error(err)
 	} else {
 		pf_prod1.Workloads[0].WorkloadPassword = "abcdefg"
-		if err := pf_prod1.ObscureWorkloadPWs("","098765"); err != nil {
+		if err := pf_prod1.ObscureWorkloadPWs("", "098765"); err != nil {
 			t.Error(err)
 		} else if pf_prod1.Workloads[0].WorkloadPassword == "abcdefg" {
 			t.Errorf("Password was not obscured in %v", pf_prod1.Workloads[0])
@@ -388,10 +388,10 @@ func Test_Policy_Workload_obscure2(t *testing.T) {
 
 func Test_MinimumProtocolVersion(t *testing.T) {
 
-	var p1,p2 *Policy
+	var p1, p2 *Policy
 
-	pa := `{"agreementProtocols":[{"name":"`+CitizenScientist+`","blockchains":[{"name":"fred"}]}]}`
-	pb := `{"agreementProtocols":[{"name":"`+CitizenScientist+`","blockchains":[{"name":"fred"}]}]}`
+	pa := `{"agreementProtocols":[{"name":"` + CitizenScientist + `","blockchains":[{"name":"fred"}]}]}`
+	pb := `{"agreementProtocols":[{"name":"` + CitizenScientist + `","blockchains":[{"name":"fred"}]}]}`
 
 	if p1 = create_Policy(pa, t); p1 == nil {
 		t.Errorf("Error: returned %v, should have returned %v\n", p1, pa)
@@ -401,8 +401,8 @@ func Test_MinimumProtocolVersion(t *testing.T) {
 		t.Errorf("Error: the min version should be 1 but was %v\n", pv)
 	}
 
-	pa = `{"agreementProtocols":[{"name":"`+CitizenScientist+`","protocolVersion":2}]}`
-	pb = `{"agreementProtocols":[{"name":"`+CitizenScientist+`","protocolVersion":1}]}`
+	pa = `{"agreementProtocols":[{"name":"` + CitizenScientist + `","protocolVersion":2}]}`
+	pb = `{"agreementProtocols":[{"name":"` + CitizenScientist + `","protocolVersion":1}]}`
 
 	if p1 = create_Policy(pa, t); p1 == nil {
 		t.Errorf("Error: returned %v, should have returned %v\n", p1, pa)
@@ -412,8 +412,8 @@ func Test_MinimumProtocolVersion(t *testing.T) {
 		t.Errorf("Error: the min version should be 1 but was %v\n", pv)
 	}
 
-	pa = `{"agreementProtocols":[{"name":"`+CitizenScientist+`","protocolVersion":3}]}`
-	pb = `{"agreementProtocols":[{"name":"`+CitizenScientist+`"}]}`
+	pa = `{"agreementProtocols":[{"name":"` + CitizenScientist + `","protocolVersion":3}]}`
+	pb = `{"agreementProtocols":[{"name":"` + CitizenScientist + `"}]}`
 
 	if p1 = create_Policy(pa, t); p1 == nil {
 		t.Errorf("Error: returned %v, should have returned %v\n", p1, pa)
@@ -423,8 +423,8 @@ func Test_MinimumProtocolVersion(t *testing.T) {
 		t.Errorf("Error: the min version should be 2 but was %v\n", pv)
 	}
 
-	pa = `{"agreementProtocols":[{"name":"`+CitizenScientist+`","protocolVersion":3}]}`
-	pb = `{"agreementProtocols":[{"name":"`+CitizenScientist+`"}]}`
+	pa = `{"agreementProtocols":[{"name":"` + CitizenScientist + `","protocolVersion":3}]}`
+	pb = `{"agreementProtocols":[{"name":"` + CitizenScientist + `"}]}`
 
 	if p1 = create_Policy(pa, t); p1 == nil {
 		t.Errorf("Error: returned %v, should have returned %v\n", p1, pa)
@@ -434,8 +434,8 @@ func Test_MinimumProtocolVersion(t *testing.T) {
 		t.Errorf("Error: the min version should be 3 but was %v\n", pv)
 	}
 
-	pa = `{"agreementProtocols":[{"name":"`+CitizenScientist+`","protocolVersion":2}]}`
-	pb = `{"agreementProtocols":[{"name":"`+CitizenScientist+`","protocolVersion":4}]}`
+	pa = `{"agreementProtocols":[{"name":"` + CitizenScientist + `","protocolVersion":2}]}`
+	pb = `{"agreementProtocols":[{"name":"` + CitizenScientist + `","protocolVersion":4}]}`
 
 	if p1 = create_Policy(pa, t); p1 == nil {
 		t.Errorf("Error: returned %v, should have returned %v\n", p1, pa)

--- a/policy/policy_manager.go
+++ b/policy/policy_manager.go
@@ -528,7 +528,7 @@ func (self *PolicyManager) MergeAllProducers(policies *[]Policy, previouslyMerge
 
 	// Merge all the input policies together
 	var mergedPolicy *Policy
-	for _, pol := range (*policies) {
+	for _, pol := range *policies {
 		if mergedPolicy == nil {
 			mergedPolicy = &pol
 		} else if newPolicy, err := Are_Compatible_Producers(mergedPolicy, &pol, uint64(previouslyMerged.DataVerify.Interval)); err != nil {

--- a/policy/policy_manager_test.go
+++ b/policy/policy_manager_test.go
@@ -189,19 +189,19 @@ func Test_find_by_apispec1(t *testing.T) {
 		t.Error(err)
 	} else {
 		searchURL := "http://mycompany.com/dm/gps"
-		pols := pm.GetPolicyByURL(searchURL,"1.0.0")
+		pols := pm.GetPolicyByURL(searchURL, "1.0.0")
 		if len(pols) != 0 {
 			t.Errorf("Expected to find 0 policy, found %v", len(pols))
 		}
 
 		searchURL = "http://mycompany.com/dm/cpu_temp"
-		pols = pm.GetPolicyByURL(searchURL,"1.0.1")
+		pols = pm.GetPolicyByURL(searchURL, "1.0.1")
 		if len(pols) != 1 {
 			t.Errorf("Expected to find 1 policies, found %v", len(pols))
 		}
 
 		searchURL = ""
-		pols = pm.GetPolicyByURL(searchURL,"1.0.0")
+		pols = pm.GetPolicyByURL(searchURL, "1.0.0")
 		if len(pols) != 0 {
 			t.Errorf("Expected to find 0 policies, found %v", len(pols))
 		}
@@ -319,7 +319,7 @@ func Test_MergeAllProducers1(t *testing.T) {
 		pm := PolicyManager_Factory()
 		if mergedPol, err := pm.MergeAllProducers(&policies, p3); err != nil {
 			t.Errorf("Error: %v merging %v and %v\n", err, p1, p2)
-		} else  if _, err := Are_Compatible_Producers(p3, mergedPol, 600); err != nil {
+		} else if _, err := Are_Compatible_Producers(p3, mergedPol, 600); err != nil {
 			t.Errorf("Error: %v merging %v and %v are not compatible\n", err, p3, mergedPol)
 		} else {
 			t.Logf("Merged Policy from 2 producer policies: %v", mergedPol)
@@ -359,7 +359,7 @@ func Test_MergeAllProducers3(t *testing.T) {
 		pm := PolicyManager_Factory()
 		if mergedPol, err := pm.MergeAllProducers(&policies, p3); err != nil {
 			t.Errorf("Error: %v merging %v with nothing\n", err, p1)
-		} else  if _, err := Are_Compatible_Producers(p3, mergedPol, 600); err != nil {
+		} else if _, err := Are_Compatible_Producers(p3, mergedPol, 600); err != nil {
 			t.Errorf("Error: %v merging %v and %v are not compatible\n", err, p3, mergedPol)
 		} else {
 			t.Logf("Merged Policy from 1 producer policies: %v", mergedPol)

--- a/policy/resourcelimit.go
+++ b/policy/resourcelimit.go
@@ -1,52 +1,52 @@
 package policy
 
 import (
-    "fmt"
+	"fmt"
 )
 
 type ResourceLimit struct {
-    NetworkUpload   int `json:"networkUpload,omitempty"`   // The max network upload allowed to be consumed Kbps
-    NetworkDownload int `json:"networkDownload,omitempty"` // The max network download allowed to be consumed Kbps
-    Memory          int `json:"memory,omitempty"`          // The max memory allowed to be consumed MB
-    CPUs            int `json:"cpus,omitempty"`            // The max number of CPUs allowed to be consumed
+	NetworkUpload   int `json:"networkUpload,omitempty"`   // The max network upload allowed to be consumed Kbps
+	NetworkDownload int `json:"networkDownload,omitempty"` // The max network download allowed to be consumed Kbps
+	Memory          int `json:"memory,omitempty"`          // The max memory allowed to be consumed MB
+	CPUs            int `json:"cpus,omitempty"`            // The max number of CPUs allowed to be consumed
 }
 
 func (r ResourceLimit) String() string {
-    return fmt.Sprintf("NetworkUpload: %v, NetworkDownload: %v, Memory: %v, CPUs: %v", r.NetworkUpload, r.NetworkDownload, r.Memory, r.CPUs)
+	return fmt.Sprintf("NetworkUpload: %v, NetworkDownload: %v, Memory: %v, CPUs: %v", r.NetworkUpload, r.NetworkDownload, r.Memory, r.CPUs)
 }
 
 func (self *ResourceLimit) IsSatisfiedBy(other *ResourceLimit) bool {
 
-    // If the producer doesn't care then it is easily satisfied
-    if other.NetworkUpload != 0 && self.NetworkUpload > other.NetworkUpload {
-        return false
-    } else if other.NetworkDownload != 0 && self.NetworkDownload > other.NetworkDownload {
-        return false
-    } else if other.Memory != 0 && self.Memory > other.Memory {
-        return false
-    } else if other.CPUs != 0 && self.CPUs > other.CPUs {
-        return false
-    }
+	// If the producer doesn't care then it is easily satisfied
+	if other.NetworkUpload != 0 && self.NetworkUpload > other.NetworkUpload {
+		return false
+	} else if other.NetworkDownload != 0 && self.NetworkDownload > other.NetworkDownload {
+		return false
+	} else if other.Memory != 0 && self.Memory > other.Memory {
+		return false
+	} else if other.CPUs != 0 && self.CPUs > other.CPUs {
+		return false
+	}
 
-    return true
+	return true
 }
 
 func (self *ResourceLimit) MergeProducers(other *ResourceLimit) *ResourceLimit {
 
-    max := func(a, b int) int {
-        if a > b {
-            return a
-        } else {
-            return b
-        }
-    }
+	max := func(a, b int) int {
+		if a > b {
+			return a
+		} else {
+			return b
+		}
+	}
 
-    // Setup the new structure to hold the merged limits
-    merged_rl := new(ResourceLimit)
-    merged_rl.NetworkUpload = max(self.NetworkUpload, other.NetworkUpload)
-    merged_rl.NetworkDownload = max(self.NetworkDownload, other.NetworkDownload)
-    merged_rl.Memory = max(self.Memory, other.Memory)
-    merged_rl.CPUs = max(self.CPUs, other.CPUs)
+	// Setup the new structure to hold the merged limits
+	merged_rl := new(ResourceLimit)
+	merged_rl.NetworkUpload = max(self.NetworkUpload, other.NetworkUpload)
+	merged_rl.NetworkDownload = max(self.NetworkDownload, other.NetworkDownload)
+	merged_rl.Memory = max(self.Memory, other.Memory)
+	merged_rl.CPUs = max(self.CPUs, other.CPUs)
 
-    return merged_rl
+	return merged_rl
 }

--- a/policy/version.go
+++ b/policy/version.go
@@ -237,7 +237,7 @@ func IsVersionString(expr string) bool {
 	nums := strings.Split(expr, numberSeperator)
 	if len(nums) == 0 || len(nums) > 3 {
 		return false
-	}  else {
+	} else {
 		for _, val := range nums {
 			if val == "" {
 				return false
@@ -286,7 +286,9 @@ func IsVersionExpression(expr string) bool {
 // Return a normalized version string containing all 3 version numbers. The input version string is ASSUMED to
 // be a valid version string. For example, an input version string of 1 will be returned as 1.0.0
 func normalize(expr string) string {
-	if expr == INF { return expr }
+	if expr == INF {
+		return expr
+	}
 	result := expr
 	nums := strings.Split(expr, numberSeperator)
 	if len(nums) < 3 {

--- a/policy/version_test.go
+++ b/policy/version_test.go
@@ -311,18 +311,18 @@ func TestVersionExpressionFailure(t *testing.T) {
 	}
 }
 
-// This test tests if the version string is a valide string. 
+// This test tests if the version string is a valide string.
 func TestIsVersionString(t *testing.T) {
 	v_good := []string{"1.0", "1.2", "1.234.567", "3.0.0", "234"}
-	for _, v := range(v_good) {
-		if ! IsVersionString(v){
+	for _, v := range v_good {
+		if !IsVersionString(v) {
 			t.Errorf("Version string %v is valid, however the IsVersionString function returned false.\n", v)
 		}
 	}
 
 	v_bad := []string{"1.0.0.1", "1.2.3a", "[1.2, 1.3]", "1.2.3-abc", "1.2.03"}
-	for _, v := range(v_bad) {
-		if IsVersionString(v){
+	for _, v := range v_bad {
+		if IsVersionString(v) {
 			t.Errorf("Version string %v is invalid, however the IsVersionString function returned true.\n", v)
 		}
 	}

--- a/policy/workload.go
+++ b/policy/workload.go
@@ -1,115 +1,115 @@
 package policy
 
 import (
-    "crypto"
-    "crypto/rsa"
-    "crypto/sha256"
-    "crypto/x509"
-    "encoding/base64"
-    "encoding/pem"
-    "errors"
-    "fmt"
-    "github.com/golang/glog"
-    "golang.org/x/crypto/bcrypt"
-    "hash"
-    "io"
-    "io/ioutil"
-    "os"
-    "strings"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"github.com/golang/glog"
+	"golang.org/x/crypto/bcrypt"
+	"hash"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
 )
 
 type Image struct {
-    File      string `json:"file"`
-    Signature string `json:"signature"`
+	File      string `json:"file"`
+	Signature string `json:"signature"`
 }
 
 func (i Image) IsSame(compare Image) bool {
-    return i.File == compare.File && i.Signature == compare.Signature
+	return i.File == compare.File && i.Signature == compare.Signature
 }
 
 type Torrent struct {
-    Url    string  `json:"url"`
-    Images []Image `json:"images"`
+	Url    string  `json:"url"`
+	Images []Image `json:"images"`
 }
 
 func (t Torrent) IsSame(compare Torrent) bool {
-    if t.Url != compare.Url {
-        return false
-    } else {
-        for _, i := range t.Images {
-            found := false
-            for _, compareI := range compare.Images {
-                if i.IsSame(compareI) {
-                    found = true
-                    break
-                }
-            }
-            if !found {
-                return false
-            }
-        }
-        return true
-    }
+	if t.Url != compare.Url {
+		return false
+	} else {
+		for _, i := range t.Images {
+			found := false
+			for _, compareI := range compare.Images {
+				if i.IsSame(compareI) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	}
 }
 
 type WorkloadPriority struct {
-    PriorityValue     int `json:"priority_value,omitempty"`  // The priority of the workload
-    Retries           int `json:"retries,omitempty"`         // The number of retries before giving up and moving to the next priority
-    RetryDurationS    int `json:"retry_durations,omitempty"` // The number of seconds in which the specified number of retries must occur in order for the next priority workload to be attempted.
-    VerifiedDurationS int `json:"verified_durations,omitempty"` // The number of second in which verified data must exist before the rollback retry feature is turned off
+	PriorityValue     int `json:"priority_value,omitempty"`     // The priority of the workload
+	Retries           int `json:"retries,omitempty"`            // The number of retries before giving up and moving to the next priority
+	RetryDurationS    int `json:"retry_durations,omitempty"`    // The number of seconds in which the specified number of retries must occur in order for the next priority workload to be attempted.
+	VerifiedDurationS int `json:"verified_durations,omitempty"` // The number of second in which verified data must exist before the rollback retry feature is turned off
 }
 
 func (wp WorkloadPriority) String() string {
-    return fmt.Sprintf("PriorityValue: %v, " +
-        "Retries: %v, " +
-        "RetryDurationS: %v, " +
-        "VerifiedDurationS: %v",
-        wp.PriorityValue, wp.Retries, wp.RetryDurationS, wp.VerifiedDurationS)
+	return fmt.Sprintf("PriorityValue: %v, "+
+		"Retries: %v, "+
+		"RetryDurationS: %v, "+
+		"VerifiedDurationS: %v",
+		wp.PriorityValue, wp.Retries, wp.RetryDurationS, wp.VerifiedDurationS)
 }
 
 func (wp WorkloadPriority) IsSame(compare WorkloadPriority) bool {
-    return wp.PriorityValue == compare.PriorityValue &&
-            wp.Retries == compare.Retries &&
-            wp.RetryDurationS == compare.RetryDurationS &&
-            wp.VerifiedDurationS == compare.VerifiedDurationS
+	return wp.PriorityValue == compare.PriorityValue &&
+		wp.Retries == compare.Retries &&
+		wp.RetryDurationS == compare.RetryDurationS &&
+		wp.VerifiedDurationS == compare.VerifiedDurationS
 }
 
 type Workload struct {
-    Deployment                   string           `json:"deployment"`
-    DeploymentSignature          string           `json:"deployment_signature"`
-    DeploymentUserInfo           string           `json:"deployment_user_info,omitempty"`
-    Torrent                      Torrent          `json:"torrent"`
-    WorkloadPassword             string           `json:"workload_password,omitempty"` // The password used to create the bcrypt hash that is passed to the workload so that the workload can verify the caller
-    Priority                     WorkloadPriority `json:"priority,omitempty"` // The highest priority workload is tried first for an agrement, if it fails, the next priority is tried. Priority 1 is the highest, priority 2 is next, etc.
-    WorkloadURL                  string           `json:"workloadUrl,omitempty"`  // Added with MS split, refers to a workload definition in the exchange
-    Version                      string           `json:"version,omitempty"`   // Added with MS split, refers to the version of the workload
-    Arch                         string           `json:"arch,omitempty"`     // Added with MS split, refers to the hardware architecture of the workload definition
-    DeploymentOverrides          string           `json:"deployment_overrides,omitempty"`     // Added with MS split, env var overrides for the workload
-    DeploymentOverridesSignature string           `json:"deployment_overrides_signature,omitempty"`   // Added with MS split, signature of env var overrides
+	Deployment                   string           `json:"deployment"`
+	DeploymentSignature          string           `json:"deployment_signature"`
+	DeploymentUserInfo           string           `json:"deployment_user_info,omitempty"`
+	Torrent                      Torrent          `json:"torrent"`
+	WorkloadPassword             string           `json:"workload_password,omitempty"`              // The password used to create the bcrypt hash that is passed to the workload so that the workload can verify the caller
+	Priority                     WorkloadPriority `json:"priority,omitempty"`                       // The highest priority workload is tried first for an agrement, if it fails, the next priority is tried. Priority 1 is the highest, priority 2 is next, etc.
+	WorkloadURL                  string           `json:"workloadUrl,omitempty"`                    // Added with MS split, refers to a workload definition in the exchange
+	Version                      string           `json:"version,omitempty"`                        // Added with MS split, refers to the version of the workload
+	Arch                         string           `json:"arch,omitempty"`                           // Added with MS split, refers to the hardware architecture of the workload definition
+	DeploymentOverrides          string           `json:"deployment_overrides,omitempty"`           // Added with MS split, env var overrides for the workload
+	DeploymentOverridesSignature string           `json:"deployment_overrides_signature,omitempty"` // Added with MS split, signature of env var overrides
 }
 
 func (w Workload) String() string {
-    return fmt.Sprintf("Priority: %v, " +
-        "Deployment: %v, " +
-        "DeploymentSignature: %v, " +
-        "DeploymentUserInfo: %v, " +
-        "Torrent: %v, " +
-        "Workload Password: %v, " +
-        "Workload URL: %v, " +
-        "Version: %v, " +
-        "Arch: %v, " +
-        "Deployment Overrides: %v, " +
-        "Deployment Overrides Signature: %v",
-        w.Priority, w.Deployment, w.DeploymentSignature, w.DeploymentUserInfo, w.Torrent, w.WorkloadPassword,
-        w.WorkloadURL, w.Version, w.Arch, w.DeploymentOverrides, w.DeploymentOverridesSignature)
+	return fmt.Sprintf("Priority: %v, "+
+		"Deployment: %v, "+
+		"DeploymentSignature: %v, "+
+		"DeploymentUserInfo: %v, "+
+		"Torrent: %v, "+
+		"Workload Password: %v, "+
+		"Workload URL: %v, "+
+		"Version: %v, "+
+		"Arch: %v, "+
+		"Deployment Overrides: %v, "+
+		"Deployment Overrides Signature: %v",
+		w.Priority, w.Deployment, w.DeploymentSignature, w.DeploymentUserInfo, w.Torrent, w.WorkloadPassword,
+		w.WorkloadURL, w.Version, w.Arch, w.DeploymentOverrides, w.DeploymentOverridesSignature)
 }
 
 func (w Workload) ShortString() string {
-    return fmt.Sprintf("Priority: %v, " +
-        "Workload URL: %v, " +
-        "Version: %v, " +
-        "Deployment: %v",
-        w.Priority, w.WorkloadURL, w.Version, w.Deployment)
+	return fmt.Sprintf("Priority: %v, "+
+		"Workload URL: %v, "+
+		"Version: %v, "+
+		"Deployment: %v",
+		w.Priority, w.WorkloadURL, w.Version, w.Deployment)
 }
 
 // This function compares 2 workload objects for sameness. This is slightly complicated because 2 workloads can be
@@ -118,159 +118,158 @@ func (w Workload) ShortString() string {
 // ignore comparing the details fields and just stick with a comparison of the URL.
 func (wl Workload) IsSame(compare Workload) bool {
 
-    // Common comparison checks
-    if wl.WorkloadPassword != compare.WorkloadPassword || !wl.Priority.IsSame(compare.Priority) {
-        return false
-    }
+	// Common comparison checks
+	if wl.WorkloadPassword != compare.WorkloadPassword || !wl.Priority.IsSame(compare.Priority) {
+		return false
+	}
 
-    // old style policy file with workload details embedded in it
-    if wl.WorkloadURL == "" {
-        return wl.Deployment == compare.Deployment &&
-            wl.DeploymentSignature == compare.DeploymentSignature &&
-            wl.DeploymentUserInfo == compare.DeploymentUserInfo &&
-            wl.Torrent.IsSame(compare.Torrent)
+	// old style policy file with workload details embedded in it
+	if wl.WorkloadURL == "" {
+		return wl.Deployment == compare.Deployment &&
+			wl.DeploymentSignature == compare.DeploymentSignature &&
+			wl.DeploymentUserInfo == compare.DeploymentUserInfo &&
+			wl.Torrent.IsSame(compare.Torrent)
 
-    } else {
-        return wl.WorkloadURL == compare.WorkloadURL &&
-            wl.Version == compare.Version &&
-            wl.Arch == compare.Arch &&
-            wl.DeploymentOverrides == compare.DeploymentOverrides &&
-            wl.DeploymentOverridesSignature == compare.DeploymentOverridesSignature
-    }
+	} else {
+		return wl.WorkloadURL == compare.WorkloadURL &&
+			wl.Version == compare.Version &&
+			wl.Arch == compare.Arch &&
+			wl.DeploymentOverrides == compare.DeploymentOverrides &&
+			wl.DeploymentOverridesSignature == compare.DeploymentOverridesSignature
+	}
 
 }
 
 func (w *Workload) Obscure(agreementId string, defaultPW string) error {
 
-    if w.WorkloadPassword == "" && defaultPW == "" {
-        return nil
-    }
+	if w.WorkloadPassword == "" && defaultPW == "" {
+		return nil
+	}
 
-    // Workload password in a policy file overrides the default workload PW from the config
-    wpw := w.WorkloadPassword
-    if defaultPW != "" {
-        wpw = defaultPW
-    }
+	// Workload password in a policy file overrides the default workload PW from the config
+	wpw := w.WorkloadPassword
+	if defaultPW != "" {
+		wpw = defaultPW
+	}
 
-    // Convert the workload password into a hash by first concatenating the agreement id onto the end of the password
-    if hash, err := bcrypt.GenerateFromPassword([]byte(wpw + agreementId), bcrypt.DefaultCost); err != nil {
-        return err
-    } else {
-        w.WorkloadPassword = string(hash)
-        return nil
-    }
+	// Convert the workload password into a hash by first concatenating the agreement id onto the end of the password
+	if hash, err := bcrypt.GenerateFromPassword([]byte(wpw+agreementId), bcrypt.DefaultCost); err != nil {
+		return err
+	} else {
+		w.WorkloadPassword = string(hash)
+		return nil
+	}
 }
 
 func (w Workload) HasValidSignature(pubKeyFile string, userKeys string) error {
-    glog.V(3).Infof("Verifying workload signature")
+	glog.V(3).Infof("Verifying workload signature")
 
-    if w.Deployment != "" {
-        hasher := sha256.New()
-        if _, err := io.WriteString(hasher, w.Deployment); err != nil {
-            return errors.New(fmt.Sprintf("Error hashing deployment string: %v, Error: %v", w.Deployment, err))
-        } else if _, err := VerifyWorkload(pubKeyFile, w.DeploymentSignature, hasher, userKeys); err != nil {
-            return errors.New(fmt.Sprintf("Error verifying deployment signature: %v for deployment: %v, Error: %v", w.DeploymentSignature, w.Deployment, err))
-        }
-    }
+	if w.Deployment != "" {
+		hasher := sha256.New()
+		if _, err := io.WriteString(hasher, w.Deployment); err != nil {
+			return errors.New(fmt.Sprintf("Error hashing deployment string: %v, Error: %v", w.Deployment, err))
+		} else if _, err := VerifyWorkload(pubKeyFile, w.DeploymentSignature, hasher, userKeys); err != nil {
+			return errors.New(fmt.Sprintf("Error verifying deployment signature: %v for deployment: %v, Error: %v", w.DeploymentSignature, w.Deployment, err))
+		}
+	}
 
-    if w.DeploymentOverrides == "" {
-        return nil
-    } else {
-        hasher := sha256.New()
-        if _, err := io.WriteString(hasher, w.DeploymentOverrides); err != nil {
-            return errors.New(fmt.Sprintf("Error hashing deployment overrides string: %v, Error: %v", w.DeploymentOverrides, err))
-        } else if _, err := VerifyWorkload(pubKeyFile, w.DeploymentOverridesSignature, hasher, userKeys); err != nil {
-            return errors.New(fmt.Sprintf("Error verifying deployment overrides signature: %v for deployment: %v, Error: %v", w.DeploymentOverridesSignature, w.DeploymentOverrides, err))
-        }
-        return nil
-    }
+	if w.DeploymentOverrides == "" {
+		return nil
+	} else {
+		hasher := sha256.New()
+		if _, err := io.WriteString(hasher, w.DeploymentOverrides); err != nil {
+			return errors.New(fmt.Sprintf("Error hashing deployment overrides string: %v, Error: %v", w.DeploymentOverrides, err))
+		} else if _, err := VerifyWorkload(pubKeyFile, w.DeploymentOverridesSignature, hasher, userKeys); err != nil {
+			return errors.New(fmt.Sprintf("Error verifying deployment overrides signature: %v for deployment: %v, Error: %v", w.DeploymentOverridesSignature, w.DeploymentOverrides, err))
+		}
+		return nil
+	}
 
 }
 
-
 func VerifyWorkload(pubKeyFile string, signature string, hasher hash.Hash, userKeys string) (bool, error) {
 
-    // Decode the signature into its binary form.
-    var signatureBytes []byte
-    if decoded, err := base64.StdEncoding.DecodeString(signature); err != nil {
-        return false, fmt.Errorf("Unable to base64 decode signature %v, error: %v", signature, err)
-    } else {
-        signatureBytes = decoded
-    }
+	// Decode the signature into its binary form.
+	var signatureBytes []byte
+	if decoded, err := base64.StdEncoding.DecodeString(signature); err != nil {
+		return false, fmt.Errorf("Unable to base64 decode signature %v, error: %v", signature, err)
+	} else {
+		signatureBytes = decoded
+	}
 
-    // Compute the public key directory based on the configured platform public key file location.
-    pubKeyDir := pubKeyFile[:strings.LastIndex(pubKeyFile, "/")]
+	// Compute the public key directory based on the configured platform public key file location.
+	pubKeyDir := pubKeyFile[:strings.LastIndex(pubKeyFile, "/")]
 
-    // Grab all PEM files from that location and try to verify the signature against each one.
-    if pemFiles, err := getPemFiles(pubKeyDir); err != nil {
-        return false, err
-    } else if checkAllKeys(pubKeyDir, pemFiles, hasher, signatureBytes) {
-        return true, nil
-    }
+	// Grab all PEM files from that location and try to verify the signature against each one.
+	if pemFiles, err := getPemFiles(pubKeyDir); err != nil {
+		return false, err
+	} else if checkAllKeys(pubKeyDir, pemFiles, hasher, signatureBytes) {
+		return true, nil
+	}
 
-    // Grab all PEM files from that location and try to verify the signature against each one.
-    if pemFiles, err := getPemFiles(userKeys); err != nil {
-        return false, err
-    } else if checkAllKeys(userKeys, pemFiles, hasher,signatureBytes) {
-        return true, nil
-    }
+	// Grab all PEM files from that location and try to verify the signature against each one.
+	if pemFiles, err := getPemFiles(userKeys); err != nil {
+		return false, err
+	} else if checkAllKeys(userKeys, pemFiles, hasher, signatureBytes) {
+		return true, nil
+	}
 
-    return false, fmt.Errorf("No keys found to verify signature %v", signature)
+	return false, fmt.Errorf("No keys found to verify signature %v", signature)
 
 }
 
 func checkAllKeys(pubKeyDir string, pemFiles []os.FileInfo, hasher hash.Hash, signatureBytes []byte) bool {
-    for _, fileInfo := range pemFiles {
-        fName := pubKeyDir + "/" + fileInfo.Name()
-        if publicKey := isValidPublickKey(fName); publicKey == nil {
-            continue
-        } else {
-            // Given a valid public key file, try to verify the signature.
-            glog.V(3).Infof("Using RSA pubkey file: %v and key: %v", fName, publicKey)
+	for _, fileInfo := range pemFiles {
+		fName := pubKeyDir + "/" + fileInfo.Name()
+		if publicKey := isValidPublickKey(fName); publicKey == nil {
+			continue
+		} else {
+			// Given a valid public key file, try to verify the signature.
+			glog.V(3).Infof("Using RSA pubkey file: %v and key: %v", fName, publicKey)
 
-            if err := rsa.VerifyPSS(publicKey.(*rsa.PublicKey), crypto.SHA256, hasher.Sum(nil), signatureBytes, nil); err == nil {
-                return true
-            } else {
-                glog.Warningf("Unable to verify signature using pubkey file: %v, error %v", fName, err)
-            }
-        }
-    }
-    return false
+			if err := rsa.VerifyPSS(publicKey.(*rsa.PublicKey), crypto.SHA256, hasher.Sum(nil), signatureBytes, nil); err == nil {
+				return true
+			} else {
+				glog.Warningf("Unable to verify signature using pubkey file: %v, error %v", fName, err)
+			}
+		}
+	}
+	return false
 }
 
 func isValidPublickKey(fName string) interface{} {
-    if pubKeyData, err := ioutil.ReadFile(fName); err != nil {
-        glog.Warningf("Unable to read key file: %v, error: %v", fName, err)
-    } else if block, _ := pem.Decode(pubKeyData); block == nil {
-        glog.Warningf("Unable to decode key file: %v as PEM encoded file", fName)
-    } else if publicKey, err := x509.ParsePKIXPublicKey(block.Bytes); err != nil {
-        glog.Warningf("Unable to parse key file: %v, as a public key, error: %v", fName, err)
-    } else {
-        return publicKey
-    }
-    return nil
+	if pubKeyData, err := ioutil.ReadFile(fName); err != nil {
+		glog.Warningf("Unable to read key file: %v, error: %v", fName, err)
+	} else if block, _ := pem.Decode(pubKeyData); block == nil {
+		glog.Warningf("Unable to decode key file: %v as PEM encoded file", fName)
+	} else if publicKey, err := x509.ParsePKIXPublicKey(block.Bytes); err != nil {
+		glog.Warningf("Unable to parse key file: %v, as a public key, error: %v", fName, err)
+	} else {
+		return publicKey
+	}
+	return nil
 }
 
 func getPemFiles(homePath string) ([]os.FileInfo, error) {
-    res := make([]os.FileInfo, 0, 10)
+	res := make([]os.FileInfo, 0, 10)
 
-    if files, err := ioutil.ReadDir(homePath); err != nil && !os.IsNotExist(err) {
-        return nil, errors.New(fmt.Sprintf("Unable to get list of PEM files in %v, error: %v", homePath, err))
-    } else if os.IsNotExist(err) {
-        return res, nil
-    } else {
-        for _, fileInfo := range files {
-            if strings.HasSuffix(fileInfo.Name(), ".pem") && !fileInfo.IsDir() {
-                res = append(res, fileInfo)
-            }
-        }
-        return res, nil
-    }
+	if files, err := ioutil.ReadDir(homePath); err != nil && !os.IsNotExist(err) {
+		return nil, errors.New(fmt.Sprintf("Unable to get list of PEM files in %v, error: %v", homePath, err))
+	} else if os.IsNotExist(err) {
+		return res, nil
+	} else {
+		for _, fileInfo := range files {
+			if strings.HasSuffix(fileInfo.Name(), ".pem") && !fileInfo.IsDir() {
+				res = append(res, fileInfo)
+			}
+		}
+		return res, nil
+	}
 }
 
 func (w Workload) HasEmptyPriority() bool {
-    if w.Priority.PriorityValue == 0 && w.Priority.Retries == 0 && w.Priority.RetryDurationS == 0 {
-        return true
-    }
-    return false
+	if w.Priority.PriorityValue == 0 && w.Priority.Retries == 0 && w.Priority.RetryDurationS == 0 {
+		return true
+	}
+	return false
 }

--- a/policy/workload_test.go
+++ b/policy/workload_test.go
@@ -1,65 +1,65 @@
 package policy
 
 import (
-    "bytes"
-    "crypto"
-    crand "crypto/rand"
-    "crypto/rsa"
-    "crypto/sha256"
-    "crypto/x509"
-    "encoding/base64"
-    "encoding/json"
-    "encoding/pem"
-    "golang.org/x/crypto/bcrypt"
-    "math/rand"
-    "os"
-    "testing"
-    "time"
+	"bytes"
+	"crypto"
+	crand "crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"golang.org/x/crypto/bcrypt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
 )
 
 func Test_workload_pw_hash(t *testing.T) {
 
-    random := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+	random := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
 
-    rpw := func (random *rand.Rand) string {
-        var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	rpw := func(random *rand.Rand) string {
+		var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
-        b := make([]rune, 20)
-        for i := range b {
-            b[i] = letters[random.Intn(len(letters))]
-        }
-        return string(b)
-    }
+		b := make([]rune, 20)
+		for i := range b {
+			b[i] = letters[random.Intn(len(letters))]
+		}
+		return string(b)
+	}
 
-    rHash := func(random *rand.Rand) []byte {
-        b := make([]byte, 32, 32)
-        for i := range b {
-            b[i] = byte(random.Intn(256))
-        }
-        return b
-    }
+	rHash := func(random *rand.Rand) []byte {
+		b := make([]byte, 32, 32)
+		for i := range b {
+			b[i] = byte(random.Intn(256))
+		}
+		return b
+	}
 
-    for i := 0; i < 10; i++ {
-        password := rpw(random)
-        // Perform the hash twice
-        if hash1, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); err != nil {
-            t.Error(err)
-        } else if hash2, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); err != nil {
-            t.Error(err)
-        } else if bytes.Compare(hash1, hash2) == 0 {
-            t.Errorf("2 calls to generate hash for %v result in equivalent hashes %v, but should not", password, hash1)
-        } else if err := bcrypt.CompareHashAndPassword(hash1, []byte(password)); err != nil {
-            t.Error(err)
-        } else if err := bcrypt.CompareHashAndPassword(hash2, []byte(password)); err != nil {
-            t.Error(err)
-        }
-    }
+	for i := 0; i < 10; i++ {
+		password := rpw(random)
+		// Perform the hash twice
+		if hash1, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); err != nil {
+			t.Error(err)
+		} else if hash2, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); err != nil {
+			t.Error(err)
+		} else if bytes.Compare(hash1, hash2) == 0 {
+			t.Errorf("2 calls to generate hash for %v result in equivalent hashes %v, but should not", password, hash1)
+		} else if err := bcrypt.CompareHashAndPassword(hash1, []byte(password)); err != nil {
+			t.Error(err)
+		} else if err := bcrypt.CompareHashAndPassword(hash2, []byte(password)); err != nil {
+			t.Error(err)
+		}
+	}
 
-    password := rpw(random)
-    rh := rHash(random)
-    if err := bcrypt.CompareHashAndPassword(rh, []byte(password)); err == nil {
-        t.Errorf("Random hash %v should not verify %v", rh, password)
-    }
+	password := rpw(random)
+	rh := rHash(random)
+	if err := bcrypt.CompareHashAndPassword(rh, []byte(password)); err == nil {
+		t.Errorf("Random hash %v should not verify %v", rh, password)
+	}
 
 }
 
@@ -87,95 +87,94 @@ func Test_workload_pw_hash(t *testing.T) {
 
 func Test_workload_pw_hash_error(t *testing.T) {
 
-    pw := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	pw := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
-    if hash1, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost); err != nil {
-        t.Error(err)
-    } else if len(hash1) == 0 {
-        t.Errorf("bcrypt returned zero length hash\n")
-    } else if err := bcrypt.CompareHashAndPassword(hash1, []byte(pw[:71])); err == nil {
-        t.Errorf("Password was shortened and should not validate, but it did.")
-    }
+	if hash1, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost); err != nil {
+		t.Error(err)
+	} else if len(hash1) == 0 {
+		t.Errorf("bcrypt returned zero length hash\n")
+	} else if err := bcrypt.CompareHashAndPassword(hash1, []byte(pw[:71])); err == nil {
+		t.Errorf("Password was shortened and should not validate, but it did.")
+	}
 
 }
 
-
 func Test_workload_obscure(t *testing.T) {
 
-    wl1 := `{"deployment":"deploymentabcdefg","deployment_signature":"123456","deployment_user_info":"duiabcdefg","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
-    wl2 := `{"deployment":"deploymentabcdefg","deployment_signature":"123456","deployment_user_info":"duiabcdefg","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
-    if wla := create_Workload(wl1, t); wla != nil {
-        wpb4 := wla.WorkloadPassword
-        wla.Obscure("01020304","")
-        if wla.WorkloadPassword == wpb4 {
-            t.Errorf("Workload section %v was not obscured correctly\n", wla)
-        } else if wlb := create_Workload(wl2, t); wlb != nil {
-            if wla.IsSame(*wlb) {
-                t.Errorf("Workload section %v is the same as %v\n", wla, wlb)
-            }
-        } else {
-            wla.Obscure("","05060708")
-            if wla.WorkloadPassword == wpb4 {
-                t.Errorf("Workload section %v was not obscured correctly\n", wla)
-            } else if wlb := create_Workload(wl2, t); wlb != nil {
-                if wla.IsSame(*wlb) {
-                    t.Errorf("Workload section %v is the same as %v\n", wla, wlb)
-                }
-            }
-        }
-    }
+	wl1 := `{"deployment":"deploymentabcdefg","deployment_signature":"123456","deployment_user_info":"duiabcdefg","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+	wl2 := `{"deployment":"deploymentabcdefg","deployment_signature":"123456","deployment_user_info":"duiabcdefg","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+	if wla := create_Workload(wl1, t); wla != nil {
+		wpb4 := wla.WorkloadPassword
+		wla.Obscure("01020304", "")
+		if wla.WorkloadPassword == wpb4 {
+			t.Errorf("Workload section %v was not obscured correctly\n", wla)
+		} else if wlb := create_Workload(wl2, t); wlb != nil {
+			if wla.IsSame(*wlb) {
+				t.Errorf("Workload section %v is the same as %v\n", wla, wlb)
+			}
+		} else {
+			wla.Obscure("", "05060708")
+			if wla.WorkloadPassword == wpb4 {
+				t.Errorf("Workload section %v was not obscured correctly\n", wla)
+			} else if wlb := create_Workload(wl2, t); wlb != nil {
+				if wla.IsSame(*wlb) {
+					t.Errorf("Workload section %v is the same as %v\n", wla, wlb)
+				}
+			}
+		}
+	}
 
 }
 
 func Test_workload_signature(t *testing.T) {
 
-    tempKeyFile := "/tmp/temppolicytestkey.pem"
-    if _, err := os.Stat(tempKeyFile); !os.IsNotExist(err) {
-        os.Remove(tempKeyFile)
-    }
+	tempKeyFile := "/tmp/temppolicytestkey.pem"
+	if _, err := os.Stat(tempKeyFile); !os.IsNotExist(err) {
+		os.Remove(tempKeyFile)
+	}
 
-    // Generate RSA key pair for testing and save in a temporary file
-    if privateKey, err := rsa.GenerateKey(crand.Reader, 2048); err != nil {
-        t.Errorf("Could not generate private key, error %v\n", err)
-    } else if pubFile, err := os.Create(tempKeyFile); err != nil {
-        t.Errorf("Could not create public key file %v, error %v\n", tempKeyFile, err)
-    } else if err := pubFile.Chmod(0600); err != nil {
-        t.Errorf("Could not chmod public key file %v, error %v\n", tempKeyFile, err)
-    } else {
-        publicKey := &privateKey.PublicKey
+	// Generate RSA key pair for testing and save in a temporary file
+	if privateKey, err := rsa.GenerateKey(crand.Reader, 2048); err != nil {
+		t.Errorf("Could not generate private key, error %v\n", err)
+	} else if pubFile, err := os.Create(tempKeyFile); err != nil {
+		t.Errorf("Could not create public key file %v, error %v\n", tempKeyFile, err)
+	} else if err := pubFile.Chmod(0600); err != nil {
+		t.Errorf("Could not chmod public key file %v, error %v\n", tempKeyFile, err)
+	} else {
+		publicKey := &privateKey.PublicKey
 
-        if pubKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey); err != nil {
-            t.Errorf("Could not marshal public key, error %v\n", err)
-        } else {
-            pubEnc := &pem.Block{
-                Type:    "PUBLIC KEY",
-                Headers: nil,
-                Bytes:   pubKeyBytes}
-            if err := pem.Encode(pubFile, pubEnc); err != nil {
-                t.Errorf("Could not encode public key to file, error %v\n", err)
-            } else {
-                pubFile.Close()
-            }
+		if pubKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey); err != nil {
+			t.Errorf("Could not marshal public key, error %v\n", err)
+		} else {
+			pubEnc := &pem.Block{
+				Type:    "PUBLIC KEY",
+				Headers: nil,
+				Bytes:   pubKeyBytes}
+			if err := pem.Encode(pubFile, pubEnc); err != nil {
+				t.Errorf("Could not encode public key to file, error %v\n", err)
+			} else {
+				pubFile.Close()
+			}
 
-            // Sign a simple deployment string and then verify the signature with the workload method
-            hasher := sha256.New()
-            if _, err = hasher.Write([]byte("teststring")); err != nil {
-                t.Errorf("Could not hash the deployment string, error %v\n", err)
-            } else if sig, err := rsa.SignPSS(crand.Reader, privateKey, crypto.SHA256, hasher.Sum(nil), nil); err != nil {
-                t.Errorf("Could not sign test string, error %v\n", err)
-            } else {
-                strSig := base64.StdEncoding.EncodeToString(sig)
-                wl1 := `{"deployment":"teststring","deployment_signature":"","deployment_user_info":"","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
-                if wla := create_Workload(wl1, t); wla != nil {
-                    wla.DeploymentSignature = strSig
-                    if err := wla.HasValidSignature("/tmp/temppolicytestkey.pem", ""); err != nil {
-                        t.Errorf("Could not verify signed deployment, error %v\n", err)
-                    }
-                }
-            }
+			// Sign a simple deployment string and then verify the signature with the workload method
+			hasher := sha256.New()
+			if _, err = hasher.Write([]byte("teststring")); err != nil {
+				t.Errorf("Could not hash the deployment string, error %v\n", err)
+			} else if sig, err := rsa.SignPSS(crand.Reader, privateKey, crypto.SHA256, hasher.Sum(nil), nil); err != nil {
+				t.Errorf("Could not sign test string, error %v\n", err)
+			} else {
+				strSig := base64.StdEncoding.EncodeToString(sig)
+				wl1 := `{"deployment":"teststring","deployment_signature":"","deployment_user_info":"","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+				if wla := create_Workload(wl1, t); wla != nil {
+					wla.DeploymentSignature = strSig
+					if err := wla.HasValidSignature("/tmp/temppolicytestkey.pem", ""); err != nil {
+						t.Errorf("Could not verify signed deployment, error %v\n", err)
+					}
+				}
+			}
 
-        }
-    }
+		}
+	}
 }
 
 // func Test_debug_signature(t *testing.T) {
@@ -197,193 +196,193 @@ func Test_workload_signature(t *testing.T) {
 
 func Test_workload_signature_invalid(t *testing.T) {
 
-    tempKeyFile := "/tmp/temppolicytestkey.pem"
-    if _, err := os.Stat(tempKeyFile); !os.IsNotExist(err) {
-        os.Remove(tempKeyFile)
-    }
+	tempKeyFile := "/tmp/temppolicytestkey.pem"
+	if _, err := os.Stat(tempKeyFile); !os.IsNotExist(err) {
+		os.Remove(tempKeyFile)
+	}
 
-    // Generate RSA key pair for testing and save in a temporary file
-    if privateKey, err := rsa.GenerateKey(crand.Reader, 2048); err != nil {
-        t.Errorf("Could not generate private key, error %v\n", err)
-    } else if pubFile, err := os.Create(tempKeyFile); err != nil {
-        t.Errorf("Could not create public key file %v, error %v\n", tempKeyFile, err)
-    } else if err := pubFile.Chmod(0600); err != nil {
-        t.Errorf("Could not chmod public key file %v, error %v\n", tempKeyFile, err)
-    } else {
-        publicKey := &privateKey.PublicKey
+	// Generate RSA key pair for testing and save in a temporary file
+	if privateKey, err := rsa.GenerateKey(crand.Reader, 2048); err != nil {
+		t.Errorf("Could not generate private key, error %v\n", err)
+	} else if pubFile, err := os.Create(tempKeyFile); err != nil {
+		t.Errorf("Could not create public key file %v, error %v\n", tempKeyFile, err)
+	} else if err := pubFile.Chmod(0600); err != nil {
+		t.Errorf("Could not chmod public key file %v, error %v\n", tempKeyFile, err)
+	} else {
+		publicKey := &privateKey.PublicKey
 
-        if pubKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey); err != nil {
-            t.Errorf("Could not marshal public key, error %v\n", err)
-        } else {
-            pubEnc := &pem.Block{
-                Type:    "PUBLIC KEY",
-                Headers: nil,
-                Bytes:   pubKeyBytes}
-            if err := pem.Encode(pubFile, pubEnc); err != nil {
-                t.Errorf("Could not encode public key to file, error %v\n", err)
-            } else {
-                pubFile.Close()
-            }
+		if pubKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey); err != nil {
+			t.Errorf("Could not marshal public key, error %v\n", err)
+		} else {
+			pubEnc := &pem.Block{
+				Type:    "PUBLIC KEY",
+				Headers: nil,
+				Bytes:   pubKeyBytes}
+			if err := pem.Encode(pubFile, pubEnc); err != nil {
+				t.Errorf("Could not encode public key to file, error %v\n", err)
+			} else {
+				pubFile.Close()
+			}
 
-            // Sign a simple deployment string and then verify the signature with the workload method
-            hasher := sha256.New()
-            if _, err = hasher.Write([]byte("teststringX")); err != nil {
-                t.Errorf("Could not hash the deployment string, error %v\n", err)
-            } else if sig, err := rsa.SignPSS(crand.Reader, privateKey, crypto.SHA256, hasher.Sum(nil), nil); err != nil {
-                t.Errorf("Could not sign test string, error %v\n", err)
-            } else {
-                strSig := base64.StdEncoding.EncodeToString(sig)
-                wl1 := `{"deployment":"teststring","deployment_signature":"","deployment_user_info":"","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
-                if wla := create_Workload(wl1, t); wla != nil {
-                    wla.DeploymentSignature = strSig
-                    if err := wla.HasValidSignature("/tmp/temppolicytestkey.pem", ""); err == nil {
-                        t.Errorf("Should not have been able to verify signed deployment, error %v\n", err)
-                    }
-                }
-            }
+			// Sign a simple deployment string and then verify the signature with the workload method
+			hasher := sha256.New()
+			if _, err = hasher.Write([]byte("teststringX")); err != nil {
+				t.Errorf("Could not hash the deployment string, error %v\n", err)
+			} else if sig, err := rsa.SignPSS(crand.Reader, privateKey, crypto.SHA256, hasher.Sum(nil), nil); err != nil {
+				t.Errorf("Could not sign test string, error %v\n", err)
+			} else {
+				strSig := base64.StdEncoding.EncodeToString(sig)
+				wl1 := `{"deployment":"teststring","deployment_signature":"","deployment_user_info":"","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+				if wla := create_Workload(wl1, t); wla != nil {
+					wla.DeploymentSignature = strSig
+					if err := wla.HasValidSignature("/tmp/temppolicytestkey.pem", ""); err == nil {
+						t.Errorf("Should not have been able to verify signed deployment, error %v\n", err)
+					}
+				}
+			}
 
-        }
-    }
+		}
+	}
 }
 
 func Test_nexthighestpriority_workload1(t *testing.T) {
 
-    wl1 := `{"priority":{"priority_value":3,"retries":2,"retry_durations":5},"deployment":"3","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
-    wl2 := `{"priority":{"priority_value":2,"retries":2,"retry_durations":5},"deployment":"2","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
-    wl3 := `{"priority":{"priority_value":1,"retries":2,"retry_durations":5},"deployment":"1","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+	wl1 := `{"priority":{"priority_value":3,"retries":2,"retry_durations":5},"deployment":"3","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+	wl2 := `{"priority":{"priority_value":2,"retries":2,"retry_durations":5},"deployment":"2","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+	wl3 := `{"priority":{"priority_value":1,"retries":2,"retry_durations":5},"deployment":"1","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
 
-    if wla := create_Workload(wl1, t); wla == nil {
-        t.Errorf("Error unmarshalling Workload json string: %v\n", wl1)
-    } else if wlb := create_Workload(wl2, t); wlb == nil {
-        t.Errorf("Error unmarshalling Workload json string: %v\n", wl2)
-    } else if wlc := create_Workload(wl3, t); wlc == nil {
-        t.Errorf("Error unmarshalling Workload json string: %v\n", wl3)
-    } else {
+	if wla := create_Workload(wl1, t); wla == nil {
+		t.Errorf("Error unmarshalling Workload json string: %v\n", wl1)
+	} else if wlb := create_Workload(wl2, t); wlb == nil {
+		t.Errorf("Error unmarshalling Workload json string: %v\n", wl2)
+	} else if wlc := create_Workload(wl3, t); wlc == nil {
+		t.Errorf("Error unmarshalling Workload json string: %v\n", wl3)
+	} else {
 
-        pf_created := Policy_Factory("test creation")
-        pf_created.Workloads = append(pf_created.Workloads, *wlb)
+		pf_created := Policy_Factory("test creation")
+		pf_created.Workloads = append(pf_created.Workloads, *wlb)
 
-        // Try with 1 workload
-        if wl := pf_created.NextHighestPriorityWorkload(0, 0, 0); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "2" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Try with 1 workload
+		if wl := pf_created.NextHighestPriorityWorkload(0, 0, 0); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "2" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Now add multiple workloads
-        pf_created.Workloads = append(pf_created.Workloads, *wla)
-        pf_created.Workloads = append(pf_created.Workloads, *wlc)
+		// Now add multiple workloads
+		pf_created.Workloads = append(pf_created.Workloads, *wla)
+		pf_created.Workloads = append(pf_created.Workloads, *wlc)
 
-        // Find priority 1 workload
-        if wl := pf_created.NextHighestPriorityWorkload(0, 0, 0); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "1" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Find priority 1 workload
+		if wl := pf_created.NextHighestPriorityWorkload(0, 0, 0); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "1" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Find priority 1 again
-        if wl := pf_created.NextHighestPriorityWorkload(1, 1, 1000); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "1" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Find priority 1 again
+		if wl := pf_created.NextHighestPriorityWorkload(1, 1, 1000); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "1" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Move to priority 2 due to retries
-        now := uint64(time.Now().Unix())
-        if wl := pf_created.NextHighestPriorityWorkload(1, 2, now-1); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "2" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Move to priority 2 due to retries
+		now := uint64(time.Now().Unix())
+		if wl := pf_created.NextHighestPriorityWorkload(1, 2, now-1); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "2" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Stay with priority 2
-        if wl := pf_created.NextHighestPriorityWorkload(2, 1, now-1); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "2" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Stay with priority 2
+		if wl := pf_created.NextHighestPriorityWorkload(2, 1, now-1); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "2" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Stay with priority 2 - not enough retries in the alloted retry duration
-        if wl := pf_created.NextHighestPriorityWorkload(2, 2, now-6); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "2" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Stay with priority 2 - not enough retries in the alloted retry duration
+		if wl := pf_created.NextHighestPriorityWorkload(2, 2, now-6); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "2" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Move to priority 3
-        if wl := pf_created.NextHighestPriorityWorkload(2, 2, now-1); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "3" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Move to priority 3
+		if wl := pf_created.NextHighestPriorityWorkload(2, 2, now-1); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "3" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Stay with priority 3 - not enough retries yet
-        if wl := pf_created.NextHighestPriorityWorkload(3, 0, now-1); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "3" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Stay with priority 3 - not enough retries yet
+		if wl := pf_created.NextHighestPriorityWorkload(3, 0, now-1); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "3" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Stay with priority 3 - not enough retries yet
-        if wl := pf_created.NextHighestPriorityWorkload(3, 1, now-1); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "3" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Stay with priority 3 - not enough retries yet
+		if wl := pf_created.NextHighestPriorityWorkload(3, 1, now-1); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "3" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Stay with priority 3 - retries exceeded but not in the time limit
-        if wl := pf_created.NextHighestPriorityWorkload(3, 2, now-10); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "3" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Stay with priority 3 - retries exceeded but not in the time limit
+		if wl := pf_created.NextHighestPriorityWorkload(3, 2, now-10); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "3" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Stay with priority 3 - retries exceeded but lowest priority workload
-        if wl := pf_created.NextHighestPriorityWorkload(3, 2, now-1); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "3" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Stay with priority 3 - retries exceeded but lowest priority workload
+		if wl := pf_created.NextHighestPriorityWorkload(3, 2, now-1); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "3" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-        // Stay with priority 3 - retries exceeded but lowest priority workload
-        if wl := pf_created.NextHighestPriorityWorkload(3, 3, now-1); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "3" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Stay with priority 3 - retries exceeded but lowest priority workload
+		if wl := pf_created.NextHighestPriorityWorkload(3, 3, now-1); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "3" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-    }
+	}
 
 }
 
 func Test_nexthighestpriority_workload2(t *testing.T) {
 
-    wl1 := `{"priority":{"priority_value":3,"retries":2,"retry_durations":5},"deployment":"3","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
-    wl2 := `{"priority":{"priority_value":2,"retries":0,"retry_durations":5},"deployment":"2","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
-    wl3 := `{"priority":{"priority_value":1,"retries":2,"retry_durations":5},"deployment":"1","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+	wl1 := `{"priority":{"priority_value":3,"retries":2,"retry_durations":5},"deployment":"3","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+	wl2 := `{"priority":{"priority_value":2,"retries":0,"retry_durations":5},"deployment":"2","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
+	wl3 := `{"priority":{"priority_value":1,"retries":2,"retry_durations":5},"deployment":"1","deployment_signature":"1","deployment_user_info":"d","torrent":{"url":"torrURL","images":[{"file":"filename","signature":"abcdefg"}]},"workload_password":"mysecret"}`
 
-    if wla := create_Workload(wl1, t); wla == nil {
-        t.Errorf("Error unmarshalling Workload json string: %v\n", wl1)
-    } else if wlb := create_Workload(wl2, t); wlb == nil {
-        t.Errorf("Error unmarshalling Workload json string: %v\n", wl2)
-    } else if wlc := create_Workload(wl3, t); wlc == nil {
-        t.Errorf("Error unmarshalling Workload json string: %v\n", wl3)
-    } else {
+	if wla := create_Workload(wl1, t); wla == nil {
+		t.Errorf("Error unmarshalling Workload json string: %v\n", wl1)
+	} else if wlb := create_Workload(wl2, t); wlb == nil {
+		t.Errorf("Error unmarshalling Workload json string: %v\n", wl2)
+	} else if wlc := create_Workload(wl3, t); wlc == nil {
+		t.Errorf("Error unmarshalling Workload json string: %v\n", wl3)
+	} else {
 
-        pf_created := Policy_Factory("test creation")
-        pf_created.Workloads = append(pf_created.Workloads, *wlb)
-        pf_created.Workloads = append(pf_created.Workloads, *wla)
-        pf_created.Workloads = append(pf_created.Workloads, *wlc)
+		pf_created := Policy_Factory("test creation")
+		pf_created.Workloads = append(pf_created.Workloads, *wlb)
+		pf_created.Workloads = append(pf_created.Workloads, *wla)
+		pf_created.Workloads = append(pf_created.Workloads, *wlc)
 
-        // Find priority 3 workload
-        now := uint64(time.Now().Unix())
-        if wl := pf_created.NextHighestPriorityWorkload(2, 1, now-1); wl == nil {
-            t.Errorf("Error finding highest priority workload.\n")
-        } else if wl.Deployment != "3" {
-            t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
-        }
+		// Find priority 3 workload
+		now := uint64(time.Now().Unix())
+		if wl := pf_created.NextHighestPriorityWorkload(2, 1, now-1); wl == nil {
+			t.Errorf("Error finding highest priority workload.\n")
+		} else if wl.Deployment != "3" {
+			t.Errorf("Returned workload is not the next highest priority, returned %v", wl)
+		}
 
-    }
+	}
 
 }
 
@@ -391,12 +390,12 @@ func Test_nexthighestpriority_workload2(t *testing.T) {
 // does not have to be a valid Workload serialization, just has to be a valid
 // JSON serialization.
 func create_Workload(jsonString string, t *testing.T) *Workload {
-    wl := new(Workload)
+	wl := new(Workload)
 
-    if err := json.Unmarshal([]byte(jsonString), &wl); err != nil {
-        t.Errorf("Error unmarshalling Workload json string: %v error:%v\n", jsonString, err)
-        return nil
-    } else {
-        return wl
-    }
+	if err := json.Unmarshal([]byte(jsonString), &wl); err != nil {
+		t.Errorf("Error unmarshalling Workload json string: %v error:%v\n", jsonString, err)
+		return nil
+	} else {
+		return wl
+	}
 }

--- a/producer/basic_protocol_handler.go
+++ b/producer/basic_protocol_handler.go
@@ -11,8 +11,6 @@ import (
 	"github.com/open-horizon/anax/persistence"
 	"github.com/open-horizon/anax/policy"
 	"github.com/open-horizon/anax/worker"
-	"net/http"
-	"time"
 )
 
 type BasicProtocolHandler struct {
@@ -24,15 +22,14 @@ func NewBasicProtocolHandler(name string, cfg *config.HorizonConfig, db *bolt.DB
 	if name == basicprotocol.PROTOCOL_NAME {
 		return &BasicProtocolHandler{
 			BaseProducerProtocolHandler: &BaseProducerProtocolHandler{
-				name:       name,
-				pm:         pm,
-				db:         db,
-				config:     cfg,
-				deviceId:   deviceId,
-				token:      token,
-				httpClient: &http.Client{Timeout: time.Duration(config.HTTPDEFAULTTIMEOUT * time.Millisecond)},
+				name:     name,
+				pm:       pm,
+				db:       db,
+				config:   cfg,
+				deviceId: deviceId,
+				token:    token,
 			},
-			agreementPH: basicprotocol.NewProtocolHandler(pm),
+			agreementPH: basicprotocol.NewProtocolHandler(cfg.Collaborators.HTTPClientFactory.NewHTTPClient(nil), pm),
 		}
 	} else {
 		return nil

--- a/producer/cs_protocol_handler_test.go
+++ b/producer/cs_protocol_handler_test.go
@@ -1,155 +1,154 @@
 package producer
 
 import (
-    "encoding/json"
-    "github.com/open-horizon/anax/citizenscientist"
-    "github.com/open-horizon/anax/persistence"
-    "github.com/open-horizon/anax/policy"
-    "os"
-    "testing"
+	"encoding/json"
+	"github.com/open-horizon/anax/citizenscientist"
+	"github.com/open-horizon/anax/persistence"
+	"github.com/open-horizon/anax/policy"
+	"os"
+	"testing"
 )
 
 func Test_agreement_with_override(t *testing.T) {
 
-    expectedType := policy.Ethereum_bc
-    expectedName := "ethel"
+	expectedType := policy.Ethereum_bc
+	expectedName := "ethel"
 
-    testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
-    testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist"}]}`
+	testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist"}]}`
 
-    os.Setenv("CMTN_BLOCKCHAIN", "ethel")
-    if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
-        t.Errorf("Error creating mock agreement, %v", err)
-    } else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
-        t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
-    }
-    os.Setenv("CMTN_BLOCKCHAIN", "")
+	os.Setenv("CMTN_BLOCKCHAIN", "ethel")
+	if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
+		t.Errorf("Error creating mock agreement, %v", err)
+	} else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
+		t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
+	}
+	os.Setenv("CMTN_BLOCKCHAIN", "")
 
 }
 
 func Test_old_agreement_success(t *testing.T) {
 
-    expectedType := policy.Ethereum_bc
-    expectedName := policy.Default_Blockchain_name
+	expectedType := policy.Ethereum_bc
+	expectedName := policy.Default_Blockchain_name
 
-    testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
-    testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist"}]}`
+	testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist"}]}`
 
-    if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
-        t.Errorf("Error creating mock agreement, %v", err)
-    } else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
-        t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
-    }
+	if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
+		t.Errorf("Error creating mock agreement, %v", err)
+	} else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
+		t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
+	}
 
 }
 
 func Test_new_agreement_success1(t *testing.T) {
 
-    expectedType := "fred"
-    expectedName := "ethel"
+	expectedType := "fred"
+	expectedName := "ethel"
 
-    testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
-    testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"}]}]}`
+	testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"}]}]}`
 
-    if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
-        t.Errorf("Error creating mock agreement, %v", err)
-    } else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
-        t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
-    }
+	if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
+		t.Errorf("Error creating mock agreement, %v", err)
+	} else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
+		t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
+	}
 
 }
 
 func Test_new_agreement_success2(t *testing.T) {
 
-    expectedType := "fred"
-    expectedName := "ethel"
+	expectedType := "fred"
+	expectedName := "ethel"
 
-    testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
-    testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"},{"type":"lucy","name":"dezi"}]}]}`
+	testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"},{"type":"lucy","name":"dezi"}]}]}`
 
-    if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
-        t.Errorf("Error creating mock agreement, %v", err)
-    } else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
-        t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
-    }
+	if ag, err := createAgreement(testProposal, testPolicy, 0, "", ""); err != nil {
+		t.Errorf("Error creating mock agreement, %v", err)
+	} else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
+		t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
+	}
 
 }
 
 func Test_new_agreement_success3(t *testing.T) {
 
-    expectedType := "fred"
-    expectedName := "ethel"
+	expectedType := "fred"
+	expectedName := "ethel"
 
-    testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
-    testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"},{"type":"lucy","name":"dezi"}]}]}`
+	testProposal := `{"address":"123456","producerPolicy":"policy","consumerId":"ag12345","type":"proposal","protocol":"Citizen Scientist","version":1,"agreementId":"deadbeef"}`
+	testPolicy := `{"header":{"name":"testpolicy","version":"1.0"},"agreementProtocols":[{"name":"Citizen Scientist","blockchains":[{"type":"fred","name":"ethel"},{"type":"lucy","name":"dezi"}]}]}`
 
-    if ag, err := createAgreement(testProposal, testPolicy, 2, expectedType, expectedName); err != nil {
-        t.Errorf("Error creating mock agreement, %v", err)
-    } else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
-        t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
-    }
+	if ag, err := createAgreement(testProposal, testPolicy, 2, expectedType, expectedName); err != nil {
+		t.Errorf("Error creating mock agreement, %v", err)
+	} else if bcType, bcName := createEmptyPH().GetKnownBlockchain(ag); bcType != expectedType || bcName != expectedName {
+		t.Errorf("Wrong BC type %v and name %v returned, expecting %v %v", bcType, bcName, expectedType, expectedName)
+	}
 
 }
 
 // Utility to help create the testing context
 func createEmptyPH() *CSProtocolHandler {
-    return &CSProtocolHandler{
-            BaseProducerProtocolHandler: &BaseProducerProtocolHandler{
-                name:       "test",
-                pm:         nil,
-                db:         nil,
-                config:     nil,
-                deviceId:   "an12345",
-                token:      "abcdefg",
-                httpClient: nil,
-            },
-            genericAgreementPH: nil,
-            bcState:            nil,
-        }
+	return &CSProtocolHandler{
+		BaseProducerProtocolHandler: &BaseProducerProtocolHandler{
+			name:       "test",
+			pm:         nil,
+			db:         nil,
+			config:     nil,
+			deviceId:   "an12345",
+			token:      "abcdefg",
+			httpClient: nil,
+		},
+		genericAgreementPH: nil,
+		bcState:            nil,
+	}
 }
 
 func createAgreement(proposal string, pol string, agpVersion int, bcType string, bcName string) (*persistence.EstablishedAgreement, error) {
 
-    ag := &persistence.EstablishedAgreement{
-        Name:                            "",
-        SensorUrl:                       []string{""},
-        Archived:                        false,
-        CurrentAgreementId:              "",
-        ConsumerId:                      "",
-        CounterPartyAddress:             "",
-        AgreementCreationTime:           0,
-        AgreementAcceptedTime:           0,
-        AgreementBCUpdateAckTime:        0,
-        AgreementFinalizedTime:          0,
-        AgreementTerminatedTime:         0,
-        AgreementForceTerminatedTime:    0,
-        AgreementExecutionStartTime:     0,
-        AgreementDataReceivedTime:       0,
-        CurrentDeployment:               nil,
-        Proposal:                        "",
-        ProposalSig:                     "",
-        AgreementProtocol:               "Citizen Scientist",
-        ProtocolVersion:                 agpVersion,
-        TerminatedReason:                0,
-        TerminatedDescription:           "",
-        AgreementProtocolTerminatedTime: 0,
-        WorkloadTerminatedTime:          0,
-        MeteringNotificationMsg:         persistence.MeteringNotification{},
-        BlockchainType:                  bcType,
-        BlockchainName:                  bcName,
-    }
+	ag := &persistence.EstablishedAgreement{
+		Name:                            "",
+		SensorUrl:                       []string{""},
+		Archived:                        false,
+		CurrentAgreementId:              "",
+		ConsumerId:                      "",
+		CounterPartyAddress:             "",
+		AgreementCreationTime:           0,
+		AgreementAcceptedTime:           0,
+		AgreementBCUpdateAckTime:        0,
+		AgreementFinalizedTime:          0,
+		AgreementTerminatedTime:         0,
+		AgreementForceTerminatedTime:    0,
+		AgreementExecutionStartTime:     0,
+		AgreementDataReceivedTime:       0,
+		CurrentDeployment:               nil,
+		Proposal:                        "",
+		ProposalSig:                     "",
+		AgreementProtocol:               "Citizen Scientist",
+		ProtocolVersion:                 agpVersion,
+		TerminatedReason:                0,
+		TerminatedDescription:           "",
+		AgreementProtocolTerminatedTime: 0,
+		WorkloadTerminatedTime:          0,
+		MeteringNotificationMsg:         persistence.MeteringNotification{},
+		BlockchainType:                  bcType,
+		BlockchainName:                  bcName,
+	}
 
-    prop := new(citizenscientist.CSProposal)
-    if err := json.Unmarshal([]byte(proposal), prop); err != nil {
-        return nil, err
-    } else {
-        prop.TsandCs = pol
-        if propString, err := json.Marshal(prop); err != nil {
-            return nil, err
-        } else {
-            ag.Proposal = string(propString)
-            return ag, nil
-        }
-    }
+	prop := new(citizenscientist.CSProposal)
+	if err := json.Unmarshal([]byte(proposal), prop); err != nil {
+		return nil, err
+	} else {
+		prop.TsandCs = pol
+		if propString, err := json.Marshal(prop); err != nil {
+			return nil, err
+		} else {
+			ag.Proposal = string(propString)
+			return ag, nil
+		}
+	}
 }
-

--- a/torrent/signature_verify_test.go
+++ b/torrent/signature_verify_test.go
@@ -1,96 +1,96 @@
 package torrent
 
 import (
-    "crypto"
-    "crypto/rand"
-    "crypto/rsa"
-    "crypto/sha256"
-    "crypto/x509"
-    "encoding/base64"
-    "encoding/pem"
-    "github.com/open-horizon/anax/config"
-    "io"
-    "io/ioutil"
-    "os"
-    "testing"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"github.com/open-horizon/anax/config"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
 )
 
 func Test_verify(t *testing.T) {
 
-    filePath := "/tmp/torrentsigtestfile.txt"
+	filePath := "/tmp/torrentsigtestfile.txt"
 
-    if _, err := os.Stat(filePath); !os.IsNotExist(err) {
-        os.Remove(filePath)
-    }
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		os.Remove(filePath)
+	}
 
-    if _, err := os.Stat("/tmp" + config.USERKEYDIR); !os.IsNotExist(err) {
-        os.RemoveAll("/tmp" + config.USERKEYDIR)
-    }
+	if _, err := os.Stat("/tmp" + config.USERKEYDIR); !os.IsNotExist(err) {
+		os.RemoveAll("/tmp" + config.USERKEYDIR)
+	}
 
-    bytes := []byte(`some text in this file to be signed by a torrent test case.`)
-    if err := ioutil.WriteFile(filePath, bytes, 0644); err != nil {
-        t.Errorf("Could not create sig test file %v, error %v\n", filePath, err)
-    } 
+	bytes := []byte(`some text in this file to be signed by a torrent test case.`)
+	if err := ioutil.WriteFile(filePath, bytes, 0644); err != nil {
+		t.Errorf("Could not create sig test file %v, error %v\n", filePath, err)
+	}
 
-    publicFilePath := "/tmp/somekey.pem"
-    os.MkdirAll("/tmp" + config.USERKEYDIR, 0777)
+	publicFilePath := "/tmp/somekey.pem"
+	os.MkdirAll("/tmp"+config.USERKEYDIR, 0777)
 
-    tempKeyFile := "/tmp" + config.USERKEYDIR + "/tempverifysigtestkey.pem"
-    if _, err := os.Stat(tempKeyFile); !os.IsNotExist(err) {
-        os.Remove(tempKeyFile)
-    }
+	tempKeyFile := "/tmp" + config.USERKEYDIR + "/tempverifysigtestkey.pem"
+	if _, err := os.Stat(tempKeyFile); !os.IsNotExist(err) {
+		os.Remove(tempKeyFile)
+	}
 
-    // Generate RSA key pair for testing and save in a temporary file
-    if privateKey, err := rsa.GenerateKey(rand.Reader, 2048); err != nil {
-        t.Errorf("Could not generate private key, error %v\n", err)
-    } else if pubFile, err := os.Create(tempKeyFile); err != nil {
-        t.Errorf("Could not create public key file %v, error %v\n", tempKeyFile, err)
-    } else if err := pubFile.Chmod(0600); err != nil {
-        t.Errorf("Could not chmod public key file %v, error %v\n", tempKeyFile, err)
-    } else {
-        publicKey := &privateKey.PublicKey
+	// Generate RSA key pair for testing and save in a temporary file
+	if privateKey, err := rsa.GenerateKey(rand.Reader, 2048); err != nil {
+		t.Errorf("Could not generate private key, error %v\n", err)
+	} else if pubFile, err := os.Create(tempKeyFile); err != nil {
+		t.Errorf("Could not create public key file %v, error %v\n", tempKeyFile, err)
+	} else if err := pubFile.Chmod(0600); err != nil {
+		t.Errorf("Could not chmod public key file %v, error %v\n", tempKeyFile, err)
+	} else {
+		publicKey := &privateKey.PublicKey
 
-        if pubKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey); err != nil {
-            t.Errorf("Could not marshal public key, error %v\n", err)
-        } else {
-            pubEnc := &pem.Block{
-                Type:    "PUBLIC KEY",
-                Headers: nil,
-                Bytes:   pubKeyBytes}
-            if err := pem.Encode(pubFile, pubEnc); err != nil {
-                t.Errorf("Could not encode public key to file, error %v\n", err)
-            } else {
-                pubFile.Close()
-            }
-        }
+		if pubKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey); err != nil {
+			t.Errorf("Could not marshal public key, error %v\n", err)
+		} else {
+			pubEnc := &pem.Block{
+				Type:    "PUBLIC KEY",
+				Headers: nil,
+				Bytes:   pubKeyBytes}
+			if err := pem.Encode(pubFile, pubEnc); err != nil {
+				t.Errorf("Could not encode public key to file, error %v\n", err)
+			} else {
+				pubFile.Close()
+			}
+		}
 
-        if file, err := os.Open(filePath); err != nil {
-            t.Errorf("Unable to open file %v, error: %v", filePath, err)
-        } else {
+		if file, err := os.Open(filePath); err != nil {
+			t.Errorf("Unable to open file %v, error: %v", filePath, err)
+		} else {
 
-            hasher := sha256.New()
-            if _, err := io.Copy(hasher, file); err != nil {
-                t.Errorf("Unable to copy file into hash function, error: %v", err)
-            } else {
-                file.Close()
+			hasher := sha256.New()
+			if _, err := io.Copy(hasher, file); err != nil {
+				t.Errorf("Unable to copy file into hash function, error: %v", err)
+			} else {
+				file.Close()
 
-                if signature, err := rsa.SignPSS(rand.Reader, privateKey, crypto.SHA256, hasher.Sum(nil), nil); err != nil {
-                    t.Errorf("Error signing the message, error: %v", err)
-                } else if len(signature) == 0 {
-                    t.Errorf("Error signing the message, signature is empty byte array")
-                } else {
-                    encoded := base64.StdEncoding.EncodeToString(signature)
+				if signature, err := rsa.SignPSS(rand.Reader, privateKey, crypto.SHA256, hasher.Sum(nil), nil); err != nil {
+					t.Errorf("Error signing the message, error: %v", err)
+				} else if len(signature) == 0 {
+					t.Errorf("Error signing the message, signature is empty byte array")
+				} else {
+					encoded := base64.StdEncoding.EncodeToString(signature)
 
-                    if file, err := os.Open(filePath); err != nil {
-                        t.Errorf("Unable to open file %v, error: %v", filePath, err)
-                    } else if verified, err := verify(publicFilePath, "/tmp" + config.USERKEYDIR, encoded, file); err != nil {
-                        t.Errorf("No verification: %v", err)
-                    } else if !verified {
-                        t.Errorf("No verification")   
-                    }
-                }
-            }
-        }
-    }
+					if file, err := os.Open(filePath); err != nil {
+						t.Errorf("Unable to open file %v, error: %v", filePath, err)
+					} else if verified, err := verify(publicFilePath, "/tmp"+config.USERKEYDIR, encoded, file); err != nil {
+						t.Errorf("No verification: %v", err)
+					} else if !verified {
+						t.Errorf("No verification")
+					}
+				}
+			}
+		}
+	}
 
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -5,7 +5,7 @@ import (
 	"github.com/open-horizon/anax/events"
 )
 
-type Command interface{
+type Command interface {
 	ShortString() string
 }
 


### PR DESCRIPTION
Note the inclusion of the new configuration parameter, `TrustSystemCACerts` which, if enabled, will cause the HTTPClientFactory to include a Linux distribution's CA Certificate bundle (like ones in `/usr/share/ssl/certs/ca-bundle.crt` on CentOS) in the TLS cert pool configuration during Anax's configuration init. This does not preclude the use of our bundled trust store in the distributed package.

Also, not that this PR branched from reformatting work in PR #320 ; to isolate the changes from this PR only, use the Commits tab.