### PR TITLE
Issue 308 - Support patterns in agbot and nodes

### DIFF
--- a/agreementbot/api.go
+++ b/agreementbot/api.go
@@ -231,7 +231,7 @@ func (a *API) policyUpgrade(w http.ResponseWriter, r *http.Request) {
 		// Verify the input policy name. It can be either the name of the policy within the header of the policy file or the name
 		// of the file itself.
 		found := false
-		if pm, err := policy.Initialize(a.Config.AgreementBot.PolicyPath, workloadResolver); err != nil {
+		if pm, err := policy.Initialize(a.Config.AgreementBot.PolicyPath, workloadResolver, false); err != nil {
 			glog.Error(APIlogString(fmt.Sprintf("error initializing policy manager, error: %v", err)))
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/agreementbot/basic_agreement_worker.go
+++ b/agreementbot/basic_agreement_worker.go
@@ -56,7 +56,7 @@ func (a *BasicAgreementWorker) start(work chan AgreementWork, random *rand.Rand)
 					// Update state in exchange
 				} else if pol, err := policy.DemarshalPolicy(ag.Policy); err != nil {
 					glog.Errorf(bwlogstring(a.workerID, fmt.Sprintf("error demarshalling policy from agreement %v, error: %v", wi.Reply.AgreementId(), err)))
-				} else if err := a.protocolHandler.RecordConsumerAgreementState(wi.Reply.AgreementId(), pol, "Finalized Agreement", a.workerID); err != nil {
+				} else if err := a.protocolHandler.RecordConsumerAgreementState(wi.Reply.AgreementId(), pol, ag.Org, "Finalized Agreement", a.workerID); err != nil {
 					glog.Errorf(bwlogstring(a.workerID, fmt.Sprintf("error setting agreement %v finalized state in exchange: %v", wi.Reply.AgreementId(), err)))
 				}
 			}

--- a/agreementbot/basic_protocol_handler.go
+++ b/agreementbot/basic_protocol_handler.go
@@ -174,9 +174,9 @@ func (c *BasicProtocolHandler) HandleDeferredCommands() {
 	return
 }
 
-func (b *BasicProtocolHandler) PostReply(agreementId string, proposal abstractprotocol.Proposal, reply abstractprotocol.ProposalReply, consumerPolicy *policy.Policy, workerId string) error {
+func (b *BasicProtocolHandler) PostReply(agreementId string, proposal abstractprotocol.Proposal, reply abstractprotocol.ProposalReply, consumerPolicy *policy.Policy, org string, workerId string) error {
 
-	if err := b.agreementPH.RecordAgreement(proposal, reply, "", "", consumerPolicy); err != nil {
+	if err := b.agreementPH.RecordAgreement(proposal, reply, "", "", consumerPolicy, org); err != nil {
 		return err
 	} else {
 		glog.V(3).Infof(BCPHlogstring2(workerId, fmt.Sprintf("recorded agreement %v", agreementId)))

--- a/agreementbot/cs_agreementworker.go
+++ b/agreementbot/cs_agreementworker.go
@@ -168,7 +168,7 @@ func (a *CSAgreementWorker) start(work chan AgreementWork, random *rand.Rand) {
 				// Update state in exchange
 				if pol, err := policy.DemarshalPolicy(ag.Policy); err != nil {
 					glog.Errorf(logstring(a.workerID, fmt.Sprintf("error demarshalling policy from agreement %v, error: %v", wi.AgreementId, err)))
-				} else if err := a.protocolHandler.RecordConsumerAgreementState(wi.AgreementId, pol, "Finalized Agreement", a.workerID); err != nil {
+				} else if err := a.protocolHandler.RecordConsumerAgreementState(wi.AgreementId, pol, ag.Org, "Finalized Agreement", a.workerID); err != nil {
 					glog.Errorf(logstring(a.workerID, fmt.Sprintf("error setting agreement %v finalized state in exchange: %v", wi.AgreementId, err)))
 				}
 			}
@@ -249,7 +249,7 @@ func (a *CSAgreementWorker) DoAsyncWrite(cph ConsumerProtocolHandler, ag *Agreem
 		glog.Errorf(logstring(workerID, fmt.Sprintf("error demarshalling proposal from pending agreement %v, error: %v", ag.CurrentAgreementId, err)))
 	} else if pol, err := policy.DemarshalPolicy(ag.Policy); err != nil {
 		glog.Errorf(logstring(workerID, fmt.Sprintf("error demarshalling tsandcs policy from pending agreement %v, error: %v", ag.CurrentAgreementId, err)))
-	} else if err := cph.AgreementProtocolHandler(ag.BlockchainType, ag.BlockchainName, ag.BlockchainOrg).RecordAgreement(proposal, nil, ag.CounterPartyAddress, ag.ProposalSig, pol); err != nil {
+	} else if err := cph.AgreementProtocolHandler(ag.BlockchainType, ag.BlockchainName, ag.BlockchainOrg).RecordAgreement(proposal, nil, ag.CounterPartyAddress, ag.ProposalSig, pol, ag.Org); err != nil {
 		glog.Errorf(logstring(workerID, fmt.Sprintf("error trying to record agreement in blockchain, %v", err)))
 		a.CancelAgreementWithLock(cph, ag.CurrentAgreementId, cph.GetTerminationCode(TERM_REASON_CANCEL_BC_WRITE_FAILED), workerID)
 	} else {

--- a/agreementbot/cs_protocol_handler.go
+++ b/agreementbot/cs_protocol_handler.go
@@ -451,7 +451,7 @@ func (c *CSProtocolHandler) HandleDeferredCommands() {
 	}
 }
 
-func (c *CSProtocolHandler) PostReply(agreementId string, proposal abstractprotocol.Proposal, reply abstractprotocol.ProposalReply, consumerPolicy *policy.Policy, workerId string) error {
+func (c *CSProtocolHandler) PostReply(agreementId string, proposal abstractprotocol.Proposal, reply abstractprotocol.ProposalReply, consumerPolicy *policy.Policy, org string, workerId string) error {
 
 	agreement, err := FindSingleAgreementByAgreementId(c.db, agreementId, c.Name(), []AFilter{UnarchivedAFilter()})
 	if err != nil {
@@ -459,7 +459,7 @@ func (c *CSProtocolHandler) PostReply(agreementId string, proposal abstractproto
 	} else if agreement.AgreementProtocolVersion < 2 {
 		if aph := c.AgreementProtocolHandler(agreement.BlockchainType, agreement.BlockchainName, agreement.BlockchainOrg); aph == nil {
 			glog.Errorf(CPHlogStringW(workerId, fmt.Sprintf("for %v agreement protocol handler not ready", agreementId)))
-		} else if err := aph.RecordAgreement(proposal, reply, "", "", consumerPolicy); err != nil {
+		} else if err := aph.RecordAgreement(proposal, reply, "", "", consumerPolicy, org); err != nil {
 			return err
 		} else {
 			glog.V(3).Infof(CPHlogStringW(workerId, fmt.Sprintf("recorded agreement %v", agreementId)))

--- a/agreementbot/governance.go
+++ b/agreementbot/governance.go
@@ -284,7 +284,7 @@ func (w *AgreementBotWorker) checkWorkloadUsageAgreement(partnerWLU *WorkloadUsa
 		// Check to make sure the partner is heart-beating to the exchange. This should tell us if we can expect this device to
 		// complete an agreement at some time, or not.
 
-		if dev, err := getDevice(w.Config.Collaborators.HTTPClientFactory.NewHTTPClient(nil), partnerWLU.DeviceId, w.Config.AgreementBot.ExchangeURL, w.agbotId, w.token); err != nil {
+		if dev, err := GetDevice(w.Config.Collaborators.HTTPClientFactory.NewHTTPClient(nil), partnerWLU.DeviceId, w.Config.AgreementBot.ExchangeURL, w.agbotId, w.token); err != nil {
 			glog.Errorf(logString(fmt.Sprintf("error obtaining device %v heartbeat state: %v", partnerWLU.DeviceId, err)))
 		} else if len(dev.LastHeartbeat) != 0 && (uint64(timeInSeconds(dev.LastHeartbeat)+300) > uint64(time.Now().Unix())) {
 			// If the device is still alive (heart beat received in the last 5 mins), then assume this partner is trying to make an
@@ -343,13 +343,13 @@ func (w *AgreementBotWorker) TerminateAgreement(ag *Agreement, reason uint) {
 	w.consumerPH[ag.AgreementProtocol].HandleAgreementTimeout(NewAgreementTimeoutCommand(ag.CurrentAgreementId, ag.AgreementProtocol, reason), w.consumerPH[ag.AgreementProtocol])
 }
 
-func getDevice(httpClient *http.Client, deviceId string, url string, agbotId string, token string) (*exchange.Device, error) {
+func GetDevice(httpClient *http.Client, deviceId string, url string, agbotId string, token string) (*exchange.Device, error) {
 
 	glog.V(5).Infof(logString(fmt.Sprintf("retrieving device %v from exchange", deviceId)))
 
 	var resp interface{}
 	resp = new(exchange.GetDevicesResponse)
-	targetURL := url + "orgs/" + exchange.GetOrg(deviceId) + "/devices/" + exchange.GetId(deviceId)
+	targetURL := url + "orgs/" + exchange.GetOrg(deviceId) + "/nodes/" + exchange.GetId(deviceId)
 	for {
 		if err, tpErr := exchange.InvokeExchange(httpClient, "GET", targetURL, agbotId, token, nil, &resp); err != nil {
 			glog.Errorf(logString(err.Error()))

--- a/agreementbot/pattern_manager.go
+++ b/agreementbot/pattern_manager.go
@@ -1,0 +1,264 @@
+package agreementbot
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/anax/policy"
+	"golang.org/x/crypto/sha3"
+	"time"
+)
+
+type PatternEntry struct {
+	Pattern         *exchange.Pattern `json:"pattern,omitempty"`         // the metadata for this pattern from the exchange
+	Updated         uint64            `json:"updatedTime,omitempty"`     // the time when this entry was updated
+	Hash            []byte            `json:"hash,omitempty"`            // a hash of the current entry to compare for matadata changes in the exchange
+	PolicyFileNames []string          `json:"policyFileNames,omitempty"` // the list of policy names generated for this pattern
+}
+
+func (p *PatternEntry) String() string {
+	return fmt.Sprintf("Pattern Entry: "+
+		"Updated: %v "+
+		"Hash: %x "+
+		"Files: %v"+
+		"Pattern: %v",
+		p.Updated, p.Hash, p.PolicyFileNames, p.Pattern)
+}
+
+func hashPattern(p *exchange.Pattern) ([]byte, error) {
+	if ps, err := json.Marshal(p); err != nil {
+		return nil, errors.New(fmt.Sprintf("unable to marshal pattern %v to a string, error %v", p, err))
+	} else {
+		hash := sha3.Sum256([]byte(ps))
+		return hash[:], nil
+	}
+}
+
+func NewPatternEntry(p *exchange.Pattern) (*PatternEntry, error) {
+	pe := new(PatternEntry)
+	pe.Pattern = p
+	pe.Updated = uint64(time.Now().Unix())
+	if hash, err := hashPattern(p); err != nil {
+		return nil, err
+	} else {
+		pe.Hash = hash
+	}
+	pe.PolicyFileNames = make([]string, 0, 10)
+	return pe, nil
+}
+
+func (pe *PatternEntry) AddPolicyFileName(fileName string) {
+	pe.PolicyFileNames = append(pe.PolicyFileNames, fileName)
+}
+
+func (pe *PatternEntry) DeleteAllPolicyFiles(policyPath string, org string) error {
+	for _, fileName := range pe.PolicyFileNames {
+		if err := policy.DeletePolicyFile(fileName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (pe *PatternEntry) UpdateEntry(pattern *exchange.Pattern, newHash []byte) {
+	pe.Pattern = pattern
+	pe.Hash = newHash
+	pe.Updated = uint64(time.Now().Unix())
+	pe.PolicyFileNames = make([]string, 0, 10)
+}
+
+type PatternManager struct {
+	OrgPatterns map[string]map[string]*PatternEntry
+}
+
+func (p *PatternManager) String() string {
+	res := "Pattern Manager: "
+	for org, orgMap := range p.OrgPatterns {
+		res += fmt.Sprintf("Org: %v ", org)
+		for pat, pe := range orgMap {
+			res += fmt.Sprintf("Pattern: %v %v ", pat, pe)
+		}
+	}
+	return res
+}
+
+func NewPatternManager() *PatternManager {
+	pm := &PatternManager{
+		OrgPatterns: make(map[string]map[string]*PatternEntry),
+	}
+	return pm
+}
+
+func (pm *PatternManager) hasOrg(org string) bool {
+	if _, ok := pm.OrgPatterns[org]; ok {
+		return true
+	}
+	return false
+}
+
+func (pm *PatternManager) hasPattern(org string, pattern string) bool {
+	if pm.hasOrg(org) {
+		if _, ok := pm.OrgPatterns[org][pattern]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Given a list of org/pattern pairs that this agbot is supported to be serving, take that list and
+// convert it to map of maps (keyed by org and pattern name) to hold all the pattern metadata. This
+// will allow the PatternManager to know when the pattern metadata changes.
+func (pm *PatternManager) SetCurrentPatterns(servedPatterns *[]exchange.ServedPatterns, policyPath string) error {
+
+	// Exit early if nothing to do
+	if len(pm.OrgPatterns) == 0 && len(*servedPatterns) == 0 {
+		return nil
+	}
+
+	// Create a new map of maps
+	newMap := make(map[string]map[string]*PatternEntry)
+
+	// For each org/pattern pair that this agbot is supposed to be serving copy the map entries from the
+	// existing map or create new ones as necesssary.
+	for _, served := range *servedPatterns {
+
+		// If we have encountered a new org in the served pattern list, create a map of patterns for it.
+		if _, ok := newMap[served.Org]; !ok {
+			newMap[served.Org] = make(map[string]*PatternEntry)
+		}
+
+		// If the org and pattern have an entry in the old map, copy entry to new map. The PatternEntry
+		// will be nil for patterns that are newly appearing in the agbot metadata. In that case, the
+		// PatternEntry will be created later, once we have the pattern metadata from the exchange.
+		if pm.hasPattern(served.Org, served.Pattern) {
+			newMap[served.Org][served.Pattern] = pm.OrgPatterns[served.Org][served.Pattern]
+		} else {
+			newMap[served.Org][served.Pattern] = nil
+		}
+	}
+
+	// For each org in the existing PatternManager, check to see if its in the new map. If not, then
+	// this agbot is no longer serving any patterns in that org, we can get rid of everything in that org.
+	// Same goes for a pattern that is no longer present in the new map.
+	for org, orgMap := range pm.OrgPatterns {
+
+		// If the org is not in the new map, then we need to get rid of it and all its patterns.
+		if _, ok := newMap[org]; !ok {
+			// delete org and all policy files in it.
+			pm.deleteOrg(policyPath, org)
+		} else {
+
+			// If the pattern is not in the org any more, get rid of its policy files.
+			for pattern, pe := range orgMap {
+				if _, ok := newMap[org][pattern]; !ok && pe != nil {
+					// Delete the policy files.
+					if err := pe.DeleteAllPolicyFiles(policyPath, org); err != nil {
+						return err
+					}
+
+				}
+			}
+		}
+	}
+
+	// The new map of patterns is current so save it as the PatternManager's new state.
+	pm.OrgPatterns = newMap
+
+	return nil
+}
+
+// Create all the policy files for the input pattern
+func createPolicyFiles(pe *PatternEntry, patternId string, pattern *exchange.Pattern, policyPath string, org string) error {
+	if policies, err := exchange.ConvertToPolicies(patternId, pattern); err != nil {
+		return errors.New(fmt.Sprintf("error converting pattern to policies, error %v", err))
+	} else {
+		for _, pol := range policies {
+			if fileName, err := policy.CreatePolicyFile(policyPath, org, pol.Header.Name, pol); err != nil {
+				return errors.New(fmt.Sprintf("error creating policy file, error %v", err))
+			} else {
+				pe.AddPolicyFileName(fileName)
+			}
+		}
+	}
+	return nil
+}
+
+// For each org that the agbot is supporting, take the set of patterns defined within the org and save them into
+// the PatternManager. When new or updated patterns are discovered, generate policy files for each pattern so that
+// the agbot can start serving the workloads.
+func (pm *PatternManager) UpdatePatternPolicies(org string, definedPatterns map[string]exchange.Pattern, policyPath string) error {
+
+	// Exit early on error
+	if !pm.hasOrg(org) {
+		return errors.New(fmt.Sprintf("org %v not found in pattern manager", org))
+	}
+
+	// For each defined pattern, update it in the new PatternManager map
+	for patternId, pattern := range definedPatterns {
+		// If the PatternManager knows about this pattern, then its because this agbot is configured to serve it.
+		if pm.hasPattern(org, exchange.GetId(patternId)) {
+
+			// There might not be a PatternEntry for this pattern yet because the pattern might have just been
+			// discovered by the query of the agbot config. If there's no PatternEntry yet, create one and then
+			// create the policy files.
+			if pe := pm.OrgPatterns[org][exchange.GetId(patternId)]; pe == nil {
+				if newPE, err := NewPatternEntry(&pattern); err != nil {
+					return errors.New(fmt.Sprintf("unable to create pattern entry for %v, error %v", pattern, err))
+				} else {
+					pm.OrgPatterns[org][exchange.GetId(patternId)] = newPE
+					if err := createPolicyFiles(newPE, patternId, &pattern, policyPath, org); err != nil {
+						return errors.New(fmt.Sprintf("unable to create policy files for %v, error %v", pattern, err))
+					}
+				}
+			} else {
+				// The PatternEntry was already there, so check if the pattern definition has changed.
+				// If the pattern has changed, recreate all policy files. Otherwise the pattern
+				// definition we have is current.
+				newHash, err := hashPattern(&pattern)
+				if err != nil {
+					return errors.New(fmt.Sprintf("unable to hash pattern %v for %v, error %v", pattern, org, err))
+				}
+				if !bytes.Equal(pe.Hash, newHash) {
+					if err := pe.DeleteAllPolicyFiles(policyPath, org); err != nil {
+						return errors.New(fmt.Sprintf("unable to delete policy files for %v, error %v", org, err))
+					}
+					pe.UpdateEntry(&pattern, newHash)
+					if err := createPolicyFiles(pe, patternId, &pattern, policyPath, org); err != nil {
+						return errors.New(fmt.Sprintf("unable to create policy files for %v, error %v", pattern, err))
+					}
+				}
+			}
+		} else {
+			// The PatternManager does not know the pattern therefore the agbot is not configured to serve this pattern.
+			// We can safely ignore the pattern.
+		}
+	}
+
+	return nil
+}
+
+// When an org is removed from the list of supported orgs and patterns, remove the org
+// from the PatternManager and delete all the policy files for it.
+func (pm *PatternManager) deleteOrg(policyPath string, org string) error {
+
+	// Verify that we know about the org
+	if !pm.hasOrg(org) {
+		return errors.New(fmt.Sprintf("unable to delete org %v, org was not found", org))
+	}
+
+	// Delete the policy files for each pattern
+	for _, pe := range pm.OrgPatterns[org] {
+		if pe != nil {
+			if err := pe.DeleteAllPolicyFiles(policyPath, org); err != nil {
+				return errors.New(fmt.Sprintf("unable to delete policy files for %v, error %v", org, err))
+			}
+		}
+	}
+
+	// Get rid of the org map
+	delete(pm.OrgPatterns, org)
+
+	return nil
+}

--- a/agreementbot/pattern_manager_test.go
+++ b/agreementbot/pattern_manager_test.go
@@ -1,0 +1,582 @@
+// +build unit
+
+package agreementbot
+
+import (
+	"errors"
+	"fmt"
+	"github.com/open-horizon/anax/exchange"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func Test_pattern_entry_success1(t *testing.T) {
+
+	lab := "label"
+
+	p := &exchange.Pattern{
+		Label:              lab,
+		Description:        "desc",
+		Public:             true,
+		Workloads:          []exchange.WorkloadReference{},
+		AgreementProtocols: []exchange.AgreementProtocol{},
+	}
+
+	if np, err := NewPatternEntry(p); err != nil {
+		t.Errorf("Error %v creating new pattern entry from %v", err, *p)
+	} else if np.Pattern.Label != "label" {
+		t.Errorf("Error: label should be %v but is %v", lab, np.Pattern.Label)
+	} else if len(np.Hash) != 32 {
+		t.Errorf("Error: hash should be length %v", 32)
+	} else {
+		t.Log(np)
+	}
+
+}
+
+func Test_pattern_manager_success1(t *testing.T) {
+
+	if np := NewPatternManager(); np == nil {
+		t.Errorf("Error: pattern manager not created")
+	} else {
+		t.Log(np)
+	}
+
+}
+
+// No existing served patterns, no new served patterns
+func Test_pattern_manager_setpatterns0(t *testing.T) {
+
+	policyPath := "/tmp/servedpatterntest/"
+	servedPatterns := []exchange.ServedPatterns{}
+
+	if np := NewPatternManager(); np == nil {
+		t.Errorf("Error: pattern manager not created")
+	} else if err := np.SetCurrentPatterns(&servedPatterns, policyPath); err != nil {
+		t.Errorf("Error %v consuming served patterns %v", err, servedPatterns)
+	} else if len(np.OrgPatterns) != 0 {
+		t.Errorf("Error: should have 0 org in the PatternManager, have %v", len(np.OrgPatterns))
+	} else {
+		t.Log(np)
+	}
+
+}
+
+// Add a new served org and pattern
+func Test_pattern_manager_setpatterns1(t *testing.T) {
+
+	policyPath := "/tmp/servedpatterntest/"
+	servedPatterns := []exchange.ServedPatterns{
+		{
+			Org:     "myorg1",
+			Pattern: "pattern1",
+		},
+	}
+
+	if np := NewPatternManager(); np == nil {
+		t.Errorf("Error: pattern manager not created")
+	} else if err := np.SetCurrentPatterns(&servedPatterns, policyPath); err != nil {
+		t.Errorf("Error %v consuming served patterns %v", err, servedPatterns)
+	} else if len(np.OrgPatterns) != 1 {
+		t.Errorf("Error: should have 1 org in the PatternManager, have %v", len(np.OrgPatterns))
+	} else {
+		t.Log(np)
+	}
+
+}
+
+// Remove an org and pattern, replace with a new org and pattern
+func Test_pattern_manager_setpatterns2(t *testing.T) {
+
+	policyPath := "/tmp/servedpatterntest/"
+	myorg1 := "myorg1"
+	myorg2 := "myorg2"
+	pattern1 := "pattern1"
+	pattern2 := "pattern2"
+
+	servedPatterns1 := []exchange.ServedPatterns{
+		{
+			Org:     myorg1,
+			Pattern: pattern1,
+		},
+	}
+
+	servedPatterns2 := []exchange.ServedPatterns{
+		{
+			Org:     myorg2,
+			Pattern: pattern2,
+		},
+	}
+
+	definedPatterns1 := map[string]exchange.Pattern{
+		"myorg1/pattern1": exchange.Pattern{
+			Label:       "label",
+			Description: "description",
+			Public:      false,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test1",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{
+				{Name: "Basic"},
+			},
+		},
+	}
+
+	definedPatterns2 := map[string]exchange.Pattern{
+		"myorg2/pattern2": exchange.Pattern{
+			Label:       "label",
+			Description: "description",
+			Public:      false,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test2",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "1.5.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{
+				{Name: "Basic"},
+			},
+		},
+	}
+
+	// setup test
+	if err := cleanTestDir(policyPath); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// run test
+	if np := NewPatternManager(); np == nil {
+		t.Errorf("Error: pattern manager not created")
+	} else if err := np.SetCurrentPatterns(&servedPatterns1, policyPath); err != nil {
+		t.Errorf("Error %v consuming served patterns %v", err, servedPatterns1)
+	} else if err := np.UpdatePatternPolicies(myorg1, definedPatterns1, policyPath); err != nil {
+		t.Errorf("Error: error updating pattern policies, %v", err)
+	} else if len(np.OrgPatterns) != 1 {
+		t.Errorf("Error: should have 1 org in the PatternManager, have %v", len(np.OrgPatterns))
+	} else if !np.hasOrg(myorg1) {
+		t.Errorf("Error: PM should have org %v but doesnt, has %v", myorg1, np)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg1][pattern1].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg1, pattern1, err)
+	} else if err := np.SetCurrentPatterns(&servedPatterns2, policyPath); err != nil {
+		t.Errorf("Error %v consuming served patterns %v", err, servedPatterns2)
+	} else if err := np.UpdatePatternPolicies(myorg2, definedPatterns2, policyPath); err != nil {
+		t.Errorf("Error: error updating pattern policies, %v", err)
+	} else if len(np.OrgPatterns) != 1 {
+		t.Errorf("Error: should have 1 org in the PatternManager, have %v", len(np.OrgPatterns))
+	} else if !np.hasOrg(myorg2) {
+		t.Errorf("Error: PM should have org %v but doesnt, has %v", myorg2, np)
+	} else if np.hasOrg(myorg1) {
+		t.Errorf("Error: PM should NOT have org %v but does %v", myorg1, np)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg2][pattern2].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg2, pattern2, err)
+	} else if files, err := getPolicyFiles(policyPath + myorg1); err != nil {
+		t.Errorf(err.Error())
+	} else if len(files) != 0 {
+		t.Errorf("Error: found policy files for %v, %v", myorg1, files)
+	} else {
+		t.Log(np)
+	}
+
+}
+
+// Remove an org with multiple patterns, add a pattern to existing org
+func Test_pattern_manager_setpatterns3(t *testing.T) {
+
+	policyPath := "/tmp/servedpatterntest/"
+	myorg1 := "myorg1"
+	myorg2 := "myorg2"
+	pattern1 := "pattern1"
+	pattern2 := "pattern2"
+
+	servedPatterns1 := []exchange.ServedPatterns{
+		{
+			Org:     myorg1,
+			Pattern: pattern1,
+		},
+		{
+			Org:     myorg1,
+			Pattern: pattern2,
+		},
+		{
+			Org:     myorg2,
+			Pattern: pattern2,
+		},
+	}
+
+	servedPatterns2 := []exchange.ServedPatterns{
+		{
+			Org:     myorg2,
+			Pattern: pattern1,
+		},
+		{
+			Org:     myorg2,
+			Pattern: pattern2,
+		},
+	}
+
+	definedPatterns1 := map[string]exchange.Pattern{
+		"myorg1/pattern1": exchange.Pattern{
+			Label:       "label",
+			Description: "description",
+			Public:      false,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test1",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{
+				{Name: "Basic"},
+			},
+		},
+		"myorg1/pattern2": exchange.Pattern{
+			Label:       "label",
+			Description: "description",
+			Public:      false,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test1",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "2.0.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{
+				{Name: "Basic"},
+			},
+		},
+	}
+
+	definedPatterns2 := map[string]exchange.Pattern{
+		"myorg2/pattern1": exchange.Pattern{
+			Label:       "label",
+			Description: "description",
+			Public:      false,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test2",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "1.4.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{
+				{Name: "Basic"},
+			},
+		},
+		"myorg2/pattern2": exchange.Pattern{
+			Label:       "label",
+			Description: "description",
+			Public:      false,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test2",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "1.5.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{
+				{Name: "Basic"},
+			},
+		},
+	}
+
+	// setup test
+	if err := cleanTestDir(policyPath); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// run test
+	if np := NewPatternManager(); np == nil {
+		t.Errorf("Error: pattern manager not created")
+	} else if err := np.SetCurrentPatterns(&servedPatterns1, policyPath); err != nil {
+		t.Errorf("Error %v consuming served patterns %v", err, servedPatterns1)
+	} else if err := np.UpdatePatternPolicies(myorg1, definedPatterns1, policyPath); err != nil {
+		t.Errorf("Error: error updating pattern policies, %v", err)
+	} else if err := np.UpdatePatternPolicies(myorg2, definedPatterns2, policyPath); err != nil {
+		t.Errorf("Error: error updating pattern policies, %v", err)
+	} else if len(np.OrgPatterns) != 2 {
+		t.Errorf("Error: should have 2 orgs in the PatternManager, have %v", len(np.OrgPatterns))
+	} else if !np.hasOrg(myorg1) {
+		t.Errorf("Error: PM should have org %v but doesnt, has %v", myorg1, np)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg1][pattern1].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg1, pattern1, err)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg1][pattern2].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg1, pattern2, err)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg2][pattern2].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg2, pattern2, err)
+	} else if err := np.SetCurrentPatterns(&servedPatterns2, policyPath); err != nil {
+		t.Errorf("Error %v consuming served patterns %v", err, servedPatterns2)
+	} else if err := np.UpdatePatternPolicies(myorg2, definedPatterns2, policyPath); err != nil {
+		t.Errorf("Error: error updating pattern policies, %v", err)
+	} else if len(np.OrgPatterns) != 1 {
+		t.Errorf("Error: should have 1 org in the PatternManager, have %v", len(np.OrgPatterns))
+	} else if !np.hasOrg(myorg2) {
+		t.Errorf("Error: PM should have org %v but doesnt, has %v", myorg2, np)
+	} else if np.hasOrg(myorg1) {
+		t.Errorf("Error: PM should NOT have org %v but does %v", myorg1, np)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg2][pattern1].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg2, pattern1, err)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg2][pattern2].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg2, pattern2, err)
+	} else if files, err := getPolicyFiles(policyPath + myorg1); err != nil {
+		t.Errorf(err.Error())
+	} else if len(files) != 0 {
+		t.Errorf("Error: found policy files for %v, %v", myorg1, files)
+	} else {
+		t.Log(np)
+	}
+
+}
+
+// // Remove a pattern but org stays around, add a pattern to existing org
+func Test_pattern_manager_setpatterns4(t *testing.T) {
+
+	policyPath := "/tmp/servedpatterntest/"
+	myorg1 := "myorg1"
+	myorg2 := "myorg2"
+	pattern1 := "pattern1"
+	pattern2 := "pattern2"
+
+	servedPatterns1 := []exchange.ServedPatterns{
+		{
+			Org:     myorg1,
+			Pattern: pattern1,
+		},
+		{
+			Org:     myorg1,
+			Pattern: pattern2,
+		},
+		{
+			Org:     myorg2,
+			Pattern: pattern2,
+		},
+	}
+
+	servedPatterns2 := []exchange.ServedPatterns{
+		{
+			Org:     myorg1,
+			Pattern: pattern1,
+		},
+		{
+			Org:     myorg2,
+			Pattern: pattern1,
+		},
+		{
+			Org:     myorg2,
+			Pattern: pattern2,
+		},
+	}
+
+	definedPatterns1 := map[string]exchange.Pattern{
+		"myorg1/pattern1": exchange.Pattern{
+			Label:       "label",
+			Description: "description",
+			Public:      false,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test1",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{
+				{Name: "Basic"},
+			},
+		},
+		"myorg1/pattern2": exchange.Pattern{
+			Label:       "label",
+			Description: "description",
+			Public:      false,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test1",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "2.0.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{
+				{Name: "Basic"},
+			},
+		},
+	}
+
+	definedPatterns2 := map[string]exchange.Pattern{
+		"myorg2/pattern1": exchange.Pattern{
+			Label:       "label",
+			Description: "description",
+			Public:      false,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test2",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "1.4.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{
+				{Name: "Basic"},
+			},
+		},
+		"myorg2/pattern2": exchange.Pattern{
+			Label:       "label",
+			Description: "description",
+			Public:      false,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test2",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "1.5.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{
+				{Name: "Basic"},
+			},
+		},
+	}
+
+	// setup the test
+	if err := cleanTestDir(policyPath); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// run the test
+	if np := NewPatternManager(); np == nil {
+		t.Errorf("Error: pattern manager not created")
+	} else if err := np.SetCurrentPatterns(&servedPatterns1, policyPath); err != nil {
+		t.Errorf("Error %v consuming served patterns %v", err, servedPatterns1)
+	} else if err := np.UpdatePatternPolicies(myorg1, definedPatterns1, policyPath); err != nil {
+		t.Errorf("Error: error updating pattern policies, %v", err)
+	} else if err := np.UpdatePatternPolicies(myorg2, definedPatterns2, policyPath); err != nil {
+		t.Errorf("Error: error updating pattern policies, %v", err)
+	} else if len(np.OrgPatterns) != 2 {
+		t.Errorf("Error: should have 2 orgs in the PatternManager, have %v", len(np.OrgPatterns))
+	} else if !np.hasOrg(myorg1) {
+		t.Errorf("Error: PM should have org %v but doesnt, has %v", myorg1, np)
+	} else if !np.hasOrg(myorg2) {
+		t.Errorf("Error: PM should have org %v but doesnt, has %v", myorg2, np)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg1][pattern1].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg1, pattern1, err)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg1][pattern2].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg1, pattern2, err)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg2][pattern2].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg2, pattern2, err)
+	} else if err := np.SetCurrentPatterns(&servedPatterns2, policyPath); err != nil {
+		t.Errorf("Error %v consuming served patterns %v", err, servedPatterns2)
+	} else if err := np.UpdatePatternPolicies(myorg1, definedPatterns1, policyPath); err != nil {
+		t.Errorf("Error: error updating pattern policies, %v", err)
+	} else if err := np.UpdatePatternPolicies(myorg2, definedPatterns2, policyPath); err != nil {
+		t.Errorf("Error: error updating pattern policies, %v", err)
+	} else if len(np.OrgPatterns) != 2 {
+		t.Errorf("Error: should have 2 org in the PatternManager, have %v", len(np.OrgPatterns))
+	} else if !np.hasOrg(myorg2) {
+		t.Errorf("Error: PM should have org %v but doesnt, has %v", myorg2, np)
+	} else if !np.hasOrg(myorg1) {
+		t.Errorf("Error: PM should have org %v but doesnt, has %v", myorg1, np)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg1][pattern1].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg1, pattern1, err)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg2][pattern1].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg2, pattern1, err)
+	} else if err := getPatternEntryFiles(np.OrgPatterns[myorg2][pattern2].PolicyFileNames); err != nil {
+		t.Errorf("Error getting pattern entry files for %v %v, %v", myorg2, pattern2, err)
+	} else {
+		t.Log(np)
+	}
+
+}
+
+// Utility functions
+// Clean up the test directory
+func cleanTestDir(policyPath string) error {
+	if _, err := os.Stat(policyPath); !os.IsNotExist(err) {
+		if err := os.RemoveAll(policyPath); err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(policyPath, 0764); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Check for policy files referenced by the pattern manager entries
+func getPatternEntryFiles(files []string) error {
+	for _, filename := range files {
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			return errors.New(fmt.Sprintf("File %v does not exist", filename))
+		}
+	}
+	return nil
+}
+
+// Check for policy files that shouldnt have been left behind
+func getPolicyFiles(homePath string) ([]os.FileInfo, error) {
+	res := make([]os.FileInfo, 0, 10)
+
+	if files, err := ioutil.ReadDir(homePath); err != nil {
+		return nil, err
+	} else {
+		for _, fileInfo := range files {
+			if strings.HasSuffix(fileInfo.Name(), ".policy") && !fileInfo.IsDir() {
+				res = append(res, fileInfo)
+			}
+		}
+		return res, nil
+	}
+}

--- a/api/input.go
+++ b/api/input.go
@@ -14,6 +14,7 @@ import (
 type HorizonDevice struct {
 	Id                 *string `json:"id"`
 	Org                *string `json:"organization"`
+	Pattern            *string `json:"pattern"` // a simple name, not prefixed with the org
 	Name               *string `json:"name,omitempty"`
 	Token              *string `json:"token,omitempty"`
 	TokenLastValidTime *uint64 `json:"token_last_valid_time,omitempty"`

--- a/events/events.go
+++ b/events/events.go
@@ -359,10 +359,11 @@ type EdgeRegisteredExchangeMessage struct {
 	device_id string
 	token     string
 	org       string
+	pattern   string
 }
 
 func (e EdgeRegisteredExchangeMessage) String() string {
-	return fmt.Sprintf("event: %v, device_id: %v, token: %v, org: %v", e.event, e.device_id, e.token, e.org)
+	return fmt.Sprintf("event: %v, device_id: %v, token: %v, org: %v, pattern: %v", e.event, e.device_id, e.token, e.org, e.pattern)
 }
 
 func (e EdgeRegisteredExchangeMessage) ShortString() string {
@@ -385,7 +386,11 @@ func (e *EdgeRegisteredExchangeMessage) Org() string {
 	return e.org
 }
 
-func NewEdgeRegisteredExchangeMessage(evId EventId, device_id string, token string, org string) *EdgeRegisteredExchangeMessage {
+func (e *EdgeRegisteredExchangeMessage) Pattern() string {
+	return e.pattern
+}
+
+func NewEdgeRegisteredExchangeMessage(evId EventId, device_id string, token string, org string, pattern string) *EdgeRegisteredExchangeMessage {
 
 	return &EdgeRegisteredExchangeMessage{
 		event: Event{
@@ -394,6 +399,7 @@ func NewEdgeRegisteredExchangeMessage(evId EventId, device_id string, token stri
 		device_id: device_id,
 		token:     token,
 		org:       org,
+		pattern:   pattern,
 	}
 }
 

--- a/exchange/rpc_test.go
+++ b/exchange/rpc_test.go
@@ -4,6 +4,7 @@ package exchange
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -24,4 +25,147 @@ func Test_Blockchain_Demarshal(t *testing.T) {
 		}
 	}
 
+}
+
+func Test_ConvertPattern0(t *testing.T) {
+
+	org := "testorg"
+	name := "testpattern"
+
+	pa := `{"label":"Weather","description":"a weather pattern","public":true,` +
+		`"workloads":[],` +
+		`"agreementProtocols":[{"name":"Basic"}]}`
+
+	if p1 := create_Pattern(pa, t); p1 == nil {
+		t.Errorf("Pattern not created from %v\n", pa)
+	} else if pols, err := ConvertToPolicies(fmt.Sprintf("%v/%v", org, name), p1); err != nil {
+		t.Errorf("Error: %v converting %v to a policy\n", err, pa)
+	} else if len(pols) != 0 {
+		t.Errorf("Error: should be 0 policies in the pattern, there are %v\n", len(pols))
+	}
+
+}
+
+func Test_ConvertPattern1(t *testing.T) {
+
+	org := "testorg"
+	name := "testpattern"
+
+	pn := makePolicyName(name, "https://bluehorizon.network/workloads/weather", org, "amd64")
+
+	pa := `{"label":"Weather","description":"a weather pattern","public":true,` +
+		`"workloads":[` +
+		`{"workloadUrl":"https://bluehorizon.network/workloads/weather","workloadOrgid":"testorg","workloadArch":"amd64","workloadVersions":` +
+		`[{"version":"1.5.0",` +
+		`"priority":{"priority_value":3,"retries":1,"retry_durations":3600,"verified_durations":52},` +
+		`"upgradePolicy":{}},` +
+		`{"version":"1.5.0",` +
+		`"priority":{"priority_value":2,"retries":1,"retry_durations":3600,"verified_durations": 52},` +
+		`"upgradePolicy":{}}],` +
+		`"dataVerification":{"enabled":true,"user":"","password":"","URL":"myURL","interval":240,"metering":{"tokens":1,"per_time_unit":"min","notification_interval":30}}}` +
+		`],` +
+		`"agreementProtocols":[{"name":"Basic"}]}`
+
+	if p1 := create_Pattern(pa, t); p1 == nil {
+		t.Errorf("Pattern not created from %v\n", pa)
+	} else if pols, err := ConvertToPolicies(fmt.Sprintf("%v/%v", org, name), p1); err != nil {
+		t.Errorf("Error: %v converting %v to a policy\n", err, pa)
+	} else if pols[0].Header.Name != pn {
+		t.Errorf("Error: wrong header name generated, was %v\n", pols[0].Header.Name)
+	} else if len(pols) != 1 {
+		t.Errorf("Error: should be 1 policies in the pattern, there are %v\n", len(pols))
+	} else if len(pols[0].AgreementProtocols) != 1 {
+		t.Errorf("Error: should be 1 agreement protocol, but there are %v\n", len(pols[0].AgreementProtocols))
+	} else if pols[0].DataVerify.URL != "myURL" {
+		t.Errorf("Error: Data verification didnt get setup correctly, is %v\n", pols[0].DataVerify)
+	}
+
+}
+
+func Test_ConvertPattern2(t *testing.T) {
+
+	org := "testorg"
+	name := "testpattern"
+
+	pn := makePolicyName(name, "https://bluehorizon.network/workloads/weather", org, "amd64")
+
+	pa := `{"label":"Weather","description":"a weather pattern","public":true,` +
+		`"workloads":[` +
+		`{"workloadUrl":"https://bluehorizon.network/workloads/weather","workloadOrgid":"testorg","workloadArch":"amd64","workloadVersions":` +
+		`[{"version":"1.5.0",` +
+		`"priority":{"priority_value":3,"retries":1,"retry_durations":3600,"verified_durations":52},` +
+		`"upgradePolicy":{}},` +
+		`{"version":"1.5.0",` +
+		`"priority":{"priority_value":2,"retries":1,"retry_durations":3600,"verified_durations": 52},` +
+		`"upgradePolicy":{}}],` +
+		`"dataVerification":{"enabled":true,"user":"","password":"","URL":"myURL","interval":240,"metering":{"tokens":1,"per_time_unit":"min","notification_interval":30}}},` +
+		`{"workloadUrl":"https://bluehorizon.network/workloads/netspeed","workloadOrgid":"testorg","workloadArch":"amd64","workloadVersions":` +
+		`[{"version":"1.5.0",` +
+		`"priority":{"priority_value":3,"retries":1,"retry_durations":3600,"verified_durations":52},` +
+		`"upgradePolicy":{}},` +
+		`{"version":"1.5.0",` +
+		`"priority":{"priority_value":2,"retries":1,"retry_durations":3600,"verified_durations": 52},` +
+		`"upgradePolicy":{}}],` +
+		`"dataVerification":{"enabled":true,"user":"","password":"","URL":"myURL","interval":240,"metering":{"tokens":1,"per_time_unit":"min","notification_interval":30}}}` +
+		`],` +
+		`"agreementProtocols":[{"name":"Basic"}]}`
+
+	if p1 := create_Pattern(pa, t); p1 == nil {
+		t.Errorf("Pattern not created from %v\n", pa)
+	} else if pols, err := ConvertToPolicies(fmt.Sprintf("%v/%v", org, name), p1); err != nil {
+		t.Errorf("Error: %v converting %v to a policy\n", err, pa)
+	} else if pols[0].Header.Name != pn {
+		t.Errorf("Error: wrong header name generated, was %v\n", pols[0].Header.Name)
+	} else if len(pols) != 2 {
+		t.Errorf("Error: should be 2 policies in the pattern, there are %v\n", len(pols))
+	} else if len(pols[0].AgreementProtocols) != 1 {
+		t.Errorf("Error: should be 1 agreement protocol, but there are %v\n", len(pols[0].AgreementProtocols))
+	} else if pols[0].DataVerify.URL != "myURL" {
+		t.Errorf("Error: Data verification didnt get setup correctly, is %v\n", pols[0].DataVerify)
+	}
+
+}
+
+func Test_makePolicyName1(t *testing.T) {
+
+	pat := "pat1"
+	url := "http://mydomain.com"
+	org := "myorg"
+	arch := "amd64"
+
+	expected := fmt.Sprintf("%v_%v_%v_%v", pat, "mydomain.com", org, arch)
+
+	if res := makePolicyName(pat, url, org, arch); res != expected {
+		t.Errorf("Error: expecting %v got %v\n", expected, res)
+	}
+
+}
+
+func Test_makePolicyName2(t *testing.T) {
+
+	pat := "pat1"
+	url := ""
+	org := "myorg"
+	arch := "amd64"
+
+	expected := fmt.Sprintf("%v_%v_%v_%v", pat, "", org, arch)
+
+	if res := makePolicyName(pat, url, org, arch); res != expected {
+		t.Errorf("Error: expecting %v got %v\n", expected, res)
+	}
+
+}
+
+// Create a Pattern object from a JSON serialization. The JSON serialization
+// does not have to be a valid pattern serialization, just has to be a valid
+// JSON serialization.
+func create_Pattern(jsonString string, t *testing.T) *Pattern {
+	wl := new(Pattern)
+
+	if err := json.Unmarshal([]byte(jsonString), &wl); err != nil {
+		t.Errorf("Error unmarshalling pattern json string: %v error:%v\n", jsonString, err)
+		return nil
+	} else {
+		return wl
+	}
 }

--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func main() {
 	} else if err := os.MkdirAll(cfg.Edge.PolicyPath, 0644); err != nil {
 		glog.Errorf("Cannot create edge policy file path %v, terminating.", cfg.Edge.PolicyPath)
 		panic(err)
-	} else if policyManager, err := policy.Initialize(cfg.Edge.PolicyPath, nil); err != nil {
+	} else if policyManager, err := policy.Initialize(cfg.Edge.PolicyPath, nil, true); err != nil {
 		glog.Errorf("Unable to initialize policy manager, terminating.")
 		panic(err)
 	} else {

--- a/persistence/device.go
+++ b/persistence/device.go
@@ -14,6 +14,7 @@ const DEVICES = "devices"
 type ExchangeDevice struct {
 	Id                 string `json:"id"`
 	Org                string `json:"organization"`
+	Pattern            string `json:"pattern"`
 	Name               string `json:"name"`
 	Token              string `json:"token"`
 	TokenLastValidTime uint64 `json:"token_last_valid_time"`
@@ -29,14 +30,14 @@ func (e ExchangeDevice) String() string {
 		tokenShadow = "unset"
 	}
 
-	return fmt.Sprintf("Org: %v, Token: <%s>, Name: %v, TokenLastValidTime: %v, TokenValid: %v", e.Org, tokenShadow, e.Name, e.TokenLastValidTime, e.TokenValid)
+	return fmt.Sprintf("Org: %v, Token: <%s>, Name: %v, TokenLastValidTime: %v, TokenValid: %v, Pattern: %v", e.Org, tokenShadow, e.Name, e.TokenLastValidTime, e.TokenValid, e.Pattern)
 }
 
 func (e ExchangeDevice) GetId() string {
 	return fmt.Sprintf("%v/%v", e.Org, e.Id)
 }
 
-func newExchangeDevice(id string, token string, name string, tokenLastValidTime uint64, ha bool, org string) (*ExchangeDevice, error) {
+func newExchangeDevice(id string, token string, name string, tokenLastValidTime uint64, ha bool, org string, pattern string) (*ExchangeDevice, error) {
 	if id == "" || token == "" || name == "" || tokenLastValidTime == 0 || org == "" {
 		return nil, errors.New("Cannot create exchange device, illegal arguments")
 	}
@@ -49,6 +50,7 @@ func newExchangeDevice(id string, token string, name string, tokenLastValidTime 
 		TokenValid:         true,
 		HADevice:           ha,
 		Org:                org,
+		Pattern:            pattern,
 	}, nil
 }
 
@@ -130,7 +132,7 @@ func updateExchangeDeviceToken(db *bolt.DB, deviceId string, token string) (*Exc
 }
 
 // always assumed the given token is valid at the time of call
-func SaveNewExchangeDevice(db *bolt.DB, id string, token string, name string, ha bool, organization string) (*ExchangeDevice, error) {
+func SaveNewExchangeDevice(db *bolt.DB, id string, token string, name string, ha bool, organization string, pattern string) (*ExchangeDevice, error) {
 
 	if id == "" || token == "" || name == "" || organization == "" {
 		return nil, errors.New("Argument null and must not be")
@@ -154,7 +156,7 @@ func SaveNewExchangeDevice(db *bolt.DB, id string, token string, name string, ha
 		return nil, fmt.Errorf("Duplicate record found in devices for %v.", name)
 	}
 
-	exDevice, err := newExchangeDevice(id, token, name, uint64(time.Now().Unix()), ha, organization)
+	exDevice, err := newExchangeDevice(id, token, name, uint64(time.Now().Unix()), ha, organization, pattern)
 
 	if err != nil {
 		return nil, err

--- a/policy/policy_manager_test.go
+++ b/policy/policy_manager_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_Payloadmanager_init_success1(t *testing.T) {
 
-	if pm, err := Initialize("./test/pffindtest/", nil); err != nil {
+	if pm, err := Initialize("./test/pffindtest/", nil, true); err != nil {
 		t.Error(err)
 	} else {
 
@@ -19,9 +19,9 @@ func Test_Payloadmanager_init_success1(t *testing.T) {
 			t.Errorf("String format of policy manager is incorrect, returned %v", stringDump)
 		} else if pm.GetPolicy("testorg", "find test policy") == nil {
 			t.Errorf("Did not find policy by name.")
-		} else if pm.AgreementCounts["find test policy"].Count != 0 || len(pm.AgreementCounts["find test policy"].AgreementIds) != 0 {
+		} else if pm.AgreementCounts["testorg"]["http://mycompany.com/microservice/spec"].Count != 0 || len(pm.AgreementCounts["testorg"]["http://mycompany.com/microservice/spec"].AgreementIds) != 0 {
 			t.Errorf("Contract Count map is not initialized correctly %v", pm)
-		} else if atMax, err := pm.ReachedMaxAgreements(pm.GetAllPolicies("testorg")); err != nil {
+		} else if atMax, err := pm.ReachedMaxAgreements(pm.GetAllPolicies("testorg"), "testorg"); err != nil {
 			t.Error(err)
 		} else if atMax {
 			t.Errorf("Policy max agreements is %v, should not be reporting reached max contracts.", pm.Policies["testorg"][0].MaxAgreements)
@@ -32,7 +32,7 @@ func Test_Payloadmanager_init_success1(t *testing.T) {
 
 func Test_Payloadmanager_init_success2(t *testing.T) {
 
-	if pm, err := Initialize("./test/pfmultiorg/", nil); err != nil {
+	if pm, err := Initialize("./test/pfmultiorg/", nil, true); err != nil {
 		t.Error(err)
 	} else {
 
@@ -54,13 +54,13 @@ func Test_Payloadmanager_init_success2(t *testing.T) {
 
 func Test_Payloadmanager_dup_policy_name(t *testing.T) {
 
-	if _, err := Initialize("./test/pfduptest/", nil); err == nil {
+	if _, err := Initialize("./test/pfduptest/", nil, true); err == nil {
 		t.Errorf("Should have found duplicate policy names but did not.")
 	}
 }
 
 func Test_contractCounter_success(t *testing.T) {
-	if pm, err := Initialize("./test/pfmatchtest/", nil); err != nil {
+	if pm, err := Initialize("./test/pfmatchtest/", nil, true); err != nil {
 		t.Error(err)
 	} else {
 
@@ -71,47 +71,47 @@ func Test_contractCounter_success(t *testing.T) {
 		}
 
 		pol := pm.GetPolicy("testorg", "find policy2")
-		if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}); err != nil {
+		if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}, "testorg"); err != nil {
 			t.Error(err)
 		} else if atMax {
 			t.Errorf("Policy max agreements is %v, should not be reporting reached max contracts.", pol.MaxAgreements)
 		}
 
-		if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345a"); err != nil {
+		if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345a", "testorg"); err != nil {
 			t.Error(err)
-		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}); err != nil {
-			t.Error(err)
-		} else if atMax {
-			t.Errorf("Policy max agreements is %v, should not be reporting reached max contracts.", pol.MaxAgreements)
-		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345b"); err != nil {
-			t.Error(err)
-		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}); err != nil {
+		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}, "testorg"); err != nil {
 			t.Error(err)
 		} else if atMax {
 			t.Errorf("Policy max agreements is %v, should not be reporting reached max contracts.", pol.MaxAgreements)
-		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345c"); err != nil {
+		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345b", "testorg"); err != nil {
 			t.Error(err)
-		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}); err != nil {
+		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}, "testorg"); err != nil {
 			t.Error(err)
-		} else if !atMax {
-			t.Errorf("Policy max agreements is %v, should be reporting reached max contracts.", pol.MaxAgreements)
-		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345a"); err != nil {
+		} else if atMax {
+			t.Errorf("Policy max agreements is %v, should not be reporting reached max contracts.", pol.MaxAgreements)
+		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345c", "testorg"); err != nil {
 			t.Error(err)
-		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345b"); err != nil {
-			t.Error(err)
-		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345c"); err != nil {
-			t.Error(err)
-		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}); err != nil {
+		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}, "testorg"); err != nil {
 			t.Error(err)
 		} else if !atMax {
 			t.Errorf("Policy max agreements is %v, should be reporting reached max contracts.", pol.MaxAgreements)
-		} else if err := pm.CancelAgreement([]Policy{*pol}, "0x12345a"); err != nil {
+		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345a", "testorg"); err != nil {
 			t.Error(err)
-		} else if err := pm.CancelAgreement([]Policy{*pol}, "0x12345b"); err != nil {
+		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345b", "testorg"); err != nil {
 			t.Error(err)
-		} else if err := pm.CancelAgreement([]Policy{*pol}, "0x12345c"); err != nil {
+		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345c", "testorg"); err != nil {
 			t.Error(err)
-		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}); err != nil {
+		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}, "testorg"); err != nil {
+			t.Error(err)
+		} else if !atMax {
+			t.Errorf("Policy max agreements is %v, should be reporting reached max contracts.", pol.MaxAgreements)
+		} else if err := pm.CancelAgreement([]Policy{*pol}, "0x12345a", "testorg"); err != nil {
+			t.Error(err)
+		} else if err := pm.CancelAgreement([]Policy{*pol}, "0x12345b", "testorg"); err != nil {
+			t.Error(err)
+		} else if err := pm.CancelAgreement([]Policy{*pol}, "0x12345c", "testorg"); err != nil {
+			t.Error(err)
+		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}, "testorg"); err != nil {
 			t.Error(err)
 		} else if atMax {
 			t.Errorf("Policy max agreements is %v, should NOT be reporting reached max contracts.", pol.MaxAgreements)
@@ -122,7 +122,7 @@ func Test_contractCounter_success(t *testing.T) {
 func Test_contractCounter_failure1(t *testing.T) {
 
 	var wrongPol *Policy
-	if pm, err := Initialize("./test/pffindtest/", nil); err != nil {
+	if pm, err := Initialize("./test/pffindtest/", nil, true); err != nil {
 		t.Error(err)
 	} else {
 		// Grab the wrong policy so that we can do error tests
@@ -135,69 +135,69 @@ func Test_contractCounter_failure1(t *testing.T) {
 		t.Errorf("Should have returned policy pointer.")
 	}
 
-	if pm, err := Initialize("./test/pfmatchtest/", nil); err != nil {
+	if pm, err := Initialize("./test/pfmatchtest/", nil, true); err != nil {
 		t.Error(err)
 	} else {
 
-		if err := pm.AttemptingAgreement([]Policy{*wrongPol}, "0x12345a"); err == nil {
+		if err := pm.AttemptingAgreement([]Policy{*wrongPol}, "0x12345a", "testorg"); err == nil {
 			t.Errorf("Should have returned error attempting agreement on unknown policy.")
-		} else if err := pm.FinalAgreement([]Policy{*wrongPol}, "0x12345a"); err == nil {
+		} else if err := pm.FinalAgreement([]Policy{*wrongPol}, "0x12345a", "testorg"); err == nil {
 			t.Errorf("Should have returned error finalizing agreement on unknown policy.")
-		} else if err := pm.CancelAgreement([]Policy{*wrongPol}, "0x12345a"); err == nil {
+		} else if err := pm.CancelAgreement([]Policy{*wrongPol}, "0x12345a", "testorg"); err == nil {
 			t.Errorf("Should have returned error cancelling agreement on unknown policy.")
-		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*wrongPol}); err == nil {
+		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*wrongPol}, "testorg"); err == nil {
 			t.Errorf("Should have returned error checking for max agreement on unknown policy.")
 		} else if atMax {
 			t.Errorf("Should have returned false when checking for max agreement due to error.")
-		} else if err := pm.AttemptingAgreement(nil, "0x12345a"); err == nil {
+		} else if err := pm.AttemptingAgreement(nil, "0x12345a", "testorg"); err == nil {
 			t.Errorf("Should have returned error attempting agreement on nil policy.")
-		} else if err := pm.FinalAgreement(nil, "0x12345a"); err == nil {
+		} else if err := pm.FinalAgreement(nil, "0x12345a", "testorg"); err == nil {
 			t.Errorf("Should have returned error finalizing agreement on nil policy.")
-		} else if err := pm.CancelAgreement(nil, "0x12345a"); err == nil {
+		} else if err := pm.CancelAgreement(nil, "0x12345a", "testorg"); err == nil {
 			t.Errorf("Should have returned error cancelling agreement on nil policy.")
-		} else if atMax, err := pm.ReachedMaxAgreements(nil); err == nil {
+		} else if atMax, err := pm.ReachedMaxAgreements(nil, "testorg"); err == nil {
 			t.Errorf("Should have returned error checking for max agreement on nil policy.")
 		} else if atMax {
 			t.Errorf("Should have returned false when checking for max agreement due to error.")
-		} else if err := pm.AttemptingAgreement([]Policy{*wrongPol}, ""); err == nil {
+		} else if err := pm.AttemptingAgreement([]Policy{*wrongPol}, "", "testorg"); err == nil {
 			t.Errorf("Should have returned error attempting agreement with empty contract address.")
-		} else if err := pm.FinalAgreement([]Policy{*wrongPol}, ""); err == nil {
+		} else if err := pm.FinalAgreement([]Policy{*wrongPol}, "", "testorg"); err == nil {
 			t.Errorf("Should have returned error finalizing agreement with empty contract address.")
-		} else if err := pm.CancelAgreement([]Policy{*wrongPol}, ""); err == nil {
+		} else if err := pm.CancelAgreement([]Policy{*wrongPol}, "", "testorg"); err == nil {
 			t.Errorf("Should have returned error cancelling agreement with empty contract address.")
 		}
 
 		// Grab the right policy
 		pol := pm.GetPolicy("testorg", "find policy2")
-		if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345a"); err != nil {
+		if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345a", "testorg"); err != nil {
 			t.Error(err)
-		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345a"); err == nil {
+		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345a", "testorg"); err == nil {
 			t.Errorf("Should have returned error attempting agreement twice on same contract.")
-		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345b"); err != nil {
+		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345b", "testorg"); err != nil {
 			t.Error(err)
-		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345c"); err != nil {
+		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345c", "testorg"); err != nil {
 			t.Error(err)
-		} else if max, err := pm.ReachedMaxAgreements([]Policy{*pol}); !max || err != nil {
+		} else if max, err := pm.ReachedMaxAgreements([]Policy{*pol}, "testorg"); !max || err != nil {
 			t.Errorf("Should have returned true, reached max agreements of %v.", pol.MaxAgreements)
-		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345d"); err == nil {
+		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345d", "testorg"); err == nil {
 			t.Errorf("Should have returned error attempting to finalize non-existent agreement %v.", pm)
-		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345c"); err != nil {
+		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345c", "testorg"); err != nil {
 			t.Error(err)
-		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345c"); err == nil {
+		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345c", "testorg"); err == nil {
 			t.Errorf("Should have returned error attempting to finalize already final agreement %v.", pm)
-		} else if err := pm.CancelAgreement([]Policy{*pol}, "0x12345d"); err == nil {
+		} else if err := pm.CancelAgreement([]Policy{*pol}, "0x12345d", "testorg"); err == nil {
 			t.Errorf("Should have returned error cancelling non-existent agreement %v.", pol.MaxAgreements)
-		} else if err := pm.CancelAgreement([]Policy{*pol}, "0x12345b"); err != nil {
+		} else if err := pm.CancelAgreement([]Policy{*pol}, "0x12345b", "testorg"); err != nil {
 			t.Error(err)
-		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}); err != nil {
+		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}, "testorg"); err != nil {
 			t.Error(err)
 		} else if atMax {
 			t.Errorf("Policy max agreements is %v, should NOT be reporting reached max contracts.", pol.MaxAgreements)
-		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345b"); err != nil {
+		} else if err := pm.AttemptingAgreement([]Policy{*pol}, "0x12345b", "testorg"); err != nil {
 			t.Error(err)
-		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345b"); err != nil {
+		} else if err := pm.FinalAgreement([]Policy{*pol}, "0x12345b", "testorg"); err != nil {
 			t.Error(err)
-		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}); err != nil {
+		} else if atMax, err := pm.ReachedMaxAgreements([]Policy{*pol}, "testorg"); err != nil {
 			t.Error(err)
 		} else if !atMax {
 			t.Errorf("Policy max agreements is %v, should be reporting reached max contracts.", pol.MaxAgreements)
@@ -207,7 +207,7 @@ func Test_contractCounter_failure1(t *testing.T) {
 
 func Test_find_by_apispec1(t *testing.T) {
 
-	if pm, err := Initialize("./test/pfcompat1/", nil); err != nil {
+	if pm, err := Initialize("./test/pfcompat1/", nil, true); err != nil {
 		t.Error(err)
 	} else {
 		searchURL := "http://mycompany.com/dm/gps"
@@ -231,7 +231,7 @@ func Test_find_by_apispec1(t *testing.T) {
 }
 
 func Test_add_policy(t *testing.T) {
-	if pm, err := Initialize("./test/pffindtest/", nil); err != nil {
+	if pm, err := Initialize("./test/pffindtest/", nil, false); err != nil {
 		t.Error(err)
 	} else {
 
@@ -338,7 +338,7 @@ func Test_MergeAllProducers1(t *testing.T) {
 		t.Errorf("Error: returned %v, should have returned %v\n", p3, pc)
 	} else {
 		policies := []Policy{*p1, *p2}
-		pm := PolicyManager_Factory()
+		pm := PolicyManager_Factory(true)
 		if mergedPol, err := pm.MergeAllProducers(&policies, p3); err != nil {
 			t.Errorf("Error: %v merging %v and %v\n", err, p1, p2)
 		} else if _, err := Are_Compatible_Producers(p3, mergedPol, 600); err != nil {
@@ -352,7 +352,7 @@ func Test_MergeAllProducers1(t *testing.T) {
 func Test_MergeAllProducers2(t *testing.T) {
 	var p3 *Policy
 	policies := []Policy{}
-	pm := PolicyManager_Factory()
+	pm := PolicyManager_Factory(true)
 	if _, err := pm.MergeAllProducers(&policies, p3); err == nil {
 		t.Errorf("No policies, should return an error\n")
 	}
@@ -378,7 +378,7 @@ func Test_MergeAllProducers3(t *testing.T) {
 		t.Errorf("Error: returned %v, should have returned %v\n", p3, pc)
 	} else {
 		policies := []Policy{*p1}
-		pm := PolicyManager_Factory()
+		pm := PolicyManager_Factory(true)
 		if mergedPol, err := pm.MergeAllProducers(&policies, p3); err != nil {
 			t.Errorf("Error: %v merging %v with nothing\n", err, p1)
 		} else if _, err := Are_Compatible_Producers(p3, mergedPol, 600); err != nil {

--- a/policy/test/pffindtest/testorg/find.policy
+++ b/policy/test/pffindtest/testorg/find.policy
@@ -5,7 +5,7 @@
     },
     "apiSpec": [
         {
-            "specRef": "http://mycompany.com/policy",
+            "specRef": "http://mycompany.com/microservice/spec",
             "version": "[1.0.0,2.0.0)",
             "exclusiveAccess": false
         }

--- a/policy/workload_test.go
+++ b/policy/workload_test.go
@@ -388,6 +388,22 @@ func Test_nexthighestpriority_workload2(t *testing.T) {
 
 }
 
+func Test_WorkloadFactory(t *testing.T) {
+
+	wl := Workload_Factory("myurl", "myorg", "1.0.0", "armhf")
+	if wl.WorkloadURL != "myurl" || wl.Org != "myorg" || wl.Version != "1.0.0" || wl.Arch != "armhf" {
+		t.Errorf("Workload %v was not created correctly.", wl)
+	}
+}
+
+func Test_WorkloadPriority_Factory(t *testing.T) {
+
+	wl := Workload_Priority_Factory(50, 2, 120, 240)
+	if wl.PriorityValue != 50 || wl.Retries != 2 || wl.RetryDurationS != 120 || wl.VerifiedDurationS != 240 {
+		t.Errorf("Workload priority %v was not created correctly.", wl)
+	}
+}
+
 // Create a Workload section from a JSON serialization. The JSON serialization
 // does not have to be a valid Workload serialization, just has to be a valid
 // JSON serialization.


### PR DESCRIPTION
Notes:
1. This code REQUIRES exchange v1.33.
2. Old style policy files are not supported. Either use the new split microservice based policy files or use patterns.
3. agbot policy files MUST be placed in a subdirectory named the same as the org that the agbot is serving. The subdirectory goes under the configured PolicyPath directory.
4. Blockchain agreements and HA nodes have NOT been tested with this code. That will come later.
5. To serve a pattern based workload, the agbot MUST have the org and pattern configured to it in the exchange.