### PR TITLE
fixed order of header setting in common writeResponse() function such…

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -302,8 +302,8 @@ func writeResponse(w http.ResponseWriter, payload interface{}, successStatusCode
 		return
 	}
 
-	w.WriteHeader(successStatusCode)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(successStatusCode)
 
 	if _, err := w.Write(serial); err != nil {
 		glog.Error(err)


### PR DESCRIPTION
… that the content-type gets set appropriately in the HTTP response header