### PR TITLE
Issue 355 - autoconfigure microservices that dont have variables to set

### DIFF
--- a/agreement/agreement.go
+++ b/agreement/agreement.go
@@ -323,6 +323,11 @@ func (w *AgreementWorker) handleDeviceRegistered(cmd *DeviceRegisteredCommand) {
 		}
 	}
 
+	// Do a quick sync to clean out old agreements in the exchange.
+	if err := w.syncOnInit(); err != nil {
+		glog.Errorf(logString(fmt.Sprintf("error during sync up of agreements, error: %v", err)))
+	}
+
 	// Start the go thread that heartbeats to the exchange
 	targetURL := w.Manager.Config.Edge.ExchangeURL + "orgs/" + exchange.GetOrg(w.deviceId) + "/nodes/" + exchange.GetId(w.deviceId) + "/heartbeat"
 	go exchange.Heartbeat(w.httpClient, targetURL, w.deviceId, w.deviceToken, w.Worker.Manager.Config.Edge.ExchangeHeartbeat)

--- a/agreement/agreement.go
+++ b/agreement/agreement.go
@@ -135,6 +135,13 @@ func (w *AgreementWorker) NewEvent(incoming events.Message) {
 			w.containerSyncUpEvent = true
 		}
 
+	case *events.EdgeConfigCompleteMessage:
+		msg, _ := incoming.(*events.EdgeConfigCompleteMessage)
+		switch msg.Event().Id {
+		case events.NEW_DEVICE_CONFIG_COMPLETE:
+			w.Commands <- NewEdgeConfigCompleteCommand(msg)
+		}
+
 	default: //nothing
 	}
 
@@ -278,6 +285,13 @@ func (w *AgreementWorker) start() {
 				cmd, _ := command.(*producer.BCWritableCommand)
 				for _, pph := range w.producerPH {
 					pph.SetBlockchainWritable(cmd)
+				}
+
+			case *EdgeConfigCompleteCommand:
+				if w.deviceToken == "" {
+					glog.Warningf(logString(fmt.Sprintf("ignoring config complete, device not registered: %v and %v", w.deviceId, w.deviceToken)))
+				} else {
+					w.patchNodeKey()
 				}
 
 			default:
@@ -543,6 +557,30 @@ func (w *AgreementWorker) registerNode(dev *persistence.ExchangeDevice, ms *[]ex
 	}
 }
 
+func (w *AgreementWorker) patchNodeKey() error {
+
+	pdr := exchange.CreatePatchDeviceKey()
+
+	var resp interface{}
+	resp = new(exchange.PutDeviceResponse)
+	targetURL := w.Manager.Config.Edge.ExchangeURL + "orgs/" + exchange.GetOrg(w.deviceId) + "/nodes/" + exchange.GetId(w.deviceId)
+
+	glog.V(3).Infof(logString(fmt.Sprintf("patching messaging key to node entry: %v at %v", pdr, targetURL)))
+
+	for {
+		if err, tpErr := exchange.InvokeExchange(w.httpClient, "PATCH", targetURL, w.deviceId, w.deviceToken, pdr, &resp); err != nil {
+			return err
+		} else if tpErr != nil {
+			glog.Warningf(tpErr.Error())
+			time.Sleep(10 * time.Second)
+			continue
+		} else {
+			glog.V(3).Infof(logString(fmt.Sprintf("patched node key for device %v in exchange: %v", w.deviceId, resp)))
+			return nil
+		}
+	}
+}
+
 func (w *AgreementWorker) advertiseAllPolicies(location string) error {
 
 	var pType, pValue, pCompare string
@@ -621,6 +659,10 @@ func (w *AgreementWorker) advertiseAllPolicies(location string) error {
 
 		}
 
+		// Register the node's microservices and policies in the exchange so that the agbot can see
+		// what's available on the node. However, the node's messaging key is published later, after the
+		// configstate API is called to complete configuration on the node. It is the presence of this key
+		// in the exchange that tells the agbot it can make an agreement with this device.
 		if err := w.registerNode(dev, &ms); err != nil {
 			return err
 		}

--- a/agreement/commands.go
+++ b/agreement/commands.go
@@ -51,3 +51,18 @@ func NewAdvertisePolicyCommand(fileName string) *AdvertisePolicyCommand {
 		PolicyFile: fileName,
 	}
 }
+
+// ==============================================================================================================
+type EdgeConfigCompleteCommand struct {
+	Msg *events.EdgeConfigCompleteMessage
+}
+
+func (d EdgeConfigCompleteCommand) ShortString() string {
+	return fmt.Sprintf("%v", d)
+}
+
+func NewEdgeConfigCompleteCommand(msg *events.EdgeConfigCompleteMessage) *EdgeConfigCompleteCommand {
+	return &EdgeConfigCompleteCommand{
+		Msg: msg,
+	}
+}

--- a/agreementbot/pattern_manager.go
+++ b/agreementbot/pattern_manager.go
@@ -110,10 +110,10 @@ func (pm *PatternManager) hasPattern(org string, pattern string) bool {
 // Given a list of org/pattern pairs that this agbot is supported to be serving, take that list and
 // convert it to map of maps (keyed by org and pattern name) to hold all the pattern metadata. This
 // will allow the PatternManager to know when the pattern metadata changes.
-func (pm *PatternManager) SetCurrentPatterns(servedPatterns *[]exchange.ServedPatterns, policyPath string) error {
+func (pm *PatternManager) SetCurrentPatterns(servedPatterns map[string]exchange.ServedPattern, policyPath string) error {
 
 	// Exit early if nothing to do
-	if len(pm.OrgPatterns) == 0 && len(*servedPatterns) == 0 {
+	if len(pm.OrgPatterns) == 0 && len(servedPatterns) == 0 {
 		return nil
 	}
 
@@ -122,7 +122,7 @@ func (pm *PatternManager) SetCurrentPatterns(servedPatterns *[]exchange.ServedPa
 
 	// For each org/pattern pair that this agbot is supposed to be serving copy the map entries from the
 	// existing map or create new ones as necesssary.
-	for _, served := range *servedPatterns {
+	for _, served := range servedPatterns {
 
 		// If we have encountered a new org in the served pattern list, create a map of patterns for it.
 		if _, ok := newMap[served.Org]; !ok {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,10 @@
+// +build unit
+
+package api
+
+import (
+	"testing"
+)
+
+func Test_service(t *testing.T) {
+}

--- a/api/common_test.go
+++ b/api/common_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"github.com/boltdb/bolt"
+	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/anax/policy"
+	"io/ioutil"
+	"os"
+	"path"
+	"time"
+)
+
+// ========================================================================================
+// These are functions which are used across the set of API unit tests
+
+func getDummyWorkloadResolver() WorkloadResolverHandler {
+	return func(wUrl string, wOrg string, wVersion string, wArch string, id string, token string) (*policy.APISpecList, error) {
+		return nil, nil
+	}
+}
+
+func getDummyMicroserviceHandler() MicroserviceHandler {
+	return func(mUrl string, mOrg string, mVersion string, mArch string, id string, token string) (*exchange.MicroserviceDefinition, error) {
+		return nil, nil
+	}
+}
+
+func getBasicConfig() *config.HorizonConfig {
+	return &config.HorizonConfig{
+		Edge: config.Config{
+			DefaultServiceRegistrationRAM: 256,
+			PolicyPath:                    "/tmp/",
+		},
+		AgreementBot: config.AGConfig{},
+		Collaborators: config.Collaborators{
+			HTTPClientFactory: nil,
+		},
+	}
+}
+
+func getDummyGetOrg() OrgHandler {
+	return func(org string, id string, token string) (*exchange.Organization, error) {
+		return nil, nil
+	}
+}
+
+func getDummyGetPatterns() PatternHandler {
+	return func(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error) {
+		return nil, nil
+	}
+}
+
+func setup() (string, *bolt.DB, error) {
+	dir, err := ioutil.TempDir("", "horizondevice-")
+	if err != nil {
+		return "", nil, err
+	}
+
+	db, err := bolt.Open(path.Join(dir, "anax-int.db"), 0600, &bolt.Options{Timeout: 10 * time.Second})
+	if err != nil {
+		return dir, nil, err
+	}
+
+	return dir, db, nil
+}
+
+// Make a deferred call to this function after calling setup(), passing the output dirpath of the setup() function.
+func cleanTestDir(dirPath string) error {
+	if _, err := os.Stat(dirPath); !os.IsNotExist(err) {
+		if err := os.RemoveAll(dirPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/golang/glog"
+	"net/http"
+)
+
+// This function type is used to enable plug replaceable error handlers within the API
+// implementation so that business logic can be tested independently from the HTTP
+// transport that is used to access the API.
+type ErrorHandler func(err error) bool
+
+// APIUserInputError is for problems found with input path variables or input bodies. The Input field is flexible;
+// could be a field name or other. Note: the info in this field is intended to be consumed by humans, either API
+// consumers or developers of the UI. Add enum codes if these are to be evaluated in frontend code.
+type APIUserInputError struct {
+	Err   string `json:"error"`
+	Input string `json:"input,omitempty"`
+}
+
+func (e APIUserInputError) Error() string {
+	return fmt.Sprintf("Input: %v, Error: %v", e.Input, e.Err)
+}
+
+func NewAPIUserInputError(err string, input string) *APIUserInputError {
+	return &APIUserInputError{
+		Err:   err,
+		Input: input,
+	}
+}
+
+// MSMissingVariableConfigError is for problems found with microservice configuration where the microservice definition
+// requires 1 or more input variables to be set but 1 or more of those variables has not been set.
+type MSMissingVariableConfigError struct {
+	Err   string `json:"error"`
+	Input string `json:"input,omitempty"`
+}
+
+func (e MSMissingVariableConfigError) Error() string {
+	return fmt.Sprintf("Input: %v, Error: %v", e.Input, e.Err)
+}
+
+func NewMSMissingVariableConfigError(err string, input string) *MSMissingVariableConfigError {
+	return &MSMissingVariableConfigError{
+		Err:   err,
+		Input: input,
+	}
+}
+
+// DuplicateServiceError occurs when a microservice configuration is attempted for a service that has already been
+// configured.
+type DuplicateServiceError struct {
+	Err   string `json:"error"`
+	Input string `json:"input,omitempty"`
+}
+
+func (e DuplicateServiceError) Error() string {
+	return fmt.Sprintf("Input: %v, Error: %v", e.Input, e.Err)
+}
+
+func NewDuplicateServiceError(err string, input string) *DuplicateServiceError {
+	return &DuplicateServiceError{
+		Err:   err,
+		Input: input,
+	}
+}
+
+// Conflict Errors are expected, since they can occur as the result of incorrect usage of the API.
+type ConflictError struct {
+	msg string
+}
+
+func (e ConflictError) Error() string {
+	return e.msg
+}
+
+func NewConflictError(err string) *ConflictError {
+	return &ConflictError{
+		msg: err,
+	}
+}
+
+// System Errors are generally unexpected, infrastructural problems that just need to be reported out to the caller.
+type SystemError struct {
+	msg string
+}
+
+func (e SystemError) Error() string {
+	return e.msg
+}
+
+func NewSystemError(err string) *SystemError {
+	return &SystemError{
+		msg: err,
+	}
+}
+
+// Use this function to obtain an error handler that simply passes the error through itself back to caller. This is
+// done by modifying the error variable passed to this function.
+func GetPassThroughErrorHandler(passthruErr *error) ErrorHandler {
+	//return func(err error) bool {
+	return func(err error) bool {
+		*passthruErr = err
+		return true
+	}
+}
+
+// Use this function to obtain an error handler that writes errors to the HTTP response.
+func GetHTTPErrorHandler(w http.ResponseWriter) ErrorHandler {
+	// returned value indicates whether or not processing can continue
+	return func(err error) bool {
+		if err != nil {
+			switch err.(type) {
+			case *APIUserInputError:
+				apiErr := err.(*APIUserInputError)
+				writeInputErr(w, http.StatusBadRequest, apiErr)
+
+			case *MSMissingVariableConfigError:
+				// convert to an API Input Error
+				msErr := err.(*MSMissingVariableConfigError)
+				apiErr := NewAPIUserInputError(msErr.Err, msErr.Input)
+				writeInputErr(w, http.StatusBadRequest, apiErr)
+
+			case *DuplicateServiceError:
+				// convert to an API Input Error
+				dupErr := err.(*DuplicateServiceError)
+				apiErr := NewAPIUserInputError(dupErr.Err, dupErr.Input)
+				writeInputErr(w, http.StatusBadRequest, apiErr)
+
+			case *SystemError:
+				sysErr := err.(*SystemError)
+				glog.Errorf(apiLogString(sysErr.Error()))
+				http.Error(w, sysErr.Error(), http.StatusInternalServerError)
+
+			case *ConflictError:
+				conErr := err.(*ConflictError)
+				glog.Errorf(apiLogString(conErr.Error()))
+				http.Error(w, conErr.Error(), http.StatusConflict)
+
+			default:
+				glog.Errorf(apiLogString(fmt.Sprintf("unknown error (%T) %v", err, err.Error())))
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+
+			}
+			// tell the caller they should not continue processing
+			return true
+
+		} else {
+			return false
+		}
+	}
+}
+
+// use this function to properly write a User Input Error to the http response.
+func writeInputErr(writer http.ResponseWriter, status int, inputErr *APIUserInputError) {
+	if serial, err := json.Marshal(inputErr); err != nil {
+		glog.Errorf(apiLogString(fmt.Sprintf("Error serializing input error: %v, error %v", inputErr, err)))
+		http.Error(writer, "Internal server error", http.StatusInternalServerError)
+	} else {
+		writer.WriteHeader(status)
+		writer.Header().Set("Content-Type", "application/json")
+		if _, err := writer.Write(serial); err != nil {
+			glog.Errorf(apiLogString(fmt.Sprintf("Error writing response: %v, error %v", serial, err)))
+			http.Error(writer, "Internal server error", http.StatusInternalServerError)
+		} else {
+			glog.Errorf(apiLogString(fmt.Sprintf("Returning status %v for error %v", status, string(serial))))
+		}
+	}
+}

--- a/api/errors.go
+++ b/api/errors.go
@@ -82,6 +82,36 @@ func NewConflictError(err string) *ConflictError {
 	}
 }
 
+// Bad Requests are expected, since they can occur as the result of incorrect usage of the API.
+type BadRequestError struct {
+	msg string
+}
+
+func (e BadRequestError) Error() string {
+	return e.msg
+}
+
+func NewBadRequestError(err string) *BadRequestError {
+	return &BadRequestError{
+		msg: err,
+	}
+}
+
+// Not Found errors are expected, since they can occur as the result of incorrect usage of the API.
+type NotFoundError struct {
+	msg string
+}
+
+func (e NotFoundError) Error() string {
+	return e.msg
+}
+
+func NewNotFoundError(err string) *NotFoundError {
+	return &NotFoundError{
+		msg: err,
+	}
+}
+
 // System Errors are generally unexpected, infrastructural problems that just need to be reported out to the caller.
 type SystemError struct {
 	msg string
@@ -138,6 +168,16 @@ func GetHTTPErrorHandler(w http.ResponseWriter) ErrorHandler {
 				conErr := err.(*ConflictError)
 				glog.Errorf(apiLogString(conErr.Error()))
 				http.Error(w, conErr.Error(), http.StatusConflict)
+
+			case *BadRequestError:
+				badErr := err.(*BadRequestError)
+				glog.Errorf(apiLogString(badErr.Error()))
+				http.Error(w, badErr.Error(), http.StatusBadRequest)
+
+			case *NotFoundError:
+				notErr := err.(*NotFoundError)
+				glog.Errorf(apiLogString(notErr.Error()))
+				http.Error(w, notErr.Error(), http.StatusNotFound)
 
 			default:
 				glog.Errorf(apiLogString(fmt.Sprintf("unknown error (%T) %v", err, err.Error())))

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -1,0 +1,63 @@
+// +build unit
+
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_APIInputError(t *testing.T) {
+
+	theError := "the error"
+	theInput := "bad input"
+
+	apiErr := NewAPIUserInputError(theError, theInput)
+	if apiErr == nil {
+		t.Errorf("API User input constructor returned nil")
+	}
+
+	errString := apiErr.Error()
+	if !strings.Contains(errString, theError) && !strings.Contains(errString, theInput) {
+		t.Errorf("Error string does not contain the input values %v and %v, it is %v", theError, theInput, apiErr)
+	}
+
+}
+
+func Test_SystemError(t *testing.T) {
+
+	theError := "the error"
+
+	sysErr := NewSystemError(theError)
+	if sysErr == nil {
+		t.Errorf("System error constructor returned nil")
+	}
+
+	errString := sysErr.Error()
+	if !strings.Contains(errString, theError) {
+		t.Errorf("Error string does not contain the input value %v, it is %v", theError, sysErr)
+	}
+
+}
+
+func Test_PassthruHandler(t *testing.T) {
+
+	var myError error
+	handler := GetPassThroughErrorHandler(&myError)
+	if handler == nil {
+		t.Errorf("Return nil handler")
+	}
+
+	sysErr := NewSystemError("passthru test error")
+
+	handled := handler(sysErr)
+
+	if !handled {
+		t.Errorf("Handler should always return true")
+	}
+
+	if myError.Error() != sysErr.Error() {
+		t.Errorf("Passed through error was %T %v, should be %T %v", myError, myError, sysErr, sysErr)
+	}
+
+}

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/anax/policy"
+)
+
+// The handlers module defines replaceable functions that represent the API's external dependencies. These
+// handlers can be replaced by unit or integration tests to mock the external dependency.
+
+// A handler for querying the exchange for an organization.
+type OrgHandler func(org string, id string, token string) (*exchange.Organization, error)
+
+func GetHTTPExchangeOrgHandler(a *API) OrgHandler {
+	return func(org string, id string, token string) (*exchange.Organization, error) {
+		return exchange.GetOrganization(a.Config.Collaborators.HTTPClientFactory, org, a.Config.Edge.ExchangeURL, id, token)
+	}
+}
+
+// A handler for querying the exchange for patterns.
+type PatternHandler func(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error)
+
+func GetHTTPExchangePatternHandler(a *API) PatternHandler {
+	return func(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error) {
+		return exchange.GetPatterns(a.Config.Collaborators.HTTPClientFactory, org, pattern, a.Config.Edge.ExchangeURL, id, token)
+	}
+}
+
+// A handler for querying the exchange for microservices.
+type MicroserviceHandler func(mUrl string, mOrg string, mVersion string, mArch string, id string, token string) (*exchange.MicroserviceDefinition, error)
+
+func GetHTTPMicroserviceHandler(a *API) MicroserviceHandler {
+	return func(mUrl string, mOrg string, mVersion string, mArch string, id string, token string) (*exchange.MicroserviceDefinition, error) {
+		return exchange.GetMicroservice(a.Config.Collaborators.HTTPClientFactory, mUrl, mOrg, mVersion, mArch, a.Config.Edge.ExchangeURL, id, token)
+	}
+}
+
+// A handler for resolving workload references in the exchange.
+type WorkloadResolverHandler func(wUrl string, wOrg string, wVersion string, wArch string, id string, token string) (*policy.APISpecList, error)
+
+func GetHTTPWorkloadResolverHandler(a *API) WorkloadResolverHandler {
+	return func(wUrl string, wOrg string, wVersion string, wArch string, id string, token string) (*policy.APISpecList, error) {
+		return exchange.WorkloadResolver(a.Config.Collaborators.HTTPClientFactory, wUrl, wOrg, wVersion, wArch, a.Config.Edge.ExchangeURL, id, token)
+	}
+}

--- a/api/input_validation.go
+++ b/api/input_validation.go
@@ -2,18 +2,10 @@ package api
 
 import (
 	"fmt"
-	"github.com/golang/glog"
-	"net/http"
 	"regexp"
 )
 
 var IllegalInputCharRegex = `[^-*+()?&! _\w\d.@,:/\\]`
-
-// "input" is flexible; could be a field name or other. Note: this is intended to be consumed by humans, either API consumers or developers of the UI. Add enum codes if these are to be evaluated in frontend code
-type APIUserInputError struct {
-	Error string `json:"error"`
-	Input string `json:"input,omitempty"`
-}
 
 func InputIsIllegal(str string) (string, error) {
 	reg, err := regexp.Compile(IllegalInputCharRegex)
@@ -47,24 +39,22 @@ func MapInputIsIllegal(m map[string]interface{}) (string, string, error) {
 	return "", "", nil
 }
 
-func checkInputString(w http.ResponseWriter, fieldId string, input *string) bool {
+// Verify that the input string value is valid according to the list of supported characters. if there
+// is an error, this function returns true to indicate that there was an error.
+func checkInputString(errorHandler ErrorHandler, fieldId string, input *string) bool {
 	nErrMsg := "null and must not be"
 
 	// if true, bail
 	if input == nil {
-		writeInputErr(w, http.StatusBadRequest, &APIUserInputError{Input: fieldId, Error: nErrMsg})
-		return true
+		return errorHandler(NewAPIUserInputError(nErrMsg, fieldId))
 	}
 	inputErr, err := InputIsIllegal(*input)
 	if err != nil {
-		glog.Errorf("Failed to check input: %v", err)
-		w.WriteHeader(http.StatusBadRequest)
-		return true
+		return errorHandler(NewSystemError(fmt.Sprintf("Failed to check input: %v", err)))
 	}
 
 	if inputErr != "" {
-		writeInputErr(w, http.StatusBadRequest, &APIUserInputError{Input: fieldId, Error: inputErr})
-		return true
+		return errorHandler(NewAPIUserInputError(inputErr, fieldId))
 	}
 
 	return false

--- a/api/input_validation_test.go
+++ b/api/input_validation_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -40,4 +41,171 @@ func Test_MapInputIsIllegal(t *testing.T) {
 	if b, _, _ := MapInputIsIllegal(map[string]interface{}{"one": "g oo", "t#wo": "()", "t hree": "3", "f()our": " ", "germ": "foo"}); b == "" {
 		t.Errorf("Map input found to be legal but isn't")
 	}
+}
+
+func Test_CheckInputString_valid1(t *testing.T) {
+
+	var myError error
+	handler := GetPassThroughErrorHandler(&myError)
+
+	aField := "input1"
+	theInput := "instring"
+	errorOccurred := checkInputString(handler, aField, &theInput)
+
+	if errorOccurred {
+		t.Errorf("found problem with input, but it is ok: %v", theInput)
+	}
+
+	if myError != nil && len(myError.Error()) != 0 {
+		t.Errorf("error should be empty, is %v", myError.Error())
+	}
+
+}
+
+func Test_CheckInputString_valid2(t *testing.T) {
+
+	var myError error
+	handler := GetPassThroughErrorHandler(&myError)
+
+	aField := "input1"
+	theInput := ""
+	errorOccurred := checkInputString(handler, aField, &theInput)
+
+	if errorOccurred {
+		t.Errorf("found problem with input, but it is ok: %v", theInput)
+	}
+
+	if myError != nil && len(myError.Error()) != 0 {
+		t.Errorf("error should be empty, is %v", myError.Error())
+	}
+
+}
+
+func Test_CheckInputString_invalid1(t *testing.T) {
+
+	var myError error
+	handler := GetPassThroughErrorHandler(&myError)
+
+	aField := "input1"
+	theInput := ">0"
+	errorOccurred := checkInputString(handler, aField, &theInput)
+
+	if !errorOccurred {
+		t.Errorf("no problem found with input, but it illegal: %v", theInput)
+	}
+
+	if myError == nil || len(myError.Error()) == 0 {
+		t.Errorf("error should not be empty, but is")
+	}
+
+}
+
+func Test_CheckInputString_invalid2(t *testing.T) {
+
+	var myError error
+	handler := GetPassThroughErrorHandler(&myError)
+
+	aField := "input1"
+	errorOccurred := checkInputString(handler, aField, nil)
+
+	if !errorOccurred {
+		t.Errorf("no problem found with input, but it illegal")
+	}
+
+	if myError == nil || len(myError.Error()) == 0 {
+		t.Errorf("error should not be empty, but is")
+	}
+
+}
+
+func Test_CheckMapIsLegal1(t *testing.T) {
+
+	inMap := map[string]interface{}{}
+
+	key, errorMsg, err := MapInputIsIllegal(inMap)
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if key != "" {
+		t.Errorf("unexpected key value %v", key)
+	}
+
+	if errorMsg != "" {
+		t.Errorf("unexpected error message %v", errorMsg)
+	}
+
+}
+
+func Test_CheckMapIsLegal2(t *testing.T) {
+
+	inMap := map[string]interface{}{
+		"key1": "value1",
+	}
+
+	key, errorMsg, err := MapInputIsIllegal(inMap)
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if key != "" {
+		t.Errorf("unexpected key value %v", key)
+	}
+
+	if errorMsg != "" {
+		t.Errorf("unexpected error message %v", errorMsg)
+	}
+
+}
+
+func Test_CheckMapIsIllegal1(t *testing.T) {
+
+	badKey := "<0"
+
+	inMap := map[string]interface{}{
+		badKey: "value1",
+	}
+
+	key, errorMsg, err := MapInputIsIllegal(inMap)
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if key != badKey {
+		t.Errorf("expected error key value %v", badKey)
+	}
+
+	if errorMsg == "" {
+		t.Errorf("expected error message")
+	}
+
+}
+
+func Test_CheckMapIsIllegal2(t *testing.T) {
+
+	key1 := "key1"
+	badValue := "<0"
+	expectedKey := fmt.Sprintf("%v: %v", key1, badValue)
+
+	inMap := map[string]interface{}{
+		key1: badValue,
+	}
+
+	key, errorMsg, err := MapInputIsIllegal(inMap)
+
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if key != expectedKey {
+		t.Errorf("expected error key value %v but was %v", expectedKey, key)
+	}
+
+	if errorMsg == "" {
+		t.Errorf("expected error message")
+	}
+
 }

--- a/api/path_agreement.go
+++ b/api/path_agreement.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"github.com/boltdb/bolt"
+	"github.com/golang/glog"
+	"github.com/open-horizon/anax/events"
+	"github.com/open-horizon/anax/persistence"
+	"github.com/open-horizon/anax/policy"
+	"sort"
+)
+
+func FindAgreementsForOutput(db *bolt.DB) (map[string]map[string][]persistence.EstablishedAgreement, error) {
+
+	agreements, err := persistence.FindEstablishedAgreementsAllProtocols(db, policy.AllAgreementProtocols(), []persistence.EAFilter{})
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("unable to read agreement objects, error %v", err))
+	}
+
+	// The output is map that contains a set of active agreements and a set of archived agreements.
+	var agreementsKey = "agreements"
+	var archivedKey = "archived"
+	var activeKey = "active"
+
+	wrap := make(map[string]map[string][]persistence.EstablishedAgreement, 0)
+	wrap[agreementsKey] = make(map[string][]persistence.EstablishedAgreement, 0)
+	wrap[agreementsKey][archivedKey] = []persistence.EstablishedAgreement{}
+	wrap[agreementsKey][activeKey] = []persistence.EstablishedAgreement{}
+
+	for _, agreement := range agreements {
+		// The archived agreements and the agreements being terminated are returned as archived.
+		if agreement.Archived || agreement.AgreementTerminatedTime != 0 {
+			wrap[agreementsKey][archivedKey] = append(wrap[agreementsKey][archivedKey], agreement)
+		} else {
+			wrap[agreementsKey][activeKey] = append(wrap[agreementsKey][activeKey], agreement)
+		}
+	}
+
+	// do sorts
+	sort.Sort(EstablishedAgreementsByAgreementCreationTime(wrap[agreementsKey][activeKey]))
+	sort.Sort(EstablishedAgreementsByAgreementTerminatedTime(wrap[agreementsKey][archivedKey]))
+
+	return wrap, nil
+}
+
+func DeleteAgreement(errorhandler ErrorHandler, agreementId string, db *bolt.DB) (bool, *events.ApiAgreementCancelationMessage) {
+
+	glog.V(3).Infof("Handling DELETE of agreement: %v", agreementId)
+
+	var filters []persistence.EAFilter
+	filters = append(filters, persistence.UnarchivedEAFilter())
+	filters = append(filters, persistence.IdEAFilter(agreementId))
+
+	agreements, err := persistence.FindEstablishedAgreementsAllProtocols(db, policy.AllAgreementProtocols(), filters)
+	if err != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("unable to read agreement objects, error %v", err))), nil
+	} else if len(agreements) == 0 {
+		return errorhandler(NewNotFoundError(fmt.Sprintf("no agreements in local database"))), nil
+	}
+
+	// Deletion is actually handled asynchronously. If the agreement is already terminating there is nothing to do.
+	var msg *events.ApiAgreementCancelationMessage
+	if agreements[0].AgreementTerminatedTime == 0 {
+		msg = events.NewApiAgreementCancelationMessage(events.AGREEMENT_ENDED, events.AG_TERMINATED, agreements[0].AgreementProtocol, agreements[0].CurrentAgreementId, agreements[0].CurrentDeployment)
+	}
+
+	return false, msg
+}

--- a/api/path_agreement_test.go
+++ b/api/path_agreement_test.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"flag"
+	"github.com/open-horizon/anax/persistence"
+	"testing"
+)
+
+func init() {
+	flag.Set("alsologtostderr", "true")
+	flag.Set("v", "7")
+	// no need to parse flags, that's done by test framework
+}
+
+func Test_FindAgreementsForOutput0(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	// No agreements in the DB yet.
+
+	// Now test the GET /agreements function.
+	if agsout, err := FindAgreementsForOutput(db); err != nil {
+		t.Errorf("error finding agreements: %v", err)
+	} else if len(agsout["agreements"]["active"]) != 0 {
+		t.Errorf("expecting 0 active agreements have %v", agsout["agreements"]["active"])
+	} else if len(agsout["agreements"]["archived"]) != 0 {
+		t.Errorf("expecting 0 archived agreements have %v", agsout["agreements"]["archived"])
+	}
+
+}
+
+func Test_FindAgreementsForOutput1(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	// Add 3 agreements to the DB, one for each path in the /agreement GET.
+	// Agreement 1 is active, agreement2 is archived, agreement3 is active but terminating.
+	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement1: %v", err)
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement2: %v", err)
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement3: %v", err)
+	} else if _, err := persistence.ArchiveEstablishedAgreement(db, "agreementId2", "Basic"); err != nil {
+		t.Errorf("error archiving agreement2: %v", err)
+	} else if _, err := persistence.AgreementStateTerminated(db, "agreementId3", 100, "unit test termination", "Basic"); err != nil {
+		t.Errorf("error terminating agreement3: %v", err)
+	}
+
+	// Agreements are bootstrapped into the database, now test the GET /agreements function.
+	if agsout, err := FindAgreementsForOutput(db); err != nil {
+		t.Errorf("error finding agreements: %v", err)
+	} else if len(agsout["agreements"]["active"]) != 1 {
+		t.Errorf("expecting 1 active agreement have %v", agsout["agreements"]["active"])
+	} else if len(agsout["agreements"]["archived"]) != 2 {
+		t.Errorf("expecting 2 archived agreements have %v", agsout["agreements"]["archived"])
+	}
+
+}
+
+func Test_DeleteAgreement0(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	// Add 3 agreements to the DB, one for each special agreement state.
+	// Agreement 1 is active, agreement2 is archived, agreement3 is active but terminating.
+	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement1: %v", err)
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement2: %v", err)
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement3: %v", err)
+	} else if _, err := persistence.ArchiveEstablishedAgreement(db, "agreementId2", "Basic"); err != nil {
+		t.Errorf("error archiving agreement2: %v", err)
+	} else if _, err := persistence.AgreementStateTerminated(db, "agreementId3", 100, "unit test termination", "Basic"); err != nil {
+		t.Errorf("error terminating agreement3: %v", err)
+	}
+
+	// Agreements are bootstrapped into the database, now test the DELETE /agreements function on a non-existant agreement.
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	if errHandled, msg := DeleteAgreement(errorhandler, "agreementId4", db); !errHandled {
+		t.Errorf("expected to receive error")
+	} else if _, ok := myError.(*NotFoundError); !ok {
+		t.Errorf("expected error of type NotFound, but is %T, %v", myError, myError)
+	} else if msg != nil {
+		t.Errorf("should not have returned a message object, %v", msg)
+	}
+
+}
+
+func Test_DeleteAgreement1(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	// Add 3 agreements to the DB, one for each special agreement state.
+	// Agreement 1 is active, agreement2 is archived, agreement3 is active but terminating.
+	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement1: %v", err)
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement2: %v", err)
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement3: %v", err)
+	} else if _, err := persistence.ArchiveEstablishedAgreement(db, "agreementId2", "Basic"); err != nil {
+		t.Errorf("error archiving agreement2: %v", err)
+	} else if _, err := persistence.AgreementStateTerminated(db, "agreementId3", 100, "unit test termination", "Basic"); err != nil {
+		t.Errorf("error terminating agreement3: %v", err)
+	}
+
+	// Agreements are bootstrapped into the database, now test the DELETE /agreements function on an existing agreement.
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	if errHandled, msg := DeleteAgreement(errorhandler, "agreementId3", db); errHandled {
+		t.Errorf("unexpected error (%T) %v", myError, myError)
+	} else if msg != nil {
+		t.Errorf("should not have returned a message object for terminating agreement")
+	}
+
+}
+
+func Test_DeleteAgreement2(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	// Add 3 agreements to the DB, one for each special agreement state.
+	// Agreement 1 is active, agreement2 is archived, agreement3 is active but terminating.
+	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement1: %v", err)
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement2: %v", err)
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement3: %v", err)
+	} else if _, err := persistence.ArchiveEstablishedAgreement(db, "agreementId2", "Basic"); err != nil {
+		t.Errorf("error archiving agreement2: %v", err)
+	} else if _, err := persistence.AgreementStateTerminated(db, "agreementId3", 100, "unit test termination", "Basic"); err != nil {
+		t.Errorf("error terminating agreement3: %v", err)
+	}
+
+	// Agreements are bootstrapped into the database, now test the DELETE /agreements function on an existing agreement.
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	if errHandled, msg := DeleteAgreement(errorhandler, "agreementId1", db); errHandled {
+		t.Errorf("unexpected error (%T) %v", myError, myError)
+	} else if msg == nil {
+		t.Errorf("should have returned a message object")
+	}
+
+}
+
+func Test_DeleteAgreement3(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	// Add 3 agreements to the DB, one for each special agreement state.
+	// Agreement 1 is active, agreement2 is archived, agreement3 is active but terminating.
+	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement1: %v", err)
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement2: %v", err)
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg"); err != nil {
+		t.Errorf("error writing agreement3: %v", err)
+	} else if _, err := persistence.ArchiveEstablishedAgreement(db, "agreementId2", "Basic"); err != nil {
+		t.Errorf("error archiving agreement2: %v", err)
+	} else if _, err := persistence.AgreementStateTerminated(db, "agreementId3", 100, "unit test termination", "Basic"); err != nil {
+		t.Errorf("error terminating agreement3: %v", err)
+	}
+
+	// Agreements are bootstrapped into the database, now test the DELETE /agreements function on an existing agreement.
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	if errHandled, msg := DeleteAgreement(errorhandler, "agreementId2", db); !errHandled {
+		t.Errorf("expected to receive error")
+	} else if _, ok := myError.(*NotFoundError); !ok {
+		t.Errorf("expected error of type NotFound, but is %T, %v", myError, myError)
+	} else if msg != nil {
+		t.Errorf("should not have returned a message object, %v", msg)
+	}
+
+}

--- a/api/path_configstate.go
+++ b/api/path_configstate.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"github.com/boltdb/bolt"
+	"github.com/golang/glog"
+	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/cutil"
+	"github.com/open-horizon/anax/events"
+	"github.com/open-horizon/anax/persistence"
+	"github.com/open-horizon/anax/policy"
+	"strings"
+)
+
+const CONFIGSTATE_CONFIGURING = "configuring"
+const CONFIGSTATE_CONFIGURED = "configured"
+
+func NoOpStateChange(from string, to string) bool {
+	if from == to {
+		return true
+	}
+	return false
+}
+
+func ValidStateChange(from string, to string) bool {
+	if from == CONFIGSTATE_CONFIGURING && to == CONFIGSTATE_CONFIGURED {
+		return true
+	}
+	return false
+}
+
+func FindConfigstateForOutput(db *bolt.DB) (*Configstate, error) {
+
+	var device *HorizonDevice
+
+	pDevice, err := persistence.FindExchangeDevice(db)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("unable to read horizondevice object, error %v", err))
+	} else if pDevice == nil {
+		state := CONFIGSTATE_CONFIGURING
+		cfg := &Configstate{
+			State: &state,
+		}
+		return cfg, nil
+
+	} else {
+		device = ConvertFromPersistentHorizonDevice(pDevice)
+		return device.Config, nil
+	}
+
+}
+
+// Given a demarshalled Configstate object, validate it and save, returning any errors.
+func UpdateConfigstate(cfg *Configstate,
+	errorhandler ErrorHandler,
+	getOrg OrgHandler,
+	getMicroservice MicroserviceHandler,
+	getPatterns PatternHandler,
+	resolveWorkload WorkloadResolverHandler,
+	db *bolt.DB,
+	config *config.HorizonConfig) (bool, *Configstate, []*events.PolicyCreatedMessage) {
+
+	// Check for the device in the local database. If there are errors, they will be written
+	// to the HTTP response.
+	pDevice, err := persistence.FindExchangeDevice(db)
+	if err != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("Unable to read horizondevice object, error %v", err))), nil, nil
+	} else if pDevice == nil {
+		return errorhandler(NewAPIUserInputError("Exchange registration not recorded. Complete account and device registration with an exchange and then record device registration using this API's /horizondevice path.", "configstate")), nil, nil
+	}
+
+	glog.V(3).Infof(apiLogString(fmt.Sprintf("Update configstate: device in local database: %v", pDevice)))
+	msgs := make([]*events.PolicyCreatedMessage, 0, 10)
+
+	// Device registration is in the database, so verify that the requested state change is suported.
+	// The only (valid) state transition that is currently unsupported is configured to configuring.
+	// If the caller is requesting a state change that is a noop, just return the current state.
+	if *cfg.State != CONFIGSTATE_CONFIGURING && *cfg.State != CONFIGSTATE_CONFIGURED {
+		return errorhandler(NewAPIUserInputError(fmt.Sprintf("Supported state values are '%v' and '%v'.", CONFIGSTATE_CONFIGURING, CONFIGSTATE_CONFIGURED), "configstate.state")), nil, nil
+	} else if NoOpStateChange(pDevice.Config.State, *cfg.State) {
+		exDev := ConvertFromPersistentHorizonDevice(pDevice)
+		return false, exDev.Config, nil
+	} else if !ValidStateChange(pDevice.Config.State, *cfg.State) {
+		return errorhandler(NewAPIUserInputError(fmt.Sprintf("Transition from '%v' to '%v' is not supported.", pDevice.Config.State, *cfg.State), "configstate.state")), nil, nil
+	}
+
+	// From the node's pattern, resolve all the workloads to microservices and then register each microservice that is not already registered.
+	if pDevice.Pattern != "" {
+
+		glog.V(3).Infof(apiLogString(fmt.Sprintf("Configstate autoconfig of microservices starting")))
+
+		// Get the pattern definition from the exchange. There should only be one pattern returned in the map.
+		pattern, err := getPatterns(pDevice.Org, pDevice.Pattern, pDevice.GetId(), pDevice.Token)
+		if err != nil {
+			return errorhandler(NewSystemError(fmt.Sprintf("Unable to read pattern object %v from exchange, error %v", pDevice.Pattern, err))), nil, nil
+		} else if len(pattern) != 1 {
+			return errorhandler(NewSystemError(fmt.Sprintf("Expected only 1 pattern from exchange, received %v", len(pattern)))), nil, nil
+		}
+
+		// Get the pattern definition that we need to analyze.
+		patId := fmt.Sprintf("%v/%v", pDevice.Org, pDevice.Pattern)
+		patternDef, ok := pattern[patId]
+		if !ok {
+			return errorhandler(NewSystemError(fmt.Sprintf("Expected pattern id not found in GET pattern response: %v", pattern))), nil, nil
+		}
+
+		glog.V(5).Infof(apiLogString(fmt.Sprintf("Configstate working with pattern definition %v", patternDef)))
+
+		// For each workload in the pattern, resolve the workload to a list of required microservices.
+		completeAPISpecList := new(policy.APISpecList)
+		thisArch := cutil.ArchString()
+		for _, workload := range patternDef.Workloads {
+
+			// Ignore workloads that don't match this node's hardware architecture.
+			if workload.WorkloadArch != thisArch {
+				continue
+			}
+
+			// Each workload in the pattern can specify rollback workload versions, so to get a fully qualified workload URL,
+			// we need to iterate each workload choice to grab the version.
+			for _, workloadChoice := range workload.WorkloadVersions {
+				apiSpecList, err := resolveWorkload(workload.WorkloadURL, workload.WorkloadOrg, workloadChoice.Version, thisArch, pDevice.GetId(), pDevice.Token)
+				if err != nil {
+					return errorhandler(NewSystemError(fmt.Sprintf("Error resolving workload %v %v %v %v, error %v", workload.WorkloadURL, workload.WorkloadOrg, workloadChoice.Version, thisArch, err))), nil, nil
+				}
+
+				// Microservices that are defined as being shared singletons can only appear once in the complete API spec list. If there
+				// are 2 versions of the same shared singleton microservice, the higher version of the 2 will be auto configured.
+				completeAPISpecList.ReplaceHigherSharedSingleton(apiSpecList)
+
+				// MergeWith will omit exact duplicates when merging the 2 lists.
+				(*completeAPISpecList) = completeAPISpecList.MergeWith(apiSpecList)
+			}
+
+		}
+
+		glog.V(5).Infof(apiLogString(fmt.Sprintf("Configstate resolved pattern to APISpecs %v", *completeAPISpecList)))
+
+		// Using the list of APISpec objects, we can create a service (microservice) on this node automatically, for each microservice
+		// that already has configuration or which doesnt need it.
+		var createServiceError error
+		passthruHandler := GetPassThroughErrorHandler(&createServiceError)
+		for _, apiSpec := range *completeAPISpecList {
+
+			service := NewService(apiSpec.SpecRef, apiSpec.Org, makeServiceName(apiSpec.SpecRef, apiSpec.Org, apiSpec.Version), apiSpec.Version)
+			errHandled, newService, msg := CreateService(service, passthruHandler, getMicroservice, db, config)
+			if errHandled {
+				switch createServiceError.(type) {
+				case *MSMissingVariableConfigError:
+					msErr := err.(*MSMissingVariableConfigError)
+					// Cannot autoconfig this microservice because it has variables that need to be configured.
+					return errorhandler(NewAPIUserInputError(fmt.Sprintf("Configstate autoconfig, microservice %v %v %v, %v", apiSpec.SpecRef, apiSpec.Org, apiSpec.Version, msErr.Err), "configstate.state")), nil, nil
+
+				case *DuplicateServiceError:
+					// If the microservice is already registered, that's ok because the node user is allowed to configure any of the
+					// required microservices before calling the configstate API.
+
+				default:
+					return errorhandler(NewSystemError(fmt.Sprintf("unexpected error returned from service create (%T) %v", createServiceError, createServiceError))), nil, nil
+				}
+			} else {
+				glog.V(5).Infof(apiLogString(fmt.Sprintf("Configstate autoconfig created service %v", newService)))
+				msgs = append(msgs, msg)
+			}
+		}
+
+		glog.V(3).Infof(apiLogString(fmt.Sprintf("Configstate autoconfig of microservices complete")))
+
+	}
+
+	// Update the state in the local database
+	updatedDev, err := pDevice.SetConfigstate(db, pDevice.Id, *cfg.State)
+	if err != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("error persisting new config state: %v", err))), nil, nil
+	}
+
+	glog.V(5).Infof(apiLogString(fmt.Sprintf("Update configstate: updated device: %v", updatedDev)))
+
+	exDev := ConvertFromPersistentHorizonDevice(updatedDev)
+	return false, exDev.Config, msgs
+
+}
+
+func makeServiceName(msURL string, msOrg string, msVersion string) string {
+
+	url := ""
+	pieces := strings.SplitN(msURL, "/", 3)
+	if len(pieces) >= 3 {
+		url = strings.TrimSuffix(pieces[2], "/")
+		url = strings.Replace(url, "/", "-", -1)
+	}
+
+	return fmt.Sprintf("%v_%v_%v", url, msOrg, msVersion)
+
+}

--- a/api/path_configstate.go
+++ b/api/path_configstate.go
@@ -67,7 +67,7 @@ func UpdateConfigstate(cfg *Configstate,
 	if err != nil {
 		return errorhandler(NewSystemError(fmt.Sprintf("Unable to read horizondevice object, error %v", err))), nil, nil
 	} else if pDevice == nil {
-		return errorhandler(NewAPIUserInputError("Exchange registration not recorded. Complete account and device registration with an exchange and then record device registration using this API's /horizondevice path.", "configstate")), nil, nil
+		return errorhandler(NewNotFoundError("Exchange registration not recorded. Complete account and device registration with an exchange and then record device registration using this API's /horizondevice path.")), nil, nil
 	}
 
 	glog.V(3).Infof(apiLogString(fmt.Sprintf("Update configstate: device in local database: %v", pDevice)))

--- a/api/path_configstate_test.go
+++ b/api/path_configstate_test.go
@@ -1,0 +1,412 @@
+// +build unit
+
+package api
+
+import (
+	"flag"
+	"fmt"
+	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/anax/persistence"
+	"github.com/open-horizon/anax/policy"
+	"testing"
+)
+
+func init() {
+	flag.Set("alsologtostderr", "true")
+	flag.Set("v", "7")
+	// no need to parse flags, that's done by test framework
+}
+
+func Test_FindCSForOutput0(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	if cfg, err := FindConfigstateForOutput(db); err != nil {
+		t.Errorf("failed to find device in db, error %v", err)
+	} else if *cfg.State != CONFIGSTATE_CONFIGURING {
+		t.Errorf("incorrect configstate found: %v", *cfg)
+	}
+
+}
+
+// Create output configstate object based on object in the DB
+func Test_FindCSForOutput1(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	theOrg := "myorg"
+
+	_, err = persistence.SaveNewExchangeDevice(db, "testid", "testtoken", "testname", false, theOrg, "apattern", CONFIGSTATE_CONFIGURING)
+	if err != nil {
+		t.Errorf("failed to create persisted device, error %v", err)
+	}
+
+	if cfg, err := FindConfigstateForOutput(db); err != nil {
+		t.Errorf("failed to find device in db, error %v", err)
+	} else if *cfg.State != CONFIGSTATE_CONFIGURING {
+		t.Errorf("incorrect configstate, found: %v", *cfg)
+	} else if *cfg.LastUpdateTime == uint64(0) {
+		t.Errorf("incorrect last update time, found: %v", *cfg)
+	}
+
+}
+
+// no change in state - confguring to configuring
+func Test_UpdateConfigstate1(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	cs := getBasicConfigstate()
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	theOrg := "myorg"
+
+	_, err = persistence.SaveNewExchangeDevice(db, "testid", "testtoken", "testname", false, theOrg, "apattern", CONFIGSTATE_CONFIGURING)
+	if err != nil {
+		t.Errorf("failed to create persisted device, error %v", err)
+	}
+
+	errHandled, cfg, _ := UpdateConfigstate(cs, errorhandler, getDummyGetOrg(), getDummyMicroserviceHandler(), getDummyGetPatterns(), getDummyWorkloadResolver(), db, getBasicConfig())
+
+	if errHandled {
+		t.Errorf("unexpected error %v", myError)
+	} else if myError != nil && len(myError.Error()) != 0 {
+		t.Errorf("myError set unexpectedly (%T) %v", myError, myError)
+	} else if cfg == nil {
+		t.Errorf("no configstate returned")
+	} else if *cfg.State != CONFIGSTATE_CONFIGURING {
+		t.Errorf("wrong state field %v", *cfg)
+	} else if *cfg.LastUpdateTime == uint64(0) {
+		t.Errorf("last update time should be set, is %v", *cfg)
+	}
+
+}
+
+// change state to configured
+func Test_UpdateConfigstate2(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	cs := getBasicConfigstate()
+	state := CONFIGSTATE_CONFIGURED
+	cs.State = &state
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	myOrg := "myorg"
+	myPattern := "mypattern"
+
+	_, err = persistence.SaveNewExchangeDevice(db, "testid", "testtoken", "testname", false, myOrg, myPattern, CONFIGSTATE_CONFIGURING)
+	if err != nil {
+		t.Errorf("failed to create persisted device, error %v", err)
+	}
+
+	errHandled, cfg, _ := UpdateConfigstate(cs, errorhandler, getDummyGetOrg(), getDummyMicroserviceHandler(), getGoodPattern, getDummyWorkloadResolver(), db, getBasicConfig())
+
+	if errHandled {
+		t.Errorf("unexpected error %v", myError)
+	} else if myError != nil && len(myError.Error()) != 0 {
+		t.Errorf("myError set unexpectedly (%T) %v", myError, myError)
+	} else if cfg == nil {
+		t.Errorf("no configstate returned")
+	} else if *cfg.State != CONFIGSTATE_CONFIGURED {
+		t.Errorf("wrong state field %v", *cfg)
+	} else if *cfg.LastUpdateTime == uint64(0) {
+		t.Errorf("last update time should be set, is %v", *cfg)
+	}
+
+}
+
+// change state to from configured to configuring
+func Test_UpdateConfigstate_Illegal_state_change(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	cs := getBasicConfigstate()
+	state := CONFIGSTATE_CONFIGURED
+	cs.State = &state
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	myOrg := "myorg"
+	myPattern := "mypattern"
+
+	_, err = persistence.SaveNewExchangeDevice(db, "testid", "testtoken", "testname", false, myOrg, myPattern, CONFIGSTATE_CONFIGURING)
+	if err != nil {
+		t.Errorf("failed to create persisted device, error %v", err)
+	}
+
+	errHandled, cfg, _ := UpdateConfigstate(cs, errorhandler, getDummyGetOrg(), getDummyMicroserviceHandler(), getGoodPattern, getDummyWorkloadResolver(), db, getBasicConfig())
+
+	if errHandled {
+		t.Errorf("unexpected error %v", myError)
+	} else if myError != nil && len(myError.Error()) != 0 {
+		t.Errorf("myError set unexpectedly (%T) %v", myError, myError)
+	} else if cfg == nil {
+		t.Errorf("no configstate returned")
+	} else if *cfg.State != CONFIGSTATE_CONFIGURED {
+		t.Errorf("wrong state field %v", *cfg)
+	} else if *cfg.LastUpdateTime == uint64(0) {
+		t.Errorf("last update time should be set, is %v", *cfg)
+	}
+
+	state = CONFIGSTATE_CONFIGURING
+	cs.State = &state
+
+	errHandled, cfg, _ = UpdateConfigstate(cs, errorhandler, getDummyGetOrg(), getDummyMicroserviceHandler(), getGoodPattern, getDummyWorkloadResolver(), db, getBasicConfig())
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "configstate.state" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if cfg != nil {
+		t.Errorf("configstate should not be returned")
+	}
+
+}
+
+// no change in state - configured to configured
+func Test_UpdateConfigstate_no_state_change(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	cs := getBasicConfigstate()
+	state := CONFIGSTATE_CONFIGURED
+	cs.State = &state
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	myOrg := "myorg"
+	myPattern := "mypattern"
+
+	_, err = persistence.SaveNewExchangeDevice(db, "testid", "testtoken", "testname", false, myOrg, myPattern, CONFIGSTATE_CONFIGURING)
+	if err != nil {
+		t.Errorf("failed to create persisted device, error %v", err)
+	}
+
+	errHandled, cfg, _ := UpdateConfigstate(cs, errorhandler, getDummyGetOrg(), getDummyMicroserviceHandler(), getGoodPattern, getDummyWorkloadResolver(), db, getBasicConfig())
+
+	if errHandled {
+		t.Errorf("unexpected error %v", myError)
+	} else if myError != nil && len(myError.Error()) != 0 {
+		t.Errorf("myError set unexpectedly (%T) %v", myError, myError)
+	} else if cfg == nil {
+		t.Errorf("no configstate returned")
+	} else if *cfg.State != CONFIGSTATE_CONFIGURED {
+		t.Errorf("wrong state field %v", *cfg)
+	} else if *cfg.LastUpdateTime == uint64(0) {
+		t.Errorf("last update time should be set, is %v", *cfg)
+	}
+
+	errHandled, cfg, _ = UpdateConfigstate(cs, errorhandler, getDummyGetOrg(), getDummyMicroserviceHandler(), getGoodPattern, getDummyWorkloadResolver(), db, getBasicConfig())
+
+	if errHandled {
+		t.Errorf("unexpected error %v", myError)
+	} else if myError != nil && len(myError.Error()) != 0 {
+		t.Errorf("myError set unexpectedly (%T) %v", myError, myError)
+	} else if cfg == nil {
+		t.Errorf("no configstate returned")
+	} else if *cfg.State != CONFIGSTATE_CONFIGURED {
+		t.Errorf("wrong state field %v", *cfg)
+	} else if *cfg.LastUpdateTime == uint64(0) {
+		t.Errorf("last update time should be set, is %v", *cfg)
+	}
+
+}
+
+// change state to unsupported state
+func Test_UpdateConfigstate_unknown_state_change(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	cs := getBasicConfigstate()
+	state := "blah"
+	cs.State = &state
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	theOrg := "myorg"
+
+	_, err = persistence.SaveNewExchangeDevice(db, "testid", "testtoken", "testname", false, theOrg, "apattern", CONFIGSTATE_CONFIGURING)
+	if err != nil {
+		t.Errorf("failed to create persisted device, error %v", err)
+	}
+
+	errHandled, cfg, _ := UpdateConfigstate(cs, errorhandler, getDummyGetOrg(), getDummyMicroserviceHandler(), getDummyGetPatterns(), getDummyWorkloadResolver(), db, getBasicConfig())
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "configstate.state" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if cfg != nil {
+		t.Errorf("configstate should not be returned")
+	}
+
+}
+
+// change state to configured with microservices
+func Test_UpdateConfigstateWithMS(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	cs := getBasicConfigstate()
+	state := CONFIGSTATE_CONFIGURED
+	cs.State = &state
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	myOrg := "myorg"
+	myPattern := "mypattern"
+
+	_, err = persistence.SaveNewExchangeDevice(db, "testid", "testtoken", "testname", false, myOrg, myPattern, CONFIGSTATE_CONFIGURING)
+	if err != nil {
+		t.Errorf("failed to create persisted device, error %v", err)
+	}
+
+	errHandled, cfg, _ := UpdateConfigstate(cs, errorhandler, getSingleOrgHandler, getSingleMicroserviceHandler, getFullPattern, getSingleWorkloadResolver, db, getBasicConfig())
+
+	if errHandled {
+		t.Errorf("unexpected error %v", myError)
+	} else if myError != nil && len(myError.Error()) != 0 {
+		t.Errorf("myError set unexpectedly (%T) %v", myError, myError)
+	} else if cfg == nil {
+		t.Errorf("no configstate returned")
+	} else if *cfg.State != CONFIGSTATE_CONFIGURED {
+		t.Errorf("wrong state field %v", *cfg)
+	} else if *cfg.LastUpdateTime == uint64(0) {
+		t.Errorf("last update time should be set, is %v", *cfg)
+	}
+
+	cleanTestDir(getBasicConfig().Edge.PolicyPath + "/" + myOrg)
+
+}
+
+func getBasicConfigstate() *Configstate {
+	state := CONFIGSTATE_CONFIGURING
+	cs := &Configstate{
+		State: &state,
+	}
+	return cs
+}
+
+func getGoodPattern(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error) {
+	patid := fmt.Sprintf("%v/%v", org, pattern)
+	return map[string]exchange.Pattern{
+		patid: exchange.Pattern{
+			Label:              "label",
+			Description:        "desc",
+			Public:             true,
+			Workloads:          []exchange.WorkloadReference{},
+			AgreementProtocols: []exchange.AgreementProtocol{},
+		},
+	}, nil
+
+}
+
+func getFullPattern(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error) {
+	patid := fmt.Sprintf("%v/%v", org, pattern)
+	return map[string]exchange.Pattern{
+		patid: exchange.Pattern{
+			Label:       "label",
+			Description: "desc",
+			Public:      true,
+			Workloads: []exchange.WorkloadReference{
+				{
+					WorkloadURL:  "http://mydomain.com/workload/test1",
+					WorkloadOrg:  "testorg",
+					WorkloadArch: "amd64",
+					WorkloadVersions: []exchange.WorkloadChoice{
+						{
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+			AgreementProtocols: []exchange.AgreementProtocol{},
+		},
+	}, nil
+
+}
+
+func getSingleWorkloadResolver(wUrl string, wOrg string, wVersion string, wArch string, id string, token string) (*policy.APISpecList, error) {
+	sl := policy.APISpecList{
+		policy.APISpecification{
+			SpecRef:         wUrl,
+			Org:             wOrg,
+			Version:         wVersion,
+			ExclusiveAccess: true,
+			Arch:            wArch,
+		},
+	}
+	return &sl, nil
+}
+
+func getSingleMicroserviceHandler(mUrl string, mOrg string, mVersion string, mArch string, id string, token string) (*exchange.MicroserviceDefinition, error) {
+	md := exchange.MicroserviceDefinition{
+		Owner:         "owner",
+		Label:         "label",
+		Description:   "desc",
+		SpecRef:       mUrl,
+		Version:       mVersion,
+		Arch:          mArch,
+		Sharable:      exchange.MS_SHARING_MODE_EXCLUSIVE,
+		DownloadURL:   "",
+		MatchHardware: exchange.HardwareMatch{},
+		UserInputs:    []exchange.UserInput{},
+		Workloads:     []exchange.WorkloadDeployment{},
+		LastUpdated:   "today",
+	}
+	return &md, nil
+}
+
+func getSingleOrgHandler(org string, id string, token string) (*exchange.Organization, error) {
+	o := &exchange.Organization{
+		Label:       "label",
+		Description: "desc",
+		LastUpdated: "today",
+	}
+	return o, nil
+}

--- a/api/path_horizondevice.go
+++ b/api/path_horizondevice.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"github.com/boltdb/bolt"
+	"github.com/golang/glog"
+	"github.com/open-horizon/anax/persistence"
+	"os"
+)
+
+func FindHorizonDeviceForOutput(db *bolt.DB) (*HorizonDevice, error) {
+
+	var device *HorizonDevice
+
+	pDevice, err := persistence.FindExchangeDevice(db)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("unable to read horizondevice object, error %v", err))
+	} else if pDevice == nil {
+		device_id := os.Getenv("CMTN_DEVICE_ID")
+		state := CONFIGSTATE_CONFIGURING
+		cfg := &Configstate{
+			State: &state,
+		}
+		device = &HorizonDevice{
+			Id:     &device_id,
+			Config: cfg,
+		}
+	} else {
+		device = ConvertFromPersistentHorizonDevice(pDevice)
+	}
+
+	return device, nil
+}
+
+// Given a demarshalled HorizonDevice object, validate it and save it, returning any errors.
+func CreateHorizonDevice(device *HorizonDevice,
+	errorhandler ErrorHandler,
+	getOrg OrgHandler,
+	getPatterns PatternHandler,
+	db *bolt.DB) (bool, *HorizonDevice, *HorizonDevice) {
+
+	// Check for the device in the local database. If there are errors, they will be written
+	// to the HTTP response.
+
+	if pDevice, err := persistence.FindExchangeDevice(db); err != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("unable to read horizondevice object, error %v", err))), nil, nil
+	} else if pDevice != nil {
+		return errorhandler(NewConflictError("device is already registered")), nil, nil
+	}
+
+	glog.V(5).Infof(apiLogString(fmt.Sprintf("Create horizondevice payload: %v", device)))
+
+	// There is no existing device registration in the database, so proceed to verifying the input device object.
+	if device.Id == nil || *device.Id == "" {
+		device_id := os.Getenv("CMTN_DEVICE_ID")
+		if device_id == "" {
+			return errorhandler(NewAPIUserInputError("Either setup CMTN_DEVICE_ID environmental variable or specify device.id.", "device.id")), nil, nil
+		}
+		device.Id = &device_id
+	}
+
+	if bail := checkInputString(errorhandler, "device.id", device.Id); bail {
+		return true, nil, nil
+	}
+
+	if bail := checkInputString(errorhandler, "device.organization", device.Org); bail {
+		return true, nil, nil
+	}
+
+	// Device pattern is optional
+	if device.Pattern != nil && *device.Pattern != "" {
+		if bail := checkInputString(errorhandler, "device.pattern", device.Pattern); bail {
+			return true, nil, nil
+		}
+	}
+
+	if bail := checkInputString(errorhandler, "device.name", device.Name); bail {
+		return true, nil, nil
+	}
+
+	// No need to check the token for invalid input characters, it is not computed or parsed.
+	if device.Token == nil {
+		return errorhandler(NewAPIUserInputError("null and must not be", "device.token")), nil, nil
+	}
+
+	// HA validation. Since the HA declaration is a boolean, there is nothing to validate for HA.
+
+	// Verify that the input organization exists in the exchange.
+	deviceId := fmt.Sprintf("%v/%v", *device.Org, *device.Id)
+	if _, err := getOrg(*device.Org, deviceId, *device.Token); err != nil {
+		return errorhandler(NewAPIUserInputError(fmt.Sprintf("organization %v not found in exchange, error: %v", *device.Org, err), "device.organization")), nil, nil
+	}
+
+	// Verify that the input pattern is defined in the exchange. A device (or node) canonly use patterns that are defined within its own org.
+	if device.Pattern != nil && *device.Pattern != "" {
+		if patternDefs, err := getPatterns(*device.Org, *device.Pattern, deviceId, *device.Token); err != nil {
+			return errorhandler(NewAPIUserInputError(fmt.Sprintf("error searching for pattern %v in exchange, error: %v", *device.Pattern, err), "device.pattern")), nil, nil
+		} else if _, ok := patternDefs[fmt.Sprintf("%v/%v", *device.Org, *device.Pattern)]; !ok {
+			return errorhandler(NewAPIUserInputError(fmt.Sprintf("pattern %v not found in exchange, error: %v", *device.Pattern, err), "device.pattern")), nil, nil
+		}
+	}
+
+	// So far everything checks out and verifies, so save the registration to the local database.
+	haDevice := false
+	if device.HADevice != nil && *device.HADevice == true {
+		haDevice = true
+	}
+
+	pDev, err := persistence.SaveNewExchangeDevice(db, *device.Id, *device.Token, *device.Name, haDevice, *device.Org, *device.Pattern, CONFIGSTATE_CONFIGURING)
+	if err != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("error persisting new device registration: %v", err))), nil, nil
+	}
+
+	glog.V(5).Infof(apiLogString(fmt.Sprintf("Create horizondevice updated: %v", pDev)))
+
+	// Return 2 device objects, the first is the fully populated newly created device object. The second is a device
+	// object suitable for output (external consumption). Specifically the token is omitted.
+	exDev := ConvertFromPersistentHorizonDevice(pDev)
+	return false, device, exDev
+
+}

--- a/api/path_horizondevice_test.go
+++ b/api/path_horizondevice_test.go
@@ -1,0 +1,593 @@
+// +build unit
+
+package api
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/anax/persistence"
+	"os"
+	"testing"
+)
+
+func init() {
+	flag.Set("alsologtostderr", "true")
+	flag.Set("v", "7")
+	// no need to parse flags, that's done by test framework
+}
+
+// Create output device object based on env var setting
+func Test_FindHDForOutput0(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer cleanTestDir(dir)
+
+	myDevice := "myid"
+	os.Setenv("CMTN_DEVICE_ID", myDevice)
+
+	if dev, err := FindHorizonDeviceForOutput(db); err != nil {
+		t.Errorf("failed to find device in db, error %v", err)
+	} else if dev.Org != nil && *dev.Org != "" {
+		t.Errorf("incorrect device found: %v", *dev)
+	} else if dev.Id == nil || *dev.Id == "" {
+		t.Errorf("id should be filled in, is %v", *dev)
+	} else if *dev.Id != myDevice {
+		t.Errorf("id is not set correctly, is %v", *dev)
+	} else if dev.Config == nil {
+		t.Errorf("config state should be initialized, is %v", *dev)
+	} else if *dev.Config.State != CONFIGSTATE_CONFIGURING {
+		t.Errorf("config state has wrong state %v", *dev)
+	}
+
+	os.Unsetenv("CMTN_DEVICE_ID")
+
+}
+
+// Create output device object based on object in the DB
+func Test_FindHDForOutput1(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer cleanTestDir(dir)
+
+	theOrg := "myorg"
+
+	_, err = persistence.SaveNewExchangeDevice(db, "testid", "testtoken", "testname", false, theOrg, "apattern", CONFIGSTATE_CONFIGURING)
+	if err != nil {
+		t.Errorf("failed to create persisted device, error %v", err)
+	}
+
+	if dev, err := FindHorizonDeviceForOutput(db); err != nil {
+		t.Errorf("failed to find device in db, error %v", err)
+	} else if *dev.Org != theOrg {
+		t.Errorf("incorrect device found: %v", *dev)
+	} else if dev.Token != nil && *dev.Token != "" {
+		t.Errorf("token should not be returned, but is %v", *dev)
+	} else if dev.Config == nil {
+		t.Errorf("config state should be initialized, is %v", *dev)
+	} else if *dev.Config.State != CONFIGSTATE_CONFIGURING {
+		t.Errorf("config state has wrong state %v", *dev)
+	}
+
+}
+
+// no device id
+func Test_CreateHorizonDevice_NoDeviceid(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	badId := ""
+	hd := getBasicDevice("myOrg", "myPattern")
+	hd.Id = &badId
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatterns(), db)
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "device.id" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if device != nil {
+		t.Errorf("device should not be returned")
+	} else if exDevice != nil {
+		t.Errorf("output device should not be returned")
+	}
+
+}
+
+// Invalid characters in id
+func Test_CreateHorizonDevice_IllegalId(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	badId := "<0"
+	hd := getBasicDevice("myOrg", "myPattern")
+	hd.Id = &badId
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatterns(), db)
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "device.id" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if device != nil {
+		t.Errorf("device should not be returned")
+	} else if exDevice != nil {
+		t.Errorf("output device should not be returned")
+	}
+
+}
+
+// Invalid characters in org
+func Test_CreateHorizonDevice_IllegalOrg(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	badOrg := "<0"
+	hd := getBasicDevice(badOrg, "myPattern")
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatterns(), db)
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "device.organization" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if device != nil {
+		t.Errorf("device should not be returned")
+	} else if exDevice != nil {
+		t.Errorf("output device should not be returned")
+	}
+
+}
+
+// Invalid characters in pattern
+func Test_CreateHorizonDevice_IllegalPattern(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	badPattern := "<0"
+	hd := getBasicDevice("myOrg", badPattern)
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatterns(), db)
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "device.pattern" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if device != nil {
+		t.Errorf("device should not be returned")
+	} else if exDevice != nil {
+		t.Errorf("output device should not be returned")
+	}
+
+}
+
+// Invalid characters in name
+func Test_CreateHorizonDevice_IllegalName(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	badname := "<0"
+	hd := getBasicDevice("myOrg", "myPattern")
+	hd.Name = &badname
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatterns(), db)
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "device.name" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if device != nil {
+		t.Errorf("device should not be returned")
+	} else if exDevice != nil {
+		t.Errorf("output device should not be returned")
+	}
+
+}
+
+// empty token field
+func Test_CreateHorizonDevice_IllegalToken(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	hd := getBasicDevice("myOrg", "myPattern")
+	hd.Token = nil
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatterns(), db)
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "device.token" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if device != nil {
+		t.Errorf("device should not be returned")
+	} else if exDevice != nil {
+		t.Errorf("output device should not be returned")
+	}
+
+}
+
+// Successful create, everything works
+func Test_CreateHorizonDevice0(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	myOrg := "testOrg"
+	myPattern := "testPattern"
+	hd := getBasicDevice(myOrg, myPattern)
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	getOrg := func(org string, id string, token string) (*exchange.Organization, error) {
+		if org == myOrg {
+			return &exchange.Organization{
+				Label:       "test label",
+				Description: "test description",
+				LastUpdated: "some time ago",
+			}, nil
+		} else {
+			return nil, errors.New("org not found")
+		}
+	}
+
+	getPatterns := func(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error) {
+		if pattern == myPattern && org == myOrg {
+			patid := fmt.Sprintf("%v/%v", org, pattern)
+			return map[string]exchange.Pattern{
+				patid: exchange.Pattern{
+					Label:              "label",
+					Description:        "desc",
+					Public:             true,
+					Workloads:          []exchange.WorkloadReference{},
+					AgreementProtocols: []exchange.AgreementProtocol{},
+				},
+			}, nil
+		} else {
+			return nil, errors.New("pattern not found")
+		}
+	}
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, db)
+
+	if errHandled {
+		t.Errorf("unexpected error %v", myError)
+	} else if myError != nil && len(myError.Error()) != 0 {
+		t.Errorf("myError set unexpectedly (%T) %v", myError, myError)
+	} else if *device.Org != myOrg {
+		t.Errorf("org did not get set correctly, expecting %v is %v", myOrg, *device)
+	} else if exDevice.Token != nil {
+		t.Errorf("output device should not have token, but does %v", *exDevice)
+	}
+
+}
+
+// device id from env var
+func Test_CreateHorizonDevice_EnvVarDeviceid(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	myOrg := "testOrg"
+	myPattern := "testPattern"
+	hd := getBasicDevice(myOrg, myPattern)
+	badId := ""
+	hd.Id = &badId
+	os.Setenv("CMTN_DEVICE_ID", "myDevice")
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	getOrg := func(org string, id string, token string) (*exchange.Organization, error) {
+		if org == myOrg {
+			return &exchange.Organization{
+				Label:       "test label",
+				Description: "test description",
+				LastUpdated: "some time ago",
+			}, nil
+		} else {
+			return nil, errors.New("org not found")
+		}
+	}
+
+	getPatterns := func(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error) {
+		if pattern == myPattern && org == myOrg {
+			patid := fmt.Sprintf("%v/%v", org, pattern)
+			return map[string]exchange.Pattern{
+				patid: exchange.Pattern{
+					Label:              "label",
+					Description:        "desc",
+					Public:             true,
+					Workloads:          []exchange.WorkloadReference{},
+					AgreementProtocols: []exchange.AgreementProtocol{},
+				},
+			}, nil
+		} else {
+			return nil, errors.New("pattern not found")
+		}
+	}
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, db)
+
+	if errHandled {
+		t.Errorf("unexpected error %v", myError)
+	} else if device == nil {
+		t.Errorf("device should be returned")
+	} else if exDevice == nil {
+		t.Errorf("output device should be returned")
+	} else if *device.Id != "myDevice" {
+		t.Errorf("wrong device id, expected %v but is %v", "myDevice", *device)
+	}
+
+	os.Unsetenv("CMTN_DEVICE_ID")
+
+}
+
+// Failed create, device already registered
+func Test_CreateHorizonDevice_alreadythere(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	myOrg := "testOrg"
+	myPattern := "testPattern"
+	hd := getBasicDevice(myOrg, myPattern)
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	getOrg := func(org string, id string, token string) (*exchange.Organization, error) {
+		if org == myOrg {
+			return &exchange.Organization{
+				Label:       "test label",
+				Description: "test description",
+				LastUpdated: "some time ago",
+			}, nil
+		} else {
+			return nil, errors.New("org not found")
+		}
+	}
+
+	getPatterns := func(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error) {
+		if pattern == myPattern && org == myOrg {
+			patid := fmt.Sprintf("%v/%v", org, pattern)
+			return map[string]exchange.Pattern{
+				patid: exchange.Pattern{
+					Label:              "label",
+					Description:        "desc",
+					Public:             true,
+					Workloads:          []exchange.WorkloadReference{},
+					AgreementProtocols: []exchange.AgreementProtocol{},
+				},
+			}, nil
+		} else {
+			return nil, errors.New("pattern not found")
+		}
+	}
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, db)
+	if errHandled {
+		t.Errorf("unexpected error %v", myError)
+	}
+
+	errHandled, device, exDevice = CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, db)
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if conErr, ok := myError.(*ConflictError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if conErr.msg != "device is already registered" {
+		t.Errorf("wrong error input field")
+	} else if device != nil {
+		t.Errorf("device should not be returned")
+	} else if exDevice != nil {
+		t.Errorf("output device should not be returned")
+	}
+
+}
+
+// Org doesnt exist
+func Test_CreateHorizonDevice_badorg(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	myOrg := "testOrg"
+	myPattern := "testPattern"
+	hd := getBasicDevice("otherOrg", myPattern)
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	getOrg := func(org string, id string, token string) (*exchange.Organization, error) {
+		if org == myOrg {
+			return &exchange.Organization{
+				Label:       "test label",
+				Description: "test description",
+				LastUpdated: "some time ago",
+			}, nil
+		} else {
+			return nil, errors.New("org not found")
+		}
+	}
+
+	getPatterns := func(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error) {
+		if pattern == myPattern && org == myOrg {
+			patid := fmt.Sprintf("%v/%v", org, pattern)
+			return map[string]exchange.Pattern{
+				patid: exchange.Pattern{
+					Label:              "label",
+					Description:        "desc",
+					Public:             true,
+					Workloads:          []exchange.WorkloadReference{},
+					AgreementProtocols: []exchange.AgreementProtocol{},
+				},
+			}, nil
+		} else {
+			return nil, errors.New("pattern not found")
+		}
+	}
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, db)
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "device.organization" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if device != nil {
+		t.Errorf("device should not be returned")
+	} else if exDevice != nil {
+		t.Errorf("output device should not be returned")
+	}
+
+}
+
+// Org doesnt exist
+func Test_CreateHorizonDevice_badpattern(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	myOrg := "testOrg"
+	myPattern := "testPattern"
+	hd := getBasicDevice(myOrg, "otherPattern")
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	getOrg := func(org string, id string, token string) (*exchange.Organization, error) {
+		if org == myOrg {
+			return &exchange.Organization{
+				Label:       "test label",
+				Description: "test description",
+				LastUpdated: "some time ago",
+			}, nil
+		} else {
+			return nil, errors.New("org not found")
+		}
+	}
+
+	getPatterns := func(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error) {
+		if pattern == myPattern && org == myOrg {
+			patid := fmt.Sprintf("%v/%v", org, pattern)
+			return map[string]exchange.Pattern{
+				patid: exchange.Pattern{
+					Label:              "label",
+					Description:        "desc",
+					Public:             true,
+					Workloads:          []exchange.WorkloadReference{},
+					AgreementProtocols: []exchange.AgreementProtocol{},
+				},
+			}, nil
+		} else {
+			return nil, errors.New("pattern not found")
+		}
+	}
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, db)
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "device.pattern" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if device != nil {
+		t.Errorf("device should not be returned")
+	} else if exDevice != nil {
+		t.Errorf("output device should not be returned")
+	}
+
+}
+
+func getBasicDevice(org string, pattern string) *HorizonDevice {
+	myId := "testid"
+	myName := "testName"
+	myToken := "testToken"
+	myHA := false
+
+	hd := &HorizonDevice{
+		Id:       &myId,
+		Org:      &org,
+		Pattern:  &pattern,
+		Name:     &myName,
+		Token:    &myToken,
+		HADevice: &myHA,
+	}
+	return hd
+}

--- a/api/path_service.go
+++ b/api/path_service.go
@@ -1,0 +1,310 @@
+package api
+
+import (
+	"fmt"
+	"github.com/boltdb/bolt"
+	"github.com/golang/glog"
+	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/cutil"
+	"github.com/open-horizon/anax/events"
+	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/anax/microservice"
+	"github.com/open-horizon/anax/persistence"
+	"github.com/open-horizon/anax/policy"
+	"reflect"
+	"strconv"
+)
+
+// Given a demarshalled Service object, validate it and save it, returning any errors.
+func CreateService(service *Service,
+	errorhandler ErrorHandler,
+	getMicroservice MicroserviceHandler,
+	db *bolt.DB,
+	config *config.HorizonConfig) (bool, *Service, *events.PolicyCreatedMessage) {
+
+	// Check for the device in the local database. If there are errors, they will be written
+	// to the HTTP response.
+	pDevice, err := persistence.FindExchangeDevice(db)
+	if err != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("Unable to read horizondevice object, error %v", err))), nil, nil
+	} else if pDevice == nil {
+		return errorhandler(NewAPIUserInputError("Exchange registration not recorded. Complete account and device registration with an exchange and then record device registration using this API's /horizondevice path.", "service")), nil, nil
+	}
+
+	glog.V(5).Infof(apiLogString(fmt.Sprintf("Create service payload: %v", service)))
+
+	// Validate all the inputs in the service object.
+	if bail := checkInputString(errorhandler, "service.sensor_url", service.SensorUrl); bail {
+		return true, nil, nil
+	}
+
+	// Use the device's org if org not specified in the service object.
+	if service.SensorOrg == nil {
+		service.SensorOrg = &pDevice.Org
+	} else if bail := checkInputString(errorhandler, "service.sensor_org", service.SensorOrg); bail {
+		return true, nil, nil
+	}
+
+	if bail := checkInputString(errorhandler, "service.sensor_name", service.SensorName); bail {
+		return true, nil, nil
+	}
+
+	// The sensor_version field is checked for valid characters by the Version_Expression_Factory, it has a very
+	// specific syntax and allows a subset of normally valid characters.
+
+	// Use a default sensor version that allows all version if not specified.
+	if service.SensorVersion == nil {
+		def := "0.0.0"
+		service.SensorVersion = &def
+	}
+
+	// Convert the sensor version to a version expression.
+	vExp, err := policy.Version_Expression_Factory(*service.SensorVersion)
+	if err != nil {
+		return errorhandler(NewAPIUserInputError(fmt.Sprintf("sensor_version %v cannot be converted to a version expression, error %v", *service.SensorVersion, err), "service.sensor_version")), nil, nil
+	}
+
+	// Verify with the exchange to make sure the microservice definition is readable by this node.
+	var msdef *persistence.MicroserviceDefinition
+	e_msdef, err := getMicroservice(*service.SensorUrl, *service.SensorOrg, vExp.Get_expression(), cutil.ArchString(), pDevice.GetId(), pDevice.Token)
+	if err != nil || e_msdef == nil {
+		return errorhandler(NewAPIUserInputError(fmt.Sprintf("Unable to find the microservice definition for '%v' on the exchange. Please verify sensor_url and sensor_version.", *service.SensorName), "service")), nil, nil
+	}
+
+	// Convert the microservice definition to a persistent format so that it can be saved to the db.
+	msdef, err = microservice.ConvertToPersistent(e_msdef, *service.SensorOrg)
+	if err != nil {
+		return errorhandler(NewAPIUserInputError(fmt.Sprintf("Error converting the microservice metadata to persistent.MicroserviceDefinition for %v version %v, error %v", e_msdef.SpecRef, e_msdef.Version, err), "service")), nil, nil
+	}
+
+	// Save some of the items in the MicroserviceDefinition object for use in the upgrading process.
+	msdef.Name = *service.SensorName
+	msdef.UpgradeVersionRange = *service.SensorVersion
+	if service.AutoUpgrade != nil {
+		msdef.AutoUpgrade = *service.AutoUpgrade
+	}
+	if service.ActiveUpgrade != nil {
+		msdef.ActiveUpgrade = *service.ActiveUpgrade
+	}
+
+	// The microservice definition returned by the exchange might be newer than what was specified in the input service object, so we save
+	// the actual version of the microservice so that we know if we need to upgrade in the future.
+	service.SensorVersion = &msdef.Version
+
+	// Check if the microservice has been registered or not (currently only support one microservice registration)
+	if pms, err := persistence.FindMicroserviceDefs(db, []persistence.MSFilter{persistence.UrlMSFilter(*service.SensorUrl)}); err != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("Error accessing db to find microservice definition: %v", err))), nil, nil
+	} else if pms != nil && len(pms) > 0 {
+		//return errorhandler(NewAPIUserInputError(fmt.Sprintf("Duplicate registration for %v. Only one registration per microservice is supported.", *service.SensorUrl), "service")), nil, nil
+		return errorhandler(NewDuplicateServiceError(fmt.Sprintf("Duplicate registration for %v. Only one registration per microservice is supported.", *service.SensorUrl), "service")), nil, nil
+	}
+
+	// Validate any attributes specified in the attribute list and convert them to persistent objects.
+	// This attribute verifier makes sure that there is a mapped attribute which specifies values for all the non-default
+	// user inputs in the specific microservice selected earlier.
+	msdefAttributeVerifier := func(attr persistence.Attribute) (bool, error) {
+
+		// Verfiy that all non-defaulted userInput variables in the microservice definition are specified in a mapped property attribute
+		// of this service invocation.
+		if msdef != nil && attr.GetMeta().Type == "MappedAttributes" {
+			for _, ui := range msdef.UserInputs {
+				if ui.DefaultValue != "" {
+					continue
+				} else if _, ok := attr.GetGenericMappings()[ui.Name]; !ok {
+					// return errorhandler(NewAPIUserInputError(fmt.Sprintf("variable %v is missing from mappings", ui.Name), "service.[attribute].mapped")), nil
+					return errorhandler(NewMSMissingVariableConfigError(fmt.Sprintf("variable %v is missing from mappings", ui.Name), "service.[attribute].mapped")), nil
+				}
+			}
+		}
+
+		return false, nil
+	}
+
+	// This attribute verifier makes sure that nodes using a pattern dont try to use policy. When patterns are in use, all policy
+	// comes from the pattern.
+	patternedDeviceAttributeVerifier := func(attr persistence.Attribute) (bool, error) {
+
+		// If the device declared itself to be using a pattern, then it CANNOT specify any attributes that generate policy settings.
+		if pDevice.Pattern != "" {
+			if attr.GetMeta().Type == "MeteringAttributes" || attr.GetMeta().Type == "PropertyAttributes" || attr.GetMeta().Type == "CounterPartyPropertyAttributes" || attr.GetMeta().Type == "AgreementProtocolAttributes" {
+				return errorhandler(NewAPIUserInputError(fmt.Sprintf("device is using a pattern %v, policy attributes are not supported.", pDevice.Pattern), "service.[attribute].type")), nil
+			}
+		}
+
+		return false, nil
+	}
+
+	var attributes []persistence.Attribute
+	if service.Attributes != nil {
+		// build a serviceAttribute for each one
+		var err error
+		var inputErrWritten bool
+
+		attributes, inputErrWritten, err = toPersistedAttributesAttachedToService(errorhandler, pDevice, config.Edge.DefaultServiceRegistrationRAM, *service.Attributes, *service.SensorUrl, []AttributeVerifier{msdefAttributeVerifier, patternedDeviceAttributeVerifier})
+		if !inputErrWritten && err != nil {
+			return errorhandler(NewSystemError(fmt.Sprintf("Failure deserializing attributes: %v", err))), nil, nil
+		} else if inputErrWritten {
+			return true, nil, nil
+		}
+	}
+
+	// Information advertised in the edge node policy file
+	var policyArch string
+	var haPartner []string
+	var meterPolicy policy.Meter
+	var counterPartyProperties policy.RequiredProperty
+	var properties map[string]interface{}
+	var globalAgreementProtocols []interface{}
+
+	props := make(map[string]interface{})
+
+	// There might be node wide global attributes. Check for them and grab the values to use as defaults for later.
+	allAttrs, aerr := persistence.FindApplicableAttributes(db, "")
+	if aerr != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("Unable to fetch global attributes, error %v", err))), nil, nil
+	}
+
+	// For each node wide attribute, extract the value and save it for use later in this function.
+	for _, attr := range allAttrs {
+
+		// Extract HA property
+		if attr.GetMeta().Type == "HAAttributes" && len(attr.GetMeta().SensorUrls) == 0 {
+			haPartner = attr.(persistence.HAAttributes).Partners
+			glog.V(5).Infof(apiLogString(fmt.Sprintf("Found default global HA attribute %v", attr)))
+		}
+
+		// Global policy attributes are ignored for devices that are using a pattern. All policy is controlled
+		// by the pattern definition.
+		if pDevice.Pattern == "" {
+
+			// Extract global metering property
+			if attr.GetMeta().Type == "MeteringAttributes" && len(attr.GetMeta().SensorUrls) == 0 {
+				// found a global metering entry
+				meterPolicy = policy.Meter{
+					Tokens:                attr.(persistence.MeteringAttributes).Tokens,
+					PerTimeUnit:           attr.(persistence.MeteringAttributes).PerTimeUnit,
+					NotificationIntervalS: attr.(persistence.MeteringAttributes).NotificationIntervalS,
+				}
+				glog.V(5).Infof(apiLogString(fmt.Sprintf("Found default global metering attribute %v", attr)))
+			}
+
+			// Extract global counterparty property
+			if attr.GetMeta().Type == "CounterPartyPropertyAttributes" && len(attr.GetMeta().SensorUrls) == 0 {
+				counterPartyProperties = attr.(persistence.CounterPartyPropertyAttributes).Expression
+				glog.V(5).Infof(apiLogString(fmt.Sprintf("Found default global counterpartyproperty attribute %v", attr)))
+			}
+
+			// Extract global properties
+			if attr.GetMeta().Type == "PropertyAttributes" && len(attr.GetMeta().SensorUrls) == 0 {
+				properties = attr.(persistence.PropertyAttributes).Mappings
+				glog.V(5).Infof(apiLogString(fmt.Sprintf("Found default global properties %v", properties)))
+			}
+
+			// Extract global agreement protocol attribute
+			if attr.GetMeta().Type == "AgreementProtocolAttributes" && len(attr.GetMeta().SensorUrls) == 0 {
+				agpl := attr.(persistence.AgreementProtocolAttributes).Protocols
+				globalAgreementProtocols = agpl.([]interface{})
+				glog.V(5).Infof(apiLogString(fmt.Sprintf("Found default global agreement protocol attribute %v", globalAgreementProtocols)))
+			}
+		}
+	}
+
+	// If an HA device has no HA attribute from either node wide or service wide attributes, then the configuration is invalid.
+	// This verification cannot be done in the attribute verifier above because those verifiers dont know about global attributes.
+	haType := reflect.TypeOf(persistence.HAAttributes{}).Name()
+	if pDevice.HADevice && len(haPartner) == 0 {
+		if attr := attributesContains(attributes, *service.SensorUrl, haType); attr == nil {
+			return errorhandler(NewAPIUserInputError("services on an HA device must specify an HA partner.", "service.[attribute].type")), nil, nil
+		}
+	}
+
+	// Persist all attributes on this service, and while we're at it, fetch the attribute values we need for the node side policy file.
+	// Any policy attributes we find will overwrite values set in a global attribute of the same type.
+	var serviceAgreementProtocols []policy.AgreementProtocol
+	for _, attr := range attributes {
+
+		_, err := persistence.SaveOrUpdateAttribute(db, attr, "", false)
+		if err != nil {
+			return errorhandler(NewSystemError(fmt.Sprintf("error saving attribute %v, error %v", attr, err))), nil, nil
+		}
+
+		switch attr.(type) {
+		case *persistence.ComputeAttributes:
+			compute := attr.(*persistence.ComputeAttributes)
+			props["cpus"] = strconv.FormatInt(compute.CPUs, 10)
+			props["ram"] = strconv.FormatInt(compute.RAM, 10)
+
+		case *persistence.ArchitectureAttributes:
+			policyArch = attr.(*persistence.ArchitectureAttributes).Architecture
+
+		case *persistence.HAAttributes:
+			haPartner = attr.(*persistence.HAAttributes).Partners
+
+		case *persistence.MeteringAttributes:
+			meterPolicy = policy.Meter{
+				Tokens:                attr.(*persistence.MeteringAttributes).Tokens,
+				PerTimeUnit:           attr.(*persistence.MeteringAttributes).PerTimeUnit,
+				NotificationIntervalS: attr.(*persistence.MeteringAttributes).NotificationIntervalS,
+			}
+
+		case *persistence.CounterPartyPropertyAttributes:
+			counterPartyProperties = attr.(*persistence.CounterPartyPropertyAttributes).Expression
+
+		case *persistence.PropertyAttributes:
+			properties = attr.(*persistence.PropertyAttributes).Mappings
+
+		case *persistence.AgreementProtocolAttributes:
+			agpl := attr.(*persistence.AgreementProtocolAttributes).Protocols
+			serviceAgreementProtocols = agpl.([]policy.AgreementProtocol)
+
+		default:
+			glog.V(4).Infof("Unhandled attr type (%T): %v", attr, attr)
+		}
+	}
+
+	// Add the PropertyAttributes to props. There are several attribute types that contribute properties to the properties
+	// section of the policy file.
+	if len(properties) > 0 {
+		for key, val := range properties {
+			glog.V(5).Infof(apiLogString(fmt.Sprintf("Adding property %v=%v with value type %T", key, val, val)))
+			props[key] = val
+		}
+	}
+
+	glog.V(5).Infof(apiLogString(fmt.Sprintf("Complete Attr list for registration of service %v: %v", *service.SensorUrl, attributes)))
+
+	// Establish the correct agreement protocol list. The AGP list from this service overrides any global list that might exist.
+	var agpList *[]policy.AgreementProtocol
+	if len(serviceAgreementProtocols) != 0 {
+		agpList = &serviceAgreementProtocols
+	} else if list, err := policy.ConvertToAgreementProtocolList(globalAgreementProtocols); err != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("Error converting global agreement protocol list attribute %v to agreement protocol list, error: %v", globalAgreementProtocols, err))), nil, nil
+	} else {
+		agpList = list
+	}
+
+	// Save the microservice definition in the local database.
+	if err := persistence.SaveOrUpdateMicroserviceDef(db, msdef); err != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("Error saving microservice definition %v into db: %v", *msdef, err))), nil, nil
+	}
+
+	// Set max number of agreements for this microservice's policy.
+	maxAgreements := 1
+	if msdef.Sharable == exchange.MS_SHARING_MODE_SINGLE || msdef.Sharable == exchange.MS_SHARING_MODE_MULTIPLE {
+		if pDevice.Pattern == "" {
+			maxAgreements = 2 // hard coded to 2 for now. will change to 0 later
+		} else {
+			maxAgreements = 0 // no limites for pattern
+		}
+	}
+
+	glog.V(5).Infof(apiLogString(fmt.Sprintf("Create service: %v", service)))
+
+	// Generate a policy based on all the attributes and the service definition.
+	if msg, genErr := policy.GeneratePolicy(*service.SensorUrl, *service.SensorOrg, *service.SensorName, *service.SensorVersion, policyArch, &props, haPartner, meterPolicy, counterPartyProperties, *agpList, maxAgreements, config.Edge.PolicyPath, pDevice.Org); genErr != nil {
+		return errorhandler(NewSystemError(fmt.Sprintf("Error generating policy, error: %v", genErr))), nil, nil
+	} else {
+		return false, service, msg
+	}
+
+}

--- a/api/path_service_test.go
+++ b/api/path_service_test.go
@@ -1,0 +1,59 @@
+// +build unit
+
+package api
+
+import (
+	"flag"
+	"github.com/open-horizon/anax/persistence"
+	"testing"
+)
+
+func init() {
+	flag.Set("alsologtostderr", "true")
+	flag.Set("v", "7")
+	// no need to parse flags, that's done by test framework
+}
+
+func Test_CreateService0(t *testing.T) {
+
+	dir, db, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	surl := "http://dummy.com"
+	myOrg := "myorg"
+	name := "name"
+	vers := "1.0.0"
+	attrs := []Attribute{}
+	autoU := true
+	activeU := true
+
+	service := &Service{
+		SensorUrl:     &surl,
+		SensorOrg:     &myOrg,
+		SensorName:    &name,
+		SensorVersion: &vers,
+		AutoUpgrade:   &autoU,
+		ActiveUpgrade: &activeU,
+		Attributes:    &attrs,
+	}
+
+	_, err = persistence.SaveNewExchangeDevice(db, "testid", "testtoken", "testname", false, myOrg, "apattern", CONFIGSTATE_CONFIGURING)
+	if err != nil {
+		t.Errorf("failed to create persisted device, error %v", err)
+	}
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	errHandled, newService, msg := CreateService(service, errorhandler, getSingleMicroserviceHandler, db, getBasicConfig())
+	if errHandled {
+		t.Errorf("unexpected error (%T) %v", myError, myError)
+	} else if newService == nil {
+		t.Errorf("returned service should not be nil")
+	} else if msg == nil {
+		t.Errorf("returned msg should not be nil")
+	}
+
+}

--- a/events/events.go
+++ b/events/events.go
@@ -56,8 +56,9 @@ const (
 	DELETED_POLICY EventId = "DELETED_POLICY"
 
 	// exchange-related
-	NEW_DEVICE_REG EventId = "NEW_DEVICE_REG"
-	NEW_AGBOT_REG  EventId = "NEW_AGBOT_REG"
+	NEW_DEVICE_REG             EventId = "NEW_DEVICE_REG"
+	NEW_DEVICE_CONFIG_COMPLETE EventId = "NEW_DEVICE_CONFIG_COMPLETE"
+	NEW_AGBOT_REG              EventId = "NEW_AGBOT_REG"
 
 	// agreement-related
 	AGREEMENT_REACHED        EventId = "AGREEMENT_REACHED"
@@ -224,7 +225,7 @@ func (e PolicyCreatedMessage) ShortString() string {
 	return e.String()
 }
 
-func (e *PolicyCreatedMessage) Event() Event {
+func (e PolicyCreatedMessage) Event() Event {
 	return e.event
 }
 
@@ -389,6 +390,32 @@ func NewEdgeRegisteredExchangeMessage(evId EventId, device_id string, token stri
 		token:     token,
 		org:       org,
 		pattern:   pattern,
+	}
+}
+
+// This event indicates that the edge device configuration is complete
+type EdgeConfigCompleteMessage struct {
+	event Event
+}
+
+func (e EdgeConfigCompleteMessage) String() string {
+	return fmt.Sprintf("event: %v", e.event)
+}
+
+func (e EdgeConfigCompleteMessage) ShortString() string {
+	return e.String()
+}
+
+func (e *EdgeConfigCompleteMessage) Event() Event {
+	return e.event
+}
+
+func NewEdgeConfigCompleteMessage(evId EventId) *EdgeConfigCompleteMessage {
+
+	return &EdgeConfigCompleteMessage{
+		event: Event{
+			Id: evId,
+		},
 	}
 }
 

--- a/governance/governance.go
+++ b/governance/governance.go
@@ -1020,7 +1020,6 @@ func (w *GovernanceWorker) GetWorkloadConfig(url string, version string) (map[st
 	// Filter to return workload configs with versions less than or equal to the input workload version range
 	OlderWorkloadWCFilter := func(workload_url string, version string) persistence.WCFilter {
 		return func(e persistence.WorkloadConfig) bool {
-			// if e.WorkloadURL == workload_url && strings.Compare(e.Version, version) <= 0 {
 			if vExp, err := policy.Version_Expression_Factory(e.VersionExpression); err != nil {
 				return false
 			} else if inRange, err := vExp.Is_within_range(version); err != nil {

--- a/microservice/microservice.go
+++ b/microservice/microservice.go
@@ -382,8 +382,10 @@ func GenMicroservicePolicy(msdef *persistence.MicroserviceDefinition, policyPath
 			maxAgreements = 2 // hard coded 2 for now, will change to 0 later
 		}
 
-		if err := policy.GeneratePolicy(e, msdef.SpecRef, msdef.Org, msdef.Name, msdef.Version, policyArch, &props, haPartner, meterPolicy, counterPartyProperties, *list, maxAgreements, policyPath, deviceOrg); err != nil {
+		if msg, err := policy.GeneratePolicy(msdef.SpecRef, msdef.Org, msdef.Name, msdef.Version, policyArch, &props, haPartner, meterPolicy, counterPartyProperties, *list, maxAgreements, policyPath, deviceOrg); err != nil {
 			return fmt.Errorf("Failed to generate policy for %v version %v. Error: %v", msdef.SpecRef, msdef.Version, err)
+		} else {
+			e <- msg
 		}
 	}
 

--- a/persistence/attribute_types.go
+++ b/persistence/attribute_types.go
@@ -30,6 +30,10 @@ func (a LocationAttributes) Update(other Attribute) error {
 	return fmt.Errorf("Update not implemented for type: %T", a)
 }
 
+func (a LocationAttributes) String() string {
+	return fmt.Sprintf("meta: %v, lat: %v, lon: %v, UserProvidedCoords: %v, UseGps: %v", a.Meta, a.Lat, a.Lon, a.UserProvidedCoords, a.UseGps)
+}
+
 type ArchitectureAttributes struct {
 	Meta         *AttributeMeta `json:"meta"`
 	Architecture string         `json:"architecture"`
@@ -47,6 +51,10 @@ func (a ArchitectureAttributes) GetGenericMappings() map[string]interface{} {
 
 func (a ArchitectureAttributes) Update(other Attribute) error {
 	return fmt.Errorf("Update not implemented for type: %T", a)
+}
+
+func (a ArchitectureAttributes) String() string {
+	return fmt.Sprintf("Meta: %v, Arch: %v", a.Meta, a.Architecture)
 }
 
 type ComputeAttributes struct {
@@ -69,6 +77,10 @@ func (a ComputeAttributes) GetGenericMappings() map[string]interface{} {
 // TODO: duplicate this for the others too
 func (a ComputeAttributes) Update(other Attribute) error {
 	return fmt.Errorf("Update not implemented for type: %T", a)
+}
+
+func (a ComputeAttributes) String() string {
+	return fmt.Sprintf("Meta: %v, CPUs: %v, RAM: %v", a.Meta, a.CPUs, a.RAM)
 }
 
 type HAAttributes struct {
@@ -100,6 +112,10 @@ func (a HAAttributes) PartnersContains(id string) bool {
 	return false
 }
 
+func (a HAAttributes) String() string {
+	return fmt.Sprintf("Meta: %v, Partners: %v", a.Meta, a.Partners)
+}
+
 type MeteringAttributes struct {
 	Meta                  *AttributeMeta `json:"meta"`
 	Tokens                uint64         `json:"tokens"`
@@ -124,6 +140,10 @@ func (a MeteringAttributes) Update(other Attribute) error {
 	return fmt.Errorf("Update not implemented for type: %T", a)
 }
 
+func (a MeteringAttributes) String() string {
+	return fmt.Sprintf("Meta: %v, Tokens: %v, PerTimeUnit: %v, NotificationIntervalS: %v", a.Meta, a.Tokens, a.PerTimeUnit, a.NotificationIntervalS)
+}
+
 type CounterPartyPropertyAttributes struct {
 	Meta       *AttributeMeta         `json:"meta"`
 	Expression map[string]interface{} `json:"expression"`
@@ -142,6 +162,10 @@ func (a CounterPartyPropertyAttributes) GetGenericMappings() map[string]interfac
 // TODO: duplicate this for the others too
 func (a CounterPartyPropertyAttributes) Update(other Attribute) error {
 	return fmt.Errorf("Update not implemented for type: %T", a)
+}
+
+func (a CounterPartyPropertyAttributes) String() string {
+	return fmt.Sprintf("Meta: %v, Expression: %v", a.Meta, a.Expression)
 }
 
 type PropertyAttributes struct {
@@ -166,6 +190,10 @@ func (a PropertyAttributes) GetGenericMappings() map[string]interface{} {
 // TODO: duplicate this for the others too
 func (a PropertyAttributes) Update(other Attribute) error {
 	return fmt.Errorf("Update not implemented for type: %T", a)
+}
+
+func (a PropertyAttributes) String() string {
+	return fmt.Sprintf("Meta: %v, Mappings: %v", a.Meta, a.Mappings)
 }
 
 type MappedAttributes struct {
@@ -204,6 +232,10 @@ func (a MappedAttributes) Update(other Attribute) error {
 	return nil
 }
 
+func (a MappedAttributes) String() string {
+	return fmt.Sprintf("Meta: %v, Mappings: %v", a.Meta, a.Mappings)
+}
+
 type AgreementProtocolAttributes struct {
 	Meta      *AttributeMeta `json:"meta"`
 	Protocols interface{}    `json:"protocols"`
@@ -222,6 +254,10 @@ func (a AgreementProtocolAttributes) GetGenericMappings() map[string]interface{}
 // TODO: duplicate this for the others too
 func (a AgreementProtocolAttributes) Update(other Attribute) error {
 	return fmt.Errorf("Update not implemented for type: %T", a)
+}
+
+func (a AgreementProtocolAttributes) String() string {
+	return fmt.Sprintf("Meta: %v, Protocols: %v", a.Meta, a.Protocols)
 }
 
 type HTTPSBasicAuthAttributes struct {

--- a/persistence/attributes.go
+++ b/persistence/attributes.go
@@ -83,6 +83,7 @@ type Attribute interface {
 	GetMeta() *AttributeMeta
 	GetGenericMappings() map[string]interface{}
 	Update(other Attribute) error
+	String() string
 }
 
 type MetaAttributesOnly struct {

--- a/policy/api_spec_list_test.go
+++ b/policy/api_spec_list_test.go
@@ -383,3 +383,117 @@ func Test_APISpecification_notsupports6(t *testing.T) {
 		}
 	}
 }
+
+func Test_APISpecification_replacesharedsingleton_success0(t *testing.T) {
+	var prod_as *APISpecList
+	var con_as *APISpecList
+
+	prod1 := `[{"specRef":"http://mycompany.com/dm/gps","organization":"myorg","version":"1.0.0","exclusiveAccess":false,"arch":"amd64"}]`
+	con1 := `[]`
+	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
+		if con_as = create_APISpecification(con1, t); con_as != nil {
+			prod_as.ReplaceHigherSharedSingleton(con_as)
+			if (*prod_as)[0].Version != "1.0.0" {
+				t.Errorf("Error: should have version 2.0.0, but is %v\n", *prod_as)
+			}
+		}
+	}
+}
+
+func Test_APISpecification_replacesharedsingleton_success1(t *testing.T) {
+	var prod_as *APISpecList
+	var con_as *APISpecList
+
+	prod1 := `[]`
+	con1 := `[]`
+	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
+		if con_as = create_APISpecification(con1, t); con_as != nil {
+			prod_as.ReplaceHigherSharedSingleton(con_as)
+			if len(*prod_as) != 0 {
+				t.Errorf("Error: should be empty, but is %v\n", *prod_as)
+			}
+		}
+	}
+}
+
+func Test_APISpecification_replacesharedsingleton_success2(t *testing.T) {
+	var prod_as *APISpecList
+	var con_as *APISpecList
+
+	prod1 := `[{"specRef":"http://mycompany.com/dm/gps","organization":"myorg","version":"1.0.0","exclusiveAccess":false,"arch":"amd64"}]`
+	con1 := `[{"specRef":"http://mycompany.com/dm/gps","organization":"myorg","version":"2.0.0","exclusiveAccess":false,"arch":"amd64"}]`
+	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
+		if con_as = create_APISpecification(con1, t); con_as != nil {
+			prod_as.ReplaceHigherSharedSingleton(con_as)
+			if (*prod_as)[0].Version != "2.0.0" {
+				t.Errorf("Error: should have version 2.0.0, but is %v\n", *prod_as)
+			}
+		}
+	}
+}
+
+func Test_APISpecification_replacesharedsingleton_success3(t *testing.T) {
+	var prod_as *APISpecList
+	var con_as *APISpecList
+
+	prod1 := `[{"specRef":"http://mycompany.com/dm/gps","organization":"myorg","version":"1.0.0","exclusiveAccess":true,"arch":"amd64"}]`
+	con1 := `[{"specRef":"http://mycompany.com/dm/gps","organization":"myorg","version":"2.0.0","exclusiveAccess":false,"arch":"amd64"}]`
+	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
+		if con_as = create_APISpecification(con1, t); con_as != nil {
+			prod_as.ReplaceHigherSharedSingleton(con_as)
+			if (*prod_as)[0].Version != "1.0.0" {
+				t.Errorf("Error: should have version 2.0.0, but is %v\n", *prod_as)
+			}
+		}
+	}
+}
+
+func Test_APISpecification_replacesharedsingleton_success4(t *testing.T) {
+	var prod_as *APISpecList
+	var con_as *APISpecList
+
+	prod1 := `[{"specRef":"http://mycompany.com/dm/gps","organization":"myorg","version":"1.0.0","exclusiveAccess":false,"arch":"amd64"}]`
+	con1 := `[{"specRef":"http://mycompany.com/dm/gps","organization":"myorg","version":"2.0.0","exclusiveAccess":true,"arch":"amd64"}]`
+	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
+		if con_as = create_APISpecification(con1, t); con_as != nil {
+			prod_as.ReplaceHigherSharedSingleton(con_as)
+			if (*prod_as)[0].Version != "1.0.0" {
+				t.Errorf("Error: should have version 2.0.0, but is %v\n", *prod_as)
+			}
+		}
+	}
+}
+
+func Test_APISpecification_replacesharedsingleton_success5(t *testing.T) {
+	var prod_as *APISpecList
+	var con_as *APISpecList
+
+	prod1 := `[{"specRef":"http://mycompany.com/dm/gps","organization":"myorg","version":"1.0.0","exclusiveAccess":false,"arch":"amd64"}]`
+	con1 := `[{"specRef":"http://mycompany.com/dm/gps2","organization":"myorg","version":"2.0.0","exclusiveAccess":false,"arch":"amd64"}]`
+	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
+		if con_as = create_APISpecification(con1, t); con_as != nil {
+			prod_as.ReplaceHigherSharedSingleton(con_as)
+			if (*prod_as)[0].Version != "1.0.0" {
+				t.Errorf("Error: should have version 2.0.0, but is %v\n", *prod_as)
+			} else if (*prod_as)[0].SpecRef != "http://mycompany.com/dm/gps" {
+				t.Errorf("Error: should be 2 entries in the array, but is %v\n", *prod_as)
+			}
+		}
+	}
+}
+
+func Test_APISpecification_replacesharedsingleton_success6(t *testing.T) {
+	var prod_as *APISpecList
+	var con_as *APISpecList
+
+	prod1 := `[{"specRef":"http://mycompany.com/dm/gps","organization":"myorg","version":"1.0.0","exclusiveAccess":false,"arch":"amd64"},{"specRef":"http://mycompany.com/dm/gps2","organization":"myorg","version":"1.0.0","exclusiveAccess":false,"arch":"amd64"}]`
+	con1 := `[{"specRef":"http://mycompany.com/dm/gps","organization":"myorg","version":"1.0.0","exclusiveAccess":false,"arch":"amd64"},{"specRef":"http://mycompany.com/dm/gps2","organization":"myorg","version":"2.0.0","exclusiveAccess":false,"arch":"amd64"}]`
+	if prod_as = create_APISpecification(prod1, t); prod_as != nil {
+		if con_as = create_APISpecification(con1, t); con_as != nil {
+			prod_as.ReplaceHigherSharedSingleton(con_as)
+			if (*prod_as)[0].Version != "1.0.0" && (*prod_as)[1].Version != "2.0.0" {
+				t.Errorf("Error: should have version 1.0.0 and 2.0.0, but is %v\n", *prod_as)
+			}
+		}
+	}
+}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -13,7 +13,7 @@ import (
 // can take any version.
 // maxAgreements: 0 means unlimited.
 
-func GeneratePolicy(e chan events.Message, sensorUrl string, sensorOrg string, sensorName string, sensorVersion string, arch string, props *map[string]interface{}, haPartners []string, meterPolicy Meter, counterPartyProperties RequiredProperty, agps []AgreementProtocol, maxAgreements int, filePath string, deviceOrg string) error {
+func GeneratePolicy(sensorUrl string, sensorOrg string, sensorName string, sensorVersion string, arch string, props *map[string]interface{}, haPartners []string, meterPolicy Meter, counterPartyProperties RequiredProperty, agps []AgreementProtocol, maxAgreements int, filePath string, deviceOrg string) (*events.PolicyCreatedMessage, error) {
 
 	glog.V(5).Infof("Generating policy for %v", sensorUrl)
 
@@ -54,16 +54,12 @@ func GeneratePolicy(e chan events.Message, sensorUrl string, sensorOrg string, s
 
 	// Store the policy on the filesystem
 	if fullFileName, err := CreatePolicyFile(filePath, deviceOrg, fileName, p); err != nil {
-		return err
+		return nil, err
 	} else {
 
-		// Fire an event
-		glog.V(5).Infof("About to fire event for policy %v", fullFileName)
-		e <- events.NewPolicyCreatedMessage(events.NEW_POLICY, fullFileName)
-
-		glog.V(5).Infof("Queued policy %v for event handler", fullFileName)
-
-		return nil
+		// Create the new policy event
+		msg := events.NewPolicyCreatedMessage(events.NEW_POLICY, fullFileName)
+		return msg, nil
 	}
 }
 


### PR DESCRIPTION
Requires Exchange 1.38.
Requires changes to reg_all and any doc due to the need to use the new configstate API in order to make a node ready to make agreements.
Design doc: https://docs.google.com/document/d/1ZclxhHZP7BcBESGcx5oAGUxyew2aj1vZ0ffRXeX-vXQ
Please note that ONLY phase 0 of that design is implemented in this PR.