### PR TITLE
Bug/large file timeout

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -404,10 +404,10 @@
 			"tree": true
 		},
 		{
-			"checksumSHA1": "Z11qMGiH5ede7IJ6K91H5DXJGfk=",
+			"checksumSHA1": "/Fx0zd2hqzCYV19hrdheCrZgWu0=",
 			"path": "github.com/open-horizon/horizon-pkg-fetch",
-			"revision": "9fe96f86b9a4ae6d9c1c97d84b31e646d8079d63",
-			"revisionTime": "2017-09-29T04:46:40Z"
+			"revision": "40bcf03f4127d9d7557d21f05af660ea72a95d60",
+			"revisionTime": "2017-10-10T13:49:07Z"
 		},
 		{
 			"checksumSHA1": "RyA64Y5+znkhKUwOhvXUUHtSf4g=",


### PR DESCRIPTION
Revision 40bcf03f4127d9d7557d21f05af660ea72a95d60 of `horizon-pkg-fetch`, https://github.com/open-horizon/horizon-pkg-fetch/commit/40bcf03f4127d9d7557d21f05af660ea72a95d60, contains support for dynamic http client timeouts based on payload size (note that the golang timeout is really more of an overall deadline for download; if the set duration is exceeded even during a long but successful download, the download is canceled). The meat is here: https://github.com/open-horizon/horizon-pkg-fetch/commit/40bcf03f4127d9d7557d21f05af660ea72a95d60#diff-2ea1386281e9d2666b1739bfec7f26c8R355 .

Another, previous revision is bundled in here and it's support for downloading parts with no specified domain (so the fetcher assumes the Pkg file's domain). That's here: https://github.com/open-horizon/horizon-pkg-fetch/commit/816046b30377ede6be01be6202da4912a43babd3

(Note that I wasn't trying to circumvent any process by pushing these changes in a lib without previous review, I was under a crunch for fixing problems in a consumer's environment and so tested the lib separately and produced an RC package before this PR to main.)