### PR TITLE
Make hzn register reentrant

### DIFF
--- a/cli/cliutils/cliutils.go
+++ b/cli/cliutils/cliutils.go
@@ -24,6 +24,11 @@ const (
 	READ_FILE_ERROR    = 4
 	HTTP_ERROR         = 5
 	//EXEC_CMD_ERROR = 6
+	INTERNAL_ERROR = 99
+
+	// Anax API HTTP Codes
+	ANAX_ALREADY_CONFIGURED = 409
+	ANAX_NOT_CONFIGURED_YET = 424
 )
 
 // Holds the cmd line flags that were set so other pkgs can access
@@ -66,16 +71,29 @@ func GetHorizonUrlBase() string {
 	return HZN_API
 }
 
-// GetRespBodyString converts an http response body to a string
-func GetRespBodyString(responseBody io.ReadCloser) string {
+// GetRespBodyAsString converts an http response body to a string
+func GetRespBodyAsString(responseBody io.ReadCloser) string {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(responseBody)
 	return buf.String()
 }
 
-// HorizonGet runs a GET on the anax api and fills in the specified json structure.
-// If goodHttp is non-zero and does not match the actual http code, it will exit with an error. Otherwise the actual code is returned.
-func HorizonGet(urlSuffix string, goodHttp int, structure interface{}) (httpCode int) {
+func isGoodCode(actualHttpCode int, goodHttpCodes []int) bool {
+	if len(goodHttpCodes) == 0 {
+		return true		// passing in an empty list of good codes means anything is ok
+	}
+	for _, code := range goodHttpCodes {
+		if code == actualHttpCode {
+			return true
+		}
+	}
+	return false
+}
+
+// HorizonGet runs a GET on the anax api and fills in the specified structure with the json.
+// If the list of goodHttpCodes is not empty and none match the actual http code, it will exit with an error. Otherwise the actual code is returned.
+// Only if the actual code matches the 1st element in goodHttpCodes, will it parse the body into the specified structure.
+func HorizonGet(urlSuffix string, goodHttpCodes []int, structure interface{}) (httpCode int) {
 	url := GetHorizonUrlBase() + "/" + urlSuffix
 	apiMsg := http.MethodGet + " " + url
 	Verbose(apiMsg)
@@ -86,22 +104,24 @@ func HorizonGet(urlSuffix string, goodHttp int, structure interface{}) (httpCode
 	defer resp.Body.Close()
 	httpCode = resp.StatusCode
 	Verbose("HTTP code: %d", httpCode)
-	if goodHttp > 0 && httpCode != goodHttp {
+	if !isGoodCode(httpCode, goodHttpCodes) {
 		Fatal(HTTP_ERROR, "bad HTTP code from %s: %d", apiMsg, httpCode)
 	}
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		Fatal(HTTP_ERROR, "failed to read body response for %s: %v", apiMsg, err)
-	}
-	err = json.Unmarshal(bodyBytes, structure)
-	if err != nil {
-		Fatal(JSON_PARSING_ERROR, "failed to unmarshal body response for %s: %v", apiMsg, err)
+	if httpCode == goodHttpCodes[0] {
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			Fatal(HTTP_ERROR, "failed to read body response for %s: %v", apiMsg, err)
+		}
+		err = json.Unmarshal(bodyBytes, structure)
+		if err != nil {
+			Fatal(JSON_PARSING_ERROR, "failed to unmarshal body response for %s: %v", apiMsg, err)
+		}
 	}
 	return
 }
 
 // HorizonDelete runs a DELETE on the anax api.
-// If goodHttp is non-zero and does not match the actual http code, it will exit with an error. Otherwise the actual code is returned.
+// If the list of goodHttpCodes is not empty and none match the actual http code, it will exit with an error. Otherwise the actual code is returned.
 func HorizonDelete(urlSuffix string, goodHttpCodes []int) (httpCode int) {
 	url := GetHorizonUrlBase() + "/" + urlSuffix
 	apiMsg := http.MethodDelete + " " + url
@@ -118,23 +138,14 @@ func HorizonDelete(urlSuffix string, goodHttpCodes []int) (httpCode int) {
 	defer resp.Body.Close()
 	httpCode = resp.StatusCode
 	Verbose("HTTP code: %d", httpCode)
-	if len(goodHttpCodes) > 0 {
-		foundCode := false
-		for _, code := range goodHttpCodes {
-			if code == httpCode {
-				foundCode = true
-				break
-			}
-		}
-		if !foundCode {
-			Fatal(HTTP_ERROR, "bad HTTP code %d from %s: %s", httpCode, apiMsg, GetRespBodyString(resp.Body))
-		}
+	if !isGoodCode(httpCode, goodHttpCodes) {
+		Fatal(HTTP_ERROR, "bad HTTP code %d from %s: %s", httpCode, apiMsg, GetRespBodyAsString(resp.Body))
 	}
 	return
 }
 
 // HorizonPutPost runs a PUT or POST to the anax api to create of update a resource.
-// If the list of goodHttps is not empty and none match the actual http code, it will exit with an error. Otherwise the actual code is returned.
+// If the list of goodHttpCodes is not empty and none match the actual http code, it will exit with an error. Otherwise the actual code is returned.
 func HorizonPutPost(method string, urlSuffix string, goodHttpCodes []int, body interface{}) (httpCode int) {
 	url := GetHorizonUrlBase() + "/" + urlSuffix
 	apiMsg := method + " " + url
@@ -158,24 +169,15 @@ func HorizonPutPost(method string, urlSuffix string, goodHttpCodes []int, body i
 	defer resp.Body.Close()
 	httpCode = resp.StatusCode
 	Verbose("HTTP code: %d", httpCode)
-	if len(goodHttpCodes) > 0 {
-		foundCode := false
-		for _, code := range goodHttpCodes {
-			if code == httpCode {
-				foundCode = true
-				break
-			}
-		}
-		if !foundCode {
-			Fatal(HTTP_ERROR, "bad HTTP code %d from %s: %s", httpCode, apiMsg, GetRespBodyString(resp.Body))
-		}
+	if !isGoodCode(httpCode, goodHttpCodes) {
+		Fatal(HTTP_ERROR, "bad HTTP code %d from %s: %s", httpCode, apiMsg, GetRespBodyAsString(resp.Body))
 	}
 	return
 }
 
 // ExchangeGet runs a GET to the exchange api and fills in the specified json structure.
-// If goodHttp is non-zero and does not match the actual http code, it will exit with an error. Otherwise the actual code is returned.
-func ExchangeGet(urlBase string, urlSuffix string, credentials string, goodHttp int, structure interface{}) (httpCode int) {
+// If the list of goodHttpCodes is not empty and none match the actual http code, it will exit with an error. Otherwise the actual code is returned.
+func ExchangeGet(urlBase string, urlSuffix string, credentials string, goodHttpCodes []int, structure interface{}) (httpCode int) {
 	url := urlBase + "/" + urlSuffix
 	apiMsg := http.MethodGet + " " + url
 	Verbose(apiMsg)
@@ -194,7 +196,7 @@ func ExchangeGet(urlBase string, urlSuffix string, credentials string, goodHttp 
 	defer resp.Body.Close()
 	httpCode = resp.StatusCode
 	Verbose("HTTP code: %d", httpCode)
-	if goodHttp > 0 && httpCode != goodHttp {
+	if !isGoodCode(httpCode, goodHttpCodes) {
 		Fatal(HTTP_ERROR, "bad HTTP code from %s: %d", apiMsg, httpCode)
 	}
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
@@ -209,8 +211,8 @@ func ExchangeGet(urlBase string, urlSuffix string, credentials string, goodHttp 
 }
 
 // ExchangePutPost runs a PUT or POST to the exchange api to create of update a resource.
-// If goodHttp is non-zero and does not match the actual http code, it will exit with an error. Otherwise the actual code is returned.
-func ExchangePutPost(method string, urlBase string, urlSuffix string, credentials string, goodHttp int, body interface{}) (httpCode int) {
+// If the list of goodHttpCodes is not empty and none match the actual http code, it will exit with an error. Otherwise the actual code is returned.
+func ExchangePutPost(method string, urlBase string, urlSuffix string, credentials string, goodHttpCodes []int, body interface{}) (httpCode int) {
 	url := urlBase + "/" + urlSuffix
 	apiMsg := method + " " + url
 	Verbose(apiMsg)
@@ -234,7 +236,7 @@ func ExchangePutPost(method string, urlBase string, urlSuffix string, credential
 	defer resp.Body.Close()
 	httpCode = resp.StatusCode
 	Verbose("HTTP code: %d", httpCode)
-	if goodHttp > 0 && httpCode != goodHttp {
+	if !isGoodCode(httpCode, goodHttpCodes) {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			Fatal(HTTP_ERROR, "failed to read body response for %s: %v", apiMsg, err)

--- a/cli/cliutils/cliutils.go
+++ b/cli/cliutils/cliutils.go
@@ -80,7 +80,7 @@ func GetRespBodyAsString(responseBody io.ReadCloser) string {
 
 func isGoodCode(actualHttpCode int, goodHttpCodes []int) bool {
 	if len(goodHttpCodes) == 0 {
-		return true		// passing in an empty list of good codes means anything is ok
+		return true // passing in an empty list of good codes means anything is ok
 	}
 	for _, code := range goodHttpCodes {
 		if code == actualHttpCode {

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -17,14 +17,14 @@ func main() {
 	cliutils.Opts.Verbose = app.Flag("verbose", "Verbose output.").Short('v').Bool()
 
 	registerCmd := app.Command("register", "Register this edge node with Horizon.")
-	userPw := registerCmd.Flag("user-pw", "User credentials (user:pw) to create the node resource in the Horizon exchange if it does not already exist.").Short('u').String()
-	inputFile := registerCmd.Flag("input-file", "A JSON file that sets or overrides variables needed by the workloads and microservices that are part of this pattern. See /usr/horizon/samples/input.json").Short('f').String()
+	nodeIdTok := registerCmd.Flag("node-id-tok", "The Horizon exchange node ID and token. The node ID must be unique within the organization. If not specified, the node ID will be created by Horizon from the machine serial number or fully qualified hostname. If the token is not specified, Horizon will create a random token. If node resource in the exchange identified by the ID and token does not yet exist, you must also specify the -u flag so it can be created.").Short('n').PlaceHolder("ID:TOK").String()
+	userPw := registerCmd.Flag("user-pw", "User credentials to create the node resource in the Horizon exchange if it does not already exist.").Short('u').PlaceHolder("USER:PW").String()
+	inputFile := registerCmd.Flag("input-file", "A JSON file that sets or overrides variables needed by the node, workloads, and microservices that are part of this pattern. See /usr/horizon/samples/input.json. Specify -f- to read from stdin.").Short('f').String()
 	org := registerCmd.Arg("organization", "The Horizon exchange organization ID.").Required().String()
-	nodeId := registerCmd.Arg("nodeid", "The Horizon exchange node ID. Must be unique within the organization. Suggestions are machine serial number or fully qualified hostname. If it does not yet exist, you must also specify the -u flag").Required().String()
-	nodeToken := registerCmd.Arg("nodetoken", "The Horizon exchange node token.").Required().String()
 	pattern := registerCmd.Arg("pattern", "The Horizon exchange pattern that describes what workloads that should be deployed to this node.").Required().String()
 
 	importkeyCmd := app.Command("importkey", "Import a public key to verify signed microservices and workloads.")
+	keyFile := importkeyCmd.Arg("keyfile", "The public PEM file.").Required().String()
 
 	showCmd := app.Command("show", "Display information about this Horizon edge node.")
 	showNodeCmd := showCmd.Command("node", "Show general information about this Horizon edge node.")
@@ -41,14 +41,14 @@ func main() {
 	forceUnregister := unregisterCmd.Flag("force", "Skip the 'are you sure?' prompt.").Short('f').Bool()
 	removeNodeUnregister := unregisterCmd.Flag("remove", "Also remove this node resource from the Horizon exchange (because you no longer want to use this node with Horizon).").Short('r').Bool()
 
-	app.Version("0.0.1") //todo: get the real version of anax
+	app.Version("0.0.2") //todo: get the real version of anax
 
 	// Decide which command to run
 	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
 	case registerCmd.FullCommand():
-		register.DoIt(*org, *nodeId, *nodeToken, *pattern, *userPw, *inputFile)
+		register.DoIt(*org, *pattern, *nodeIdTok, *userPw, *inputFile)
 	case importkeyCmd.FullCommand():
-		importkey.DoIt()
+		importkey.DoIt(*keyFile)
 	//case showCmd.FullCommand():   // <- I'd like to just show usage for hzn show, but don't know how to do that yet
 	//	showCmd.?
 	case showNodeCmd.FullCommand():

--- a/cli/importkey/importkey.go
+++ b/cli/importkey/importkey.go
@@ -3,5 +3,5 @@ package importkey
 import "fmt"
 
 func DoIt(keyFile string) {
-	fmt.Println("Not implemented yet.")		//todo: implement
+	fmt.Println("Not implemented yet.") //todo: implement
 }

--- a/cli/importkey/importkey.go
+++ b/cli/importkey/importkey.go
@@ -2,6 +2,6 @@ package importkey
 
 import "fmt"
 
-func DoIt() {
-	fmt.Println("implement me")
+func DoIt(keyFile string) {
+	fmt.Println("Not implemented yet.")		//todo: implement
 }

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -6,10 +6,12 @@ import (
 	"github.com/open-horizon/anax/api"
 	"github.com/open-horizon/anax/cli/cliutils"
 	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/anax/cutil"
 	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strings"
+	"os"
 )
 
 type HorizonDevice struct {
@@ -23,6 +25,7 @@ type HorizonDevice struct {
 
 type GlobalSet struct {
 	Type      string                 `json:"type"`
+	SensorUrls  []string               `json:"sensor_urls"`
 	Variables map[string]interface{} `json:"variables"`
 }
 
@@ -41,7 +44,13 @@ type InputFile struct {
 }
 
 func readInputFile(filePath string, inputFileStruct *InputFile) {
-	fileBytes, err := ioutil.ReadFile(filePath)
+	var fileBytes []byte
+	var err error
+	if filePath == "-" {
+		fileBytes, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		fileBytes, err = ioutil.ReadFile(filePath)
+	}
 	if err != nil {
 		cliutils.Fatal(cliutils.READ_FILE_ERROR, "reading %s failed: %v", filePath, err)
 	}
@@ -55,7 +64,7 @@ func readInputFile(filePath string, inputFileStruct *InputFile) {
 	}
 }
 
-// Note: a structure like this exists in the api pkg, but has the id and everything as ptrs, so it is not convenient to use
+// Note: a structure like this exists in the api pkg, but has the id and everything as ptrs, and there are several sub-types with an interface.
 type Attribute struct {
 	Type        string                 `json:"type"`
 	SensorUrls  []string               `json:"sensor_urls"`
@@ -79,8 +88,9 @@ type Configstate struct {
 	State string `json:"state"`
 }
 
+
 // DoIt registers this node to Horizon with a pattern
-func DoIt(org string, nodeId string, nodeToken string, pattern string, userPw string, inputFile string) {
+func DoIt(org string, pattern string, nodeIdTok string, userPw string, inputFile string) {
 	// Read input file 1st, so we don't get half way thru registration before finding the problem
 	inputFileStruct := InputFile{}
 	if inputFile != "" {
@@ -90,20 +100,42 @@ func DoIt(org string, nodeId string, nodeToken string, pattern string, userPw st
 
 	// Get the exchange url from the anax api
 	status := api.Info{}
-	cliutils.HorizonGet("status", 200, &status)
+	cliutils.HorizonGet("status", []int{200}, &status)
 	exchUrlBase := strings.TrimSuffix(status.Configuration.ExchangeAPI, "/")
 	fmt.Printf("Horizon Exchange base URL: %s\n", exchUrlBase)
 
 	// See if the node exists in the exchange, and create if it doesn't
+	parts := strings.SplitN(nodeIdTok, ":", 2)
+	nodeId := parts[0]		// SplitN will always at least return 1 element
+	nodeToken := ""
+	if len(parts) >= 2 {
+		nodeToken = parts[1]
+	}
+	if nodeId == "" {
+		// Get the id from anax
+		horDevice := api.HorizonDevice{}
+		cliutils.HorizonGet("horizondevice", []int{200}, &horDevice)
+		nodeId = *horDevice.Id
+		fmt.Printf("Using node ID '%s' from the Horizon agent\n", nodeId)
+	}
+	if nodeToken == "" {
+		// Create a random token
+		var err error
+		nodeToken, err = cutil.SecureRandomString()
+		if err != nil {
+			cliutils.Fatal(cliutils.INTERNAL_ERROR, "could not create a random token")
+		}
+		fmt.Println("Generated random node token")
+	}
 	node := exchange.GetDevicesResponse{}
-	httpCode := cliutils.ExchangeGet(exchUrlBase, "orgs/"+org+"/nodes/"+nodeId, org+"/"+nodeId+":"+nodeToken, 0, &node)
+	httpCode := cliutils.ExchangeGet(exchUrlBase, "orgs/"+org+"/nodes/"+nodeId, org+"/"+nodeId+":"+nodeToken, nil, &node)
 	if httpCode != 200 {
 		if userPw == "" {
-			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "node %s/%s does not exist in the exchange and the -u flag was not specified to provide exchange user credentials to create it.", org, nodeId)
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "node %s/%s does not exist in the exchange with the specified token and the -u flag was not specified to provide exchange user credentials to create/update it.", org, nodeId)
 		}
-		fmt.Printf("Node %s/%s does not exists in the exchange, creating it...\n", org, nodeId)
+		fmt.Printf("Node %s/%s does not exists in the exchange with the specified token, creating/updating it...\n", org, nodeId)
 		putNodeReq := exchange.PutDeviceRequest{Token: nodeToken, Name: nodeId, SoftwareVersions: make(map[string]string), PublicKey: []byte("")} // we only need to set the token
-		cliutils.ExchangePutPost(http.MethodPut, exchUrlBase, "orgs/"+org+"/nodes/"+nodeId, org+"/"+userPw, 201, putNodeReq)
+		cliutils.ExchangePutPost(http.MethodPut, exchUrlBase, "orgs/"+org+"/nodes/"+nodeId, org+"/"+userPw, []int{201}, putNodeReq)
 	} else {
 		fmt.Printf("Node %s/%s exists in the exchange\n", org, nodeId)
 	}
@@ -111,19 +143,25 @@ func DoIt(org string, nodeId string, nodeToken string, pattern string, userPw st
 	// Initialize the Horizon device (node)
 	fmt.Println("Initializing the Horizon node...")
 	hd := HorizonDevice{Id: nodeId, Token: nodeToken, Org: org, Pattern: pattern, Name: nodeId, HADevice: false} //todo: support HA config
-	cliutils.HorizonPutPost(http.MethodPost, "horizondevice", []int{201, 200}, hd)
+	httpCode = cliutils.HorizonPutPost(http.MethodPost, "horizondevice", []int{201, 200, cliutils.ANAX_ALREADY_CONFIGURED}, hd)
+	if httpCode == cliutils.ANAX_ALREADY_CONFIGURED {
+		// Note: I wanted to make `hzn register` idempotent, but the anax api doesn't support changing existing settings once in configuring state (to maintain internal consistency).
+		//		And i can't query ALL the existing settings to make sure they are what we were going to set, because i can't query the node token.
+		cliutils.Fatal(cliutils.HTTP_ERROR, "this Horizon node is already registered or in the process of being registered. If you want to register it differently, run 'hzn unregister' first.")
+	}
 
 	// Process the input file and call /attribute, /service, and /workloadconfig to set the specified variables
 	if inputFile != "" {
-		// Set the global variables as attributes with no url
+		// Set the global variables as attributes with no url (or in the case of HTTPSBasicAuthAttributes, with url equal to image svr)
+		// Technically the AgreementProtocolAttributes can be set, but it has no effect on anax if a pattern is being used.
 		fmt.Println("Setting global variables...")
 		attr := Attribute{SensorUrls: []string{}, Label: "Global variables", Publishable: false, HostOnly: false} // we reuse this for each GlobalSet
 		for _, g := range inputFileStruct.Global {
 			attr.Type = g.Type
+			attr.SensorUrls = g.SensorUrls
 			attr.Mappings = g.Variables
 			cliutils.HorizonPutPost(http.MethodPost, "attribute", []int{201, 200}, attr)
 		}
-		//todo: support types: HTTPSBasicAuthAttributes, AgreementProtocolAttributes
 
 		// Set the microservice variables
 		fmt.Println("Setting microservice variables...")

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"github.com/open-horizon/anax/api"
 	"github.com/open-horizon/anax/cli/cliutils"
-	"github.com/open-horizon/anax/exchange"
 	"github.com/open-horizon/anax/cutil"
+	"github.com/open-horizon/anax/exchange"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
-	"os"
 )
 
 type HorizonDevice struct {
@@ -24,9 +24,9 @@ type HorizonDevice struct {
 }
 
 type GlobalSet struct {
-	Type      string                 `json:"type"`
-	SensorUrls  []string               `json:"sensor_urls"`
-	Variables map[string]interface{} `json:"variables"`
+	Type       string                 `json:"type"`
+	SensorUrls []string               `json:"sensor_urls"`
+	Variables  map[string]interface{} `json:"variables"`
 }
 
 // Use for both microservices and workloads
@@ -88,7 +88,6 @@ type Configstate struct {
 	State string `json:"state"`
 }
 
-
 // DoIt registers this node to Horizon with a pattern
 func DoIt(org string, pattern string, nodeIdTok string, userPw string, inputFile string) {
 	// Read input file 1st, so we don't get half way thru registration before finding the problem
@@ -106,7 +105,7 @@ func DoIt(org string, pattern string, nodeIdTok string, userPw string, inputFile
 
 	// See if the node exists in the exchange, and create if it doesn't
 	parts := strings.SplitN(nodeIdTok, ":", 2)
-	nodeId := parts[0]		// SplitN will always at least return 1 element
+	nodeId := parts[0] // SplitN will always at least return 1 element
 	nodeToken := ""
 	if len(parts) >= 2 {
 		nodeToken = parts[1]

--- a/cli/samples/more-examples.json
+++ b/cli/samples/more-examples.json
@@ -14,6 +14,24 @@ This sample will work as-is with the IBM netspeed pattern.
 				"use_gps": false,    /* true if you have, and want to use, an attached GPS sensor. Passed to each container as HZN_USE_GPS. */
 				"location_accuracy_km": 0.0   /* Make the node location inaccurate by this number of KM to protect privacy. */
 			}
+		},
+		{
+			"type": "HTTPSBasicAuthAttributes",   /* use if the image svr requires authentication */
+			"sensor_urls": [
+				"https://mycompany.com/api/horizon/images"
+			],
+			"variables": {
+				"password": "MYPASSWORDVALUE",
+				"username": "MYUSERNAMEVALUE"
+			}
+		},
+		{
+			"type": "AgreementProtocolAttributes",   /* This will not have any effect when a pattern is being used. You can use this when not using a pattern to specify that you want to record the agreement on ethereum blockchain */
+			"variables": {
+				"protocols": [
+					{"Citizen Scientist":[]}
+				]
+			}
 		}
 	],
 	/* You only need to list the workloads that need input from you the edge node owner */

--- a/cli/show/show.go
+++ b/cli/show/show.go
@@ -17,7 +17,7 @@ const MUST_REGISTER_FIRST = "this command can not be run before running 'hzn reg
 
 type Configstate struct {
 	State          *string `json:"state"`
-	LastUpdateTime string  `json:"last_update_time"`   // removed omitempty
+	LastUpdateTime string  `json:"last_update_time"` // removed omitempty
 }
 
 // This is a combo of anax's HorizonDevice and Info (status) structs
@@ -25,13 +25,13 @@ type NodeAndStatus struct {
 	// from api.HorizonDevice
 	Id                 *string     `json:"id"`
 	Org                *string     `json:"organization"`
-	Pattern            *string     `json:"pattern"` // a simple name, not prefixed with the org
-	Name               *string     `json:"name"`   // removed omitempty
-	Token              *string     `json:"token"`   // removed omitempty
-	TokenLastValidTime string      `json:"token_last_valid_time"`   // removed omitempty
-	TokenValid         *bool       `json:"token_valid"`   // removed omitempty
-	HADevice           *bool       `json:"ha_device"`   // removed omitempty
-	Config             Configstate `json:"configstate"`   // removed omitempty
+	Pattern            *string     `json:"pattern"`               // a simple name, not prefixed with the org
+	Name               *string     `json:"name"`                  // removed omitempty
+	Token              *string     `json:"token"`                 // removed omitempty
+	TokenLastValidTime string      `json:"token_last_valid_time"` // removed omitempty
+	TokenValid         *bool       `json:"token_valid"`           // removed omitempty
+	HADevice           *bool       `json:"ha_device"`             // removed omitempty
+	Config             Configstate `json:"configstate"`           // removed omitempty
 	// from api.Info
 	Geths         []api.Geth         `json:"geth"`
 	Configuration *api.Configuration `json:"configuration"`
@@ -337,9 +337,9 @@ const HTTPSBasicAuthAttributes = "HTTPSBasicAuthAttributes"
 type OurAttributes struct {
 	Type string `json:"type"`
 	//SensorUrls  []string               `json:"sensor_urls"`
-	Label     string                 `json:"label"`
-	SensorUrls  []string               `json:"sensor_urls,omitempty"`
-	Variables map[string]interface{} `json:"variables"`
+	Label      string                 `json:"label"`
+	SensorUrls []string               `json:"sensor_urls,omitempty"`
+	Variables  map[string]interface{} `json:"variables"`
 }
 
 func Attributes() {
@@ -386,7 +386,7 @@ type ServiceWrapper struct {
 }
 
 type OurService struct {
-	APISpecs  policy.APISpecList     `json:"apiSpec"`   // removed omitempty
+	APISpecs  policy.APISpecList     `json:"apiSpec"` // removed omitempty
 	Variables map[string]interface{} `json:"variables"`
 }
 


### PR DESCRIPTION
- Detect if already in the middle of registration when hzn register is run
- Give good msg for several show cmds when not registered yet
- Support reading input file from stdin
- Support HTTPSBasicAuthAttributes and AgreementProtocolAttributes
- Added more error checking
- make node id optional (get it from GET /horizondevice) and node token optional (generate random toke)