### PR TITLE
Feature/xcompile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,12 @@ test-integration:
 	-@cd $(PKGPATH) && \
 		GOPATH=$(TMPGOPATH) go test -cover -tags=integration $(PKGS)
 
-check: deps lint test test-integration
+test-ci:
+	@echo "Executing integration tests intended for CI systems with special configuration"
+	-@cd $(PKGPATH) && \
+		GOPATH=$(TMPGOPATH) go test -cover -tags=ci $(PKGS)
+
+check: deps lint test test-integration test-ci
 
 # build sequence diagrams
 diagrams:

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,8 @@ test-ci:
 	-@cd $(PKGPATH) && \
 		GOPATH=$(TMPGOPATH) go test -cover -tags=ci $(PKGS)
 
-check: deps lint test test-integration test-ci
+# N.B. this doesn't run ci tests, the ones that require CI system setup
+check: deps lint test test-integration
 
 # build sequence diagrams
 diagrams:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ $(EXECUTABLE): $(shell find . -name '*.go' -not -path './vendor/*') $(CLI_EXECUT
 	    $(COMPILE_ARGS) go build -o $(EXECUTABLE)
 
 $(CLI_EXECUTABLE): $(shell find cli -name '*.go')
-	@echo "Producing $(CLI_EXECUTABLE)"
+	@echo "Producing $(CLI_EXECUTABLE) given arch: $(arch)"
 	cd $(PKGPATH) && \
 	  export GOPATH=$(TMPGOPATH); \
 	    $(COMPILE_ARGS) go build -o $(CLI_EXECUTABLE) $(CLI_EXECUTABLE).go

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Note that the Makefile silences a lot of its output by default. If you want to s
 
     make format
 
+#### Fetch dependencies
+
+    make deps
+
+Note that this target is automatically executed when executing targets `check` and `all`. It is not automatically executed when executing `test`, `test-integration`, and generating specific executables.
+
 #### Execute both unit and integration tests
 
     make check

--- a/tools/arch-tag
+++ b/tools/arch-tag
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+uname="$(uname -m)"
+
+if [[ "$uname" =~ "aarch64" ]]; then
+  echo "arm64"
+elif [[ "$uname" =~ "arm" ]]; then
+  echo "armhf"
+elif [[ "$uname" == "x86_64" ]]; then
+  echo "amd64"
+elif [[ "$uname" == "ppc64le" ]]; then
+  # the power8 architecture is ppc64 little endian and corresponds to debian / ubuntu arch designation "ppc64el"
+  echo "ppc64el"
+else
+  (>&2 echo "Unknown architecture $uname")
+  exit 1
+fi


### PR DESCRIPTION
This PR includes the following notable changes:

- `$(EXECUTABLE)`, `test`, and `test-integration` targets don't depend on `deps` (faster builds when you know deps haven't changed); note that `all` (which is the default) and `check` still fetch dependencies as usual
- Added arch-tag script that outputs debian arch for compatibility with cross-compiling when building packages; added related cross-compiling logic
- Improved handling of `TMPGOPATH` by making it adjust a symlink if TMPGOPATH already exists; also added copy of govendor's .cache directory from GOPATH if one exists
