### PR TITLE
disable default Horizon UI page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,8 @@ install:
 	mkdir -p $(DESTDIR)/bin && \
 		cp $(EXECUTABLE) $(DESTDIR)/bin && \
 		cp $(CLI_EXECUTABLE) $(DESTDIR)/bin
-	mkdir -p $(DESTDIR)/web && \
-		cp $(DEFAULT_UI) $(DESTDIR)/web
+	# mkdir -p $(DESTDIR)/web && \
+	#	cp $(DEFAULT_UI) $(DESTDIR)/web
 	cp -Rapv cli/samples $(DESTDIR)
 	mkdir -p $(CDIR) && \
 		cp -apv ./vendor/github.com/open-horizon/go-solidity/contracts/. $(CDIR)/


### PR DESCRIPTION
Just commented out the placement of the default UI page when anax install target is used. This is temporary until issue 62 in the deb packager project is resolved.