### PR TITLE
Add ms wk to hzn

### DIFF
--- a/cli/agreement/agreement.go
+++ b/cli/agreement/agreement.go
@@ -103,7 +103,7 @@ func List(archivedAgreements bool) {
 		}
 		jsonBytes, err := json.MarshalIndent(agreements, "", cliutils.JSON_INDENT)
 		if err != nil {
-			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'show agreements' output: %v", err)
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn agreement list' output: %v", err)
 		}
 		fmt.Printf("%s\n", jsonBytes)
 	} else {
@@ -113,7 +113,7 @@ func List(archivedAgreements bool) {
 		}
 		jsonBytes, err := json.MarshalIndent(agreements, "", cliutils.JSON_INDENT)
 		if err != nil {
-			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'show agreements' output: %v", err)
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn agreement list' output: %v", err)
 		}
 		fmt.Printf("%s\n", jsonBytes)
 	}

--- a/cli/attribute/attribute.go
+++ b/cli/attribute/attribute.go
@@ -43,7 +43,7 @@ func List() {
 	// Convert to json and output
 	jsonBytes, err := json.MarshalIndent(attrs, "", cliutils.JSON_INDENT)
 	if err != nil {
-		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'show attributes' output: %v", err)
+		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn attribute list' output: %v", err)
 	}
 	fmt.Printf("%s\n", jsonBytes)
 }

--- a/cli/exchange/microservice.go
+++ b/cli/exchange/microservice.go
@@ -1,0 +1,129 @@
+package exchange
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/open-horizon/anax/cli/cliutils"
+	"net/http"
+	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/rsapss-tool/sign"
+)
+
+type ExchangeMicroservices struct {
+	Microservices  map[string]MicroserviceOutput `json:"microservices"`
+	LastIndex int                    `json:"lastIndex"`
+}
+
+//todo: the only thing keeping me from using exchange.MicroserviceDefinition is dave adding the Public field to it
+type MicroserviceOutput struct {
+	Owner         string               `json:"owner"`
+	Label         string               `json:"label"`
+	Description   string               `json:"description"`
+	Public   bool               `json:"public"`
+	SpecRef       string               `json:"specRef"`
+	Version       string               `json:"version"`
+	Arch          string               `json:"arch"`
+	Sharable      string               `json:"sharable"`
+	DownloadURL   string               `json:"downloadUrl"`
+	MatchHardware map[string]string        `json:"matchHardware"`
+	UserInputs    []exchange.UserInput          `json:"userInput"`
+	Workloads     []exchange.WorkloadDeployment `json:"workloads"`
+	LastUpdated   string               `json:"lastUpdated"`
+}
+
+type MicroserviceInput struct {
+	Label         string               `json:"label"`
+	Description   string               `json:"description"`
+	Public   bool               `json:"public"`
+	SpecRef       string               `json:"specRef"`
+	Version       string               `json:"version"`
+	Arch          string               `json:"arch"`
+	Sharable      string               `json:"sharable"`
+	DownloadURL   string               `json:"downloadUrl"`
+	MatchHardware map[string]string        `json:"matchHardware"`
+	UserInputs    []exchange.UserInput          `json:"userInput"`
+	Workloads     []exchange.WorkloadDeployment `json:"workloads"`
+}
+
+func MicroserviceList(org string, userPw string, microservice string, namesOnly bool) {
+	if microservice != "" {
+		microservice = "/" + microservice
+	}
+	if namesOnly {
+		// Only display the names
+		var resp ExchangeMicroservices
+		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/microservices"+microservice, org+"/"+userPw, []int{200}, &resp)
+		var microservices []string
+		for k := range resp.Microservices {
+			microservices = append(microservices, k)
+		}
+		jsonBytes, err := json.MarshalIndent(microservices, "", cliutils.JSON_INDENT)
+		if err != nil {
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange microservice list' output: %v", err)
+		}
+		fmt.Printf("%s\n", jsonBytes)
+	} else {
+		// Display the full resources
+		//var output string
+		var output ExchangeMicroservices
+		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/microservices"+microservice, org+"/"+userPw, []int{200}, &output)
+		jsonBytes, err := json.MarshalIndent(output, "", cliutils.JSON_INDENT)
+		if err != nil {
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange microservice list' output: %v", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}
+
+
+// MicroservicePublish signs the MS def and puts it in the exchange
+func MicroservicePublish(org string, userPw string, jsonFilePath string, keyFilePath string) {
+	// Read in the MS metadata
+	newBytes := cliutils.ReadJsonFile(jsonFilePath)
+	var microInput MicroserviceInput
+	err := json.Unmarshal(newBytes, &microInput)
+	if err != nil {
+		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to unmarshal json input file %s: %v", jsonFilePath, err)
+	}
+
+	// Loop thru the workloads array and sign the deployment strings
+	fmt.Println("Signing microservice...")
+	for i := range microInput.Workloads {
+		cliutils.Verbose("signing deployment string %d", i+1)
+		var err error
+		microInput.Workloads[i].DeploymentSignature, err = sign.Input(keyFilePath, []byte(microInput.Workloads[i].Deployment))
+		if err != nil {
+			cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem signing the deployment string with %s: %v", keyFilePath, err)
+		}
+
+		// Verify the torrent field is the form necessary for the containers that are stored in a docker registry (because that is all we support right now)
+		torrentErrorString := `currently the torrent field must be like this to indicate the images are stored in a docker registry: {\"url\":\"\",\"signature\":\"\"}`
+		if microInput.Workloads[i].Torrent == "" {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, torrentErrorString)
+		}
+		var torrentMap map[string]string
+		if err := json.Unmarshal([]byte(microInput.Workloads[i].Torrent), torrentMap); err != nil {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "failed to unmarshal torrent string number %d: %v", i+1, err)
+		}
+		if url, ok := torrentMap["url"]; !ok || url != "" {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, torrentErrorString)
+		}
+		if signature, ok := torrentMap["signature"]; !ok || signature != "" {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, torrentErrorString)
+		}
+	}
+
+	// Create of update resource in the exchange
+	exchId := cliutils.FormExchangeId(microInput.SpecRef, microInput.Version, microInput.Arch)
+	var output string
+	httpCode := cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/microservices/"+exchId, org+"/"+userPw, []int{200,404}, &output)
+	if httpCode == 200 {
+		// MS exists, update it
+		fmt.Printf("Updating %s in the exchange...\n", exchId)
+		cliutils.ExchangePutPost(http.MethodPut, cliutils.GetExchangeUrl(), "orgs/"+org+"/microservices/"+exchId, org+"/"+userPw, []int{201}, microInput)
+	} else {
+		// MS not there, create it
+		fmt.Printf("Creating %s in the exchange...\n", exchId)
+		cliutils.ExchangePutPost(http.MethodPost, cliutils.GetExchangeUrl(), "orgs/"+org+"/microservices", org+"/"+userPw, []int{201}, microInput)
+	}
+}

--- a/cli/exchange/pattern.go
+++ b/cli/exchange/pattern.go
@@ -4,22 +4,61 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/open-horizon/anax/cli/cliutils"
+	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/rsapss-tool/sign"
+	"net/http"
+	"path/filepath"
+	"strings"
 )
 
-// We only care about the pattern names, so the rest is left as interface{}
-type ExchangePattern struct {
+//todo: only using these instead of exchange.GetPatternResponse because exchange.Pattern is missing the Owner and LastUpdated fields
+type ExchangePatterns struct {
+	Patterns  map[string]PatternOutput `json:"patterns"`
 	LastIndex int                    `json:"lastIndex"`
-	Patterns  map[string]interface{} `json:"patterns"`
 }
 
-func PatternList(org string, nodeIdTok string, pattern string, namesOnly bool) {
+type PatternOutput struct {
+	Owner         string               `json:"owner"`
+	Label              string              `json:"label"`
+	Description        string              `json:"description"`
+	Public             bool                `json:"public"`
+	Workloads          []exchange.WorkloadReference `json:"workloads"`
+	AgreementProtocols []exchange.AgreementProtocol `json:"agreementProtocols"`
+	LastUpdated   string               `json:"lastUpdated"`
+}
+
+//todo: can't use exchange.Pattern (and some sub-structs) because it has omitempty on several fields required by the exchange
+type WorkloadChoice struct {
+	Version                      string           `json:"version"`  // the version of the workload
+	Priority                     exchange.WorkloadPriority `json:"priority"` // the highest priority workload is tried first for an agreement, if it fails, the next priority is tried. Priority 1 is the highest, priority 2 is next, etc.
+	Upgrade                      exchange.UpgradePolicy    `json:"upgradePolicy"`
+	DeploymentOverrides          string           `json:"deployment_overrides"`           // env var overrides for the workload
+	DeploymentOverridesSignature string           `json:"deployment_overrides_signature"` // signature of env var overrides
+}
+type WorkloadReference struct {
+	WorkloadURL      string           `json:"workloadUrl"`      // refers to a workload definition in the exchange
+	WorkloadOrg      string           `json:"workloadOrgid"`    // the org holding the workload definition
+	WorkloadArch     string           `json:"workloadArch"`     // the hardware architecture of the workload definition
+	WorkloadVersions []WorkloadChoice `json:"workloadVersions"` // a list of workload version for rollback
+	DataVerify       exchange.DataVerification `json:"dataVerification"`           // policy for verifying that the node is sending data
+	NodeH            exchange.NodeHealth       `json:"nodeHealth"`                 // policy for determining when a node's health is violating its agreements
+}
+type PatternInput struct {
+	Label              string              `json:"label"`
+	Description        string              `json:"description"`
+	Public             bool                `json:"public"`
+	Workloads          []WorkloadReference `json:"workloads"`
+	AgreementProtocols []exchange.AgreementProtocol `json:"agreementProtocols"`
+}
+
+func PatternList(org string, userPw string, pattern string, namesOnly bool) {
 	if pattern != "" {
 		pattern = "/" + pattern
 	}
 	if namesOnly {
 		// Only display the names
-		var resp ExchangePattern
-		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns"+pattern, org+"/"+nodeIdTok, []int{200}, &resp)
+		var resp ExchangePatterns
+		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns"+pattern, org+"/"+userPw, []int{200}, &resp)
 		var patterns []string
 		for p := range resp.Patterns {
 			patterns = append(patterns, p)
@@ -31,8 +70,53 @@ func PatternList(org string, nodeIdTok string, pattern string, namesOnly bool) {
 		fmt.Printf("%s\n", jsonBytes)
 	} else {
 		// Display the full resources
-		var output string
-		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns"+pattern, org+"/"+nodeIdTok, []int{200}, &output)
-		fmt.Println(output)
+		//var output string
+		var output ExchangePatterns
+		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns"+pattern, org+"/"+userPw, []int{200}, &output)
+		jsonBytes, err := json.MarshalIndent(output, "", cliutils.JSON_INDENT)
+		if err != nil {
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange pattern list' output: %v", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}
+
+
+// PatternPublish signs the MS def and puts it in the exchange
+func PatternPublish(org string, userPw string, jsonFilePath string, keyFilePath string) {
+	// Read in the MS metadata
+	newBytes := cliutils.ReadJsonFile(jsonFilePath)
+	var patInput PatternInput
+	err := json.Unmarshal(newBytes, &patInput)
+	if err != nil {
+		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to unmarshal json input file %s: %v", jsonFilePath, err)
+	}
+
+	// Loop thru the workloads array and the workloadVersions array and sign the deployment_overrides strings
+	fmt.Println("Signing pattern...")
+	for i := range patInput.Workloads {
+		for j := range patInput.Workloads[i].WorkloadVersions {
+			cliutils.Verbose("signing deployment_overrides string in workload %d, workloadVersion number %d", i+1, j+1)
+			var err error
+			patInput.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature, err = sign.Input(keyFilePath, []byte(patInput.Workloads[i].WorkloadVersions[j].DeploymentOverrides))
+			if err != nil {
+				cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem signing the deployment_overrides string with %s: %v", keyFilePath, err)
+			}
+		}
+	}
+
+	// Create of update resource in the exchange
+	exchId := filepath.Base(jsonFilePath)	// remove the leading path
+	exchId = strings.TrimSuffix(exchId, filepath.Ext(exchId))   // strip suffix if there
+	var output string
+	httpCode := cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns/"+exchId, org+"/"+userPw, []int{200,404}, &output)
+	if httpCode == 200 {
+		// Pattern exists, update it
+		fmt.Printf("Updating %s in the exchange...\n", exchId)
+		cliutils.ExchangePutPost(http.MethodPut, cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns/"+exchId, org+"/"+userPw, []int{201}, patInput)
+	} else {
+		// Pattern not there, create it
+		fmt.Printf("Creating %s in the exchange...\n", exchId)
+		cliutils.ExchangePutPost(http.MethodPost, cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns/"+exchId, org+"/"+userPw, []int{201}, patInput)
 	}
 }

--- a/cli/exchange/workload.go
+++ b/cli/exchange/workload.go
@@ -1,0 +1,129 @@
+package exchange
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/open-horizon/anax/cli/cliutils"
+	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/rsapss-tool/sign"
+	"net/http"
+)
+
+// We only care about the workload names, so the rest is left as interface{}
+type ExchangeWorkloads struct {
+	Workloads  map[string]WorkloadOutput `json:"workloads"`
+	LastIndex int                    `json:"lastIndex"`
+}
+
+//todo: the only thing keeping me from using exchange.WorkloadDefinition is dave adding the Public field to it
+type WorkloadOutput struct {
+	Owner       string               `json:"owner"`
+	Label       string               `json:"label"`
+	Description string               `json:"description"`
+	Public   bool               `json:"public"`
+	WorkloadURL string               `json:"workloadUrl"`
+	Version     string               `json:"version"`
+	Arch        string               `json:"arch"`
+	DownloadURL string               `json:"downloadUrl"`
+	APISpecs    []exchange.APISpec            `json:"apiSpec"`
+	UserInputs  []exchange.UserInput          `json:"userInput"`
+	Workloads   []exchange.WorkloadDeployment `json:"workloads"`
+	LastUpdated string               `json:"lastUpdated"`
+}
+
+type WorkloadInput struct {
+	Label       string               `json:"label"`
+	Description string               `json:"description"`
+	Public   bool               `json:"public"`
+	WorkloadURL string               `json:"workloadUrl"`
+	Version     string               `json:"version"`
+	Arch        string               `json:"arch"`
+	DownloadURL string               `json:"downloadUrl"`
+	APISpecs    []exchange.APISpec            `json:"apiSpec"`
+	UserInputs  []exchange.UserInput          `json:"userInput"`
+	Workloads   []exchange.WorkloadDeployment `json:"workloads"`
+}
+
+func WorkloadList(org string, userPw string, workload string, namesOnly bool) {
+	if workload != "" {
+		workload = "/" + workload
+	}
+	if namesOnly {
+		// Only display the names
+		var resp ExchangeWorkloads
+		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads"+workload, org+"/"+userPw, []int{200}, &resp)
+		var workloads []string
+		for k := range resp.Workloads {
+			workloads = append(workloads, k)
+		}
+		jsonBytes, err := json.MarshalIndent(workloads, "", cliutils.JSON_INDENT)
+		if err != nil {
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange workload list' output: %v", err)
+		}
+		fmt.Printf("%s\n", jsonBytes)
+	} else {
+		// Display the full resources
+		//var output string
+		var output ExchangeWorkloads
+		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads"+workload, org+"/"+userPw, []int{200}, &output)
+		jsonBytes, err := json.MarshalIndent(output, "", cliutils.JSON_INDENT)
+		if err != nil {
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange workload list' output: %v", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}
+
+
+// WorkloadPublish signs the MS def and puts it in the exchange
+func WorkloadPublish(org string, userPw string, jsonFilePath string, keyFilePath string) {
+	// Read in the workload metadata
+	newBytes := cliutils.ReadJsonFile(jsonFilePath)
+	var workInput WorkloadInput
+	err := json.Unmarshal(newBytes, &workInput)
+	if err != nil {
+		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to unmarshal json input file %s: %v", jsonFilePath, err)
+	}
+
+	// Loop thru the workloads array and sign the deployment strings
+	fmt.Println("Signing workload...")
+	for i := range workInput.Workloads {
+		cliutils.Verbose("signing deployment string %d", i+1)
+		var err error
+		workInput.Workloads[i].DeploymentSignature, err = sign.Input(keyFilePath, []byte(workInput.Workloads[i].Deployment))
+		if err != nil {
+			cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem signing the deployment string with %s: %v", keyFilePath, err)
+		}
+
+		// Verify the torrent field is the form necessary for the containers that are stored in a docker registry (because that is all we support right now)
+		torrentErrorString := `currently the torrent field must be like this to indicate the images are stored in a docker registry: {\"url\":\"\",\"signature\":\"\"}`
+		if workInput.Workloads[i].Torrent == "" {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, torrentErrorString)
+		}
+		//fmt.Printf(" torrent: %s\n", workInput.Workloads[i].Torrent)
+		var torrentMap map[string]string
+		if err := json.Unmarshal([]byte(workInput.Workloads[i].Torrent), &torrentMap); err != nil {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "failed to unmarshal torrent string number %d: %v", i+1, err)
+		}
+		if url, ok := torrentMap["url"]; !ok || url != "" {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, torrentErrorString)
+		}
+		if signature, ok := torrentMap["signature"]; !ok || signature != "" {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, torrentErrorString)
+		}
+	}
+
+	// Create of update resource in the exchange
+	exchId := cliutils.FormExchangeId(workInput.WorkloadURL, workInput.Version, workInput.Arch)
+	var output string
+	httpCode := cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads/"+exchId, org+"/"+userPw, []int{200,404}, &output)
+	if httpCode == 200 {
+		// Workload exists, update it
+		fmt.Printf("Updating %s in the exchange...\n", exchId)
+		cliutils.ExchangePutPost(http.MethodPut, cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads/"+exchId, org+"/"+userPw, []int{201}, workInput)
+	} else {
+		// Workload not there, create it
+		fmt.Printf("Creating %s in the exchange...\n", exchId)
+		cliutils.ExchangePutPost(http.MethodPost, cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads", org+"/"+userPw, []int{201}, workInput)
+	}
+}

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -20,7 +20,7 @@ import (
 
 func main() {
 	// Command flags and args - see https://github.com/alecthomas/kingpin
-	app := kingpin.New("hzn", "Command line interface for Horizon agent.")
+	app := kingpin.New("hzn", "Command line interface for Horizon agent. Most of the sub-commands use the Horizon Agent API at the default location http://localhost. Set HORIZON_URL_BASE to override this, which can facilitate using a remote Horizon Agent via an ssh tunnel. The 'hzn exchange' sub-commands will use HORIZON_EXCHANGE_URL_BASE, if set, to communicate with the exchange without having to ask the Horizon Agent for the URL.")
 	cliutils.Opts.Verbose = app.Flag("verbose", "Verbose output.").Short('v').Bool()
 
 	exchangeCmd := app.Command("exchange", "List and manage Horizon Exchange resources.")
@@ -49,7 +49,11 @@ func main() {
 	exPatternNames := exPatternListCmd.Flag("names-only", "Only list the names (IDs) of the patterns.").Short('N').Bool()
 	exPatternPublishCmd := exPatternCmd.Command("publish", "Sign and create/update the pattern resource in the Horizon Exchange.")
 	exPatJsonFile := exPatternPublishCmd.Flag("json-file", "The path of a JSON file containing the metadata necessary to create/update the pattern in the Horizon exchange. See /usr/horizon/samples/pattern.json. Specify -f- to read from stdin.").Short('f').Required().String()
-	exPatKeyFile := exPatternPublishCmd.Flag("private-key-file", "The path of a private key file to be used to sign the microservice. ").Short('k').Required().String()
+	exPatKeyFile := exPatternPublishCmd.Flag("private-key-file", "The path of a private key file to be used to sign the pattern. ").Short('k').Required().String()
+	exPatternAddWorkCmd := exPatternCmd.Command("insertworkload", "Add or replace a workload in an existing pattern resource in the Horizon Exchange.")
+	exPatAddWork := exPatternAddWorkCmd.Arg("pattern", "The existing pattern that the workload should be inserted into.").Required().String()
+	exPatAddWorkJsonFile := exPatternAddWorkCmd.Flag("json-file", "The path of a JSON file containing the additional workload metadata. See /usr/horizon/samples/insert-workload-into-pattern.json. Specify -f- to read from stdin.").Short('f').Required().String()
+	exPatAddWorkKeyFile := exPatternAddWorkCmd.Flag("private-key-file", "The path of a private key file to be used to sign the inserted workload. ").Short('k').Required().String()
 
 	exWorkloadCmd := exchangeCmd.Command("workload", "List and manage workloads in the Horizon Exchange")
 	//exWorkNodeIdTok := exWorkloadCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token to use to query the exchange. Create with 'hzn exchange node create'.").Short('n').PlaceHolder("ID:TOK").Required().String()
@@ -58,7 +62,7 @@ func main() {
 	exWorkloadNames := exWorkloadListCmd.Flag("names-only", "Only list the names (IDs) of the workloads.").Short('N').Bool()
 	exWorkloadPublishCmd := exWorkloadCmd.Command("publish", "Sign and create/update the workload resource in the Horizon Exchange.")
 	exWorkJsonFile := exWorkloadPublishCmd.Flag("json-file", "The path of a JSON file containing the metadata necessary to create/update the workload in the Horizon exchange. See /usr/horizon/samples/workload.json. Specify -f- to read from stdin.").Short('f').Required().String()
-	exWorkKeyFile := exWorkloadPublishCmd.Flag("private-key-file", "The path of a private key file to be used to sign the microservice. ").Short('k').Required().String()
+	exWorkKeyFile := exWorkloadPublishCmd.Flag("private-key-file", "The path of a private key file to be used to sign the workload. ").Short('k').Required().String()
 
 	exMicroserviceCmd := exchangeCmd.Command("microservice", "List and manage microservices in the Horizon Exchange")
 	//exMicroNodeIdTok := exMicroserviceCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token to use to query the exchange. Create with 'hzn exchange node create'.").Short('n').PlaceHolder("ID:TOK").Required().String()
@@ -144,6 +148,8 @@ func main() {
 		exchange.PatternList(*exOrg, *exUserPw, *exPattern, *exPatternNames)
 	case exPatternPublishCmd.FullCommand():
 		exchange.PatternPublish(*exOrg, *exUserPw, *exPatJsonFile, *exPatKeyFile)
+	case exPatternAddWorkCmd.FullCommand():
+		exchange.PatternAddWorkload(*exOrg, *exUserPw, *exPatAddWork, *exPatAddWorkJsonFile, *exPatAddWorkKeyFile)
 	case exWorkloadListCmd.FullCommand():
 		exchange.WorkloadList(*exOrg, *exUserPw, *exWorkload, *exWorkloadNames)
 	case exWorkloadPublishCmd.FullCommand():

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -25,25 +25,49 @@ func main() {
 
 	exchangeCmd := app.Command("exchange", "List and manage Horizon Exchange resources.")
 	exOrg := exchangeCmd.Flag("org", "The Horizon exchange organization ID.").Short('o').Default("public").String()
+	exUserPw := exchangeCmd.Flag("user-pw", "Horizon Exchange user credentials to query and create exchange resources.").Short('u').PlaceHolder("USER:PW").Required().String()
 
 	userCmd := exchangeCmd.Command("user", "List and manage users in the Horizon Exchange")
-	exUserPw := userCmd.Flag("user-pw", "User credentials in the Horizon exchange.").Short('u').PlaceHolder("USER:PW").Required().String()
+	//exUserPw := userCmd.Flag("user-pw", "User credentials in the Horizon exchange.").Short('u').PlaceHolder("USER:PW").Required().String()
 	userListCmd := userCmd.Command("list", "Display the user resource from the Horizon Exchange.")
 	userCreateCmd := userCmd.Command("create", "Create the user resource in the Horizon Exchange.")
 	userCreateEmail := userCreateCmd.Flag("email", "Your email address that should be associated with this user account when creating it in the Horizon exchange.").Short('e').Required().String()
 
 	exNodeCmd := exchangeCmd.Command("node", "List and manage nodes in the Horizon Exchange")
-	exNodeIdTok := exNodeCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token. The node ID must be unique within the organization.").Short('n').PlaceHolder("ID:TOK").Required().String()
 	exNodeListCmd := exNodeCmd.Command("list", "Display the node resource from the Horizon Exchange.")
+	exNode := exNodeListCmd.Arg("node", "List just this one node.").String()
+	exNodeNames := exNodeListCmd.Flag("names-only", "Only list the names (IDs) of the nodes.").Short('N').Bool()
 	exNodeCreateCmd := exNodeCmd.Command("create", "Create the node resource in the Horizon Exchange.")
-	exNodeUserPw := exNodeCreateCmd.Flag("user-pw", "User credentials to create the node resource in the Horizon exchange.").Short('u').PlaceHolder("USER:PW").Required().String()
+	exNodeIdTok := exNodeCreateCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token. The node ID must be unique within the organization.").Short('n').PlaceHolder("ID:TOK").Required().String()
+	//exNodeUserPw := exNodeCreateCmd.Flag("user-pw", "User credentials to create the node resource in the Horizon exchange.").Short('u').PlaceHolder("USER:PW").Required().String()
 	exNodeEmail := exNodeCreateCmd.Flag("email", "Your email address. Only needs to be specified if: the user specified in the -u flag does not exist, and you specified is the 'public' org. If these things are true we will create the user and include this value as the email attribute.").Short('e').String()
 
 	exPatternCmd := exchangeCmd.Command("pattern", "List and manage patterns in the Horizon Exchange")
-	exPatNodeIdTok := exPatternCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token to use to query the exchange. Create with 'hzn exchange node create'.").Short('n').PlaceHolder("ID:TOK").Required().String()
+	//exPatNodeIdTok := exPatternCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token to use to query the exchange. Create with 'hzn exchange node create'.").Short('n').PlaceHolder("ID:TOK").Required().String()
 	exPatternListCmd := exPatternCmd.Command("list", "Display the pattern resources from the Horizon Exchange.")
 	exPattern := exPatternListCmd.Arg("pattern", "List just this one pattern.").String()
-	exPatternNames := exPatternListCmd.Flag("names-only", "Only list the names (IDs) of the patterns.").Bool()
+	exPatternNames := exPatternListCmd.Flag("names-only", "Only list the names (IDs) of the patterns.").Short('N').Bool()
+	exPatternPublishCmd := exPatternCmd.Command("publish", "Sign and create/update the pattern resource in the Horizon Exchange.")
+	exPatJsonFile := exPatternPublishCmd.Flag("json-file", "The path of a JSON file containing the metadata necessary to create/update the pattern in the Horizon exchange. See /usr/horizon/samples/pattern.json. Specify -f- to read from stdin.").Short('f').Required().String()
+	exPatKeyFile := exPatternPublishCmd.Flag("private-key-file", "The path of a private key file to be used to sign the microservice. ").Short('k').Required().String()
+
+	exWorkloadCmd := exchangeCmd.Command("workload", "List and manage workloads in the Horizon Exchange")
+	//exWorkNodeIdTok := exWorkloadCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token to use to query the exchange. Create with 'hzn exchange node create'.").Short('n').PlaceHolder("ID:TOK").Required().String()
+	exWorkloadListCmd := exWorkloadCmd.Command("list", "Display the workload resources from the Horizon Exchange.")
+	exWorkload := exWorkloadListCmd.Arg("workload", "List just this one workload.").String()
+	exWorkloadNames := exWorkloadListCmd.Flag("names-only", "Only list the names (IDs) of the workloads.").Short('N').Bool()
+	exWorkloadPublishCmd := exWorkloadCmd.Command("publish", "Sign and create/update the workload resource in the Horizon Exchange.")
+	exWorkJsonFile := exWorkloadPublishCmd.Flag("json-file", "The path of a JSON file containing the metadata necessary to create/update the workload in the Horizon exchange. See /usr/horizon/samples/workload.json. Specify -f- to read from stdin.").Short('f').Required().String()
+	exWorkKeyFile := exWorkloadPublishCmd.Flag("private-key-file", "The path of a private key file to be used to sign the microservice. ").Short('k').Required().String()
+
+	exMicroserviceCmd := exchangeCmd.Command("microservice", "List and manage microservices in the Horizon Exchange")
+	//exMicroNodeIdTok := exMicroserviceCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token to use to query the exchange. Create with 'hzn exchange node create'.").Short('n').PlaceHolder("ID:TOK").Required().String()
+	exMicroserviceListCmd := exMicroserviceCmd.Command("list", "Display the microservice resources from the Horizon Exchange.")
+	exMicroservice := exMicroserviceListCmd.Arg("microservice", "List just this one microservice.").String()
+	exMicroserviceNames := exMicroserviceListCmd.Flag("names-only", "Only list the names (IDs) of the microservices.").Short('N').Bool()
+	exMicroservicePublishCmd := exMicroserviceCmd.Command("publish", "Sign and create/update the microservice resource in the Horizon Exchange.")
+	exMicroJsonFile := exMicroservicePublishCmd.Flag("json-file", "The path of a JSON file containing the metadata necessary to create/update the microservice in the Horizon exchange. See /usr/horizon/samples/microservice.json. Specify -f- to read from stdin.").Short('f').Required().String()
+	exMicroKeyFile := exMicroservicePublishCmd.Flag("private-key-file", "The path of a private key file to be used to sign the microservice. ").Short('k').Required().String()
 
 	registerCmd := app.Command("register", "Register this edge node with Horizon.")
 	nodeIdTok := registerCmd.Flag("node-id-tok", "The Horizon exchange node ID and token. The node ID must be unique within the organization. If not specified, the node ID will be created by Horizon from the machine serial number or fully qualified hostname. If the token is not specified, Horizon will create a random token. If node resource in the exchange identified by the ID and token does not yet exist, you must also specify the -u flag so it can be created.").Short('n').PlaceHolder("ID:TOK").String()
@@ -113,11 +137,21 @@ func main() {
 	case userCreateCmd.FullCommand():
 		exchange.UserCreate(*exOrg, *exUserPw, *userCreateEmail)
 	case exNodeListCmd.FullCommand():
-		exchange.NodeList(*exOrg, *exNodeIdTok)
+		exchange.NodeList(*exOrg, *exUserPw, *exNode, *exNodeNames)
 	case exNodeCreateCmd.FullCommand():
-		exchange.NodeCreate(*exOrg, *exNodeIdTok, *exNodeUserPw, *exNodeEmail)
+		exchange.NodeCreate(*exOrg, *exNodeIdTok, *exUserPw, *exNodeEmail)
 	case exPatternListCmd.FullCommand():
-		exchange.PatternList(*exOrg, *exPatNodeIdTok, *exPattern, *exPatternNames)
+		exchange.PatternList(*exOrg, *exUserPw, *exPattern, *exPatternNames)
+	case exPatternPublishCmd.FullCommand():
+		exchange.PatternPublish(*exOrg, *exUserPw, *exPatJsonFile, *exPatKeyFile)
+	case exWorkloadListCmd.FullCommand():
+		exchange.WorkloadList(*exOrg, *exUserPw, *exWorkload, *exWorkloadNames)
+	case exWorkloadPublishCmd.FullCommand():
+		exchange.WorkloadPublish(*exOrg, *exUserPw, *exWorkJsonFile, *exWorkKeyFile)
+	case exMicroserviceListCmd.FullCommand():
+		exchange.MicroserviceList(*exOrg, *exUserPw, *exMicroservice, *exMicroserviceNames)
+	case exMicroservicePublishCmd.FullCommand():
+		exchange.MicroservicePublish(*exOrg, *exUserPw, *exMicroJsonFile, *exMicroKeyFile)
 	case registerCmd.FullCommand():
 		register.DoIt(*org, *pattern, *nodeIdTok, *userPw, *email, *inputFile)
 	case keyListCmd.FullCommand():

--- a/cli/metering/metering.go
+++ b/cli/metering/metering.go
@@ -112,7 +112,7 @@ func List(archivedMetering bool) {
 		}
 		jsonBytes, err := json.MarshalIndent(metering, "", cliutils.JSON_INDENT)
 		if err != nil {
-			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'show metering' output: %v", err)
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn metering list' output: %v", err)
 		}
 		fmt.Printf("%s\n", jsonBytes)
 	} else {
@@ -122,7 +122,7 @@ func List(archivedMetering bool) {
 		}
 		jsonBytes, err := json.MarshalIndent(metering, "", cliutils.JSON_INDENT)
 		if err != nil {
-			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'show metering' output: %v", err)
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn metering list' output: %v", err)
 		}
 		fmt.Printf("%s\n", jsonBytes)
 	}

--- a/cli/node/node.go
+++ b/cli/node/node.go
@@ -72,7 +72,7 @@ func List() {
 	// Output the combined info
 	jsonBytes, err := json.MarshalIndent(nodeInfo, "", cliutils.JSON_INDENT)
 	if err != nil {
-		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'show node' output: %v", err)
+		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn node list' output: %v", err)
 	}
 	fmt.Printf("%s\n", jsonBytes) //todo: is there a way to output with json syntax highlighting like jq does?
 }

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -7,10 +7,7 @@ import (
 	"github.com/open-horizon/anax/cli/cliutils"
 	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/exchange"
-	"io/ioutil"
 	"net/http"
-	"os"
-	"regexp"
 )
 
 // These structs are used to parse the registration input file
@@ -35,21 +32,9 @@ type InputFile struct {
 }
 
 func readInputFile(filePath string, inputFileStruct *InputFile) {
-	var fileBytes []byte
-	var err error
-	if filePath == "-" {
-		fileBytes, err = ioutil.ReadAll(os.Stdin)
-	} else {
-		fileBytes, err = ioutil.ReadFile(filePath)
-	}
-	if err != nil {
-		cliutils.Fatal(cliutils.READ_FILE_ERROR, "reading %s failed: %v", filePath, err)
-	}
-	// remove /* */ comments
-	re := regexp.MustCompile(`(?s)/\*.*?\*/`)
-	newBytes := re.ReplaceAll(fileBytes, nil)
+	newBytes := cliutils.ReadJsonFile(filePath)
 
-	err = json.Unmarshal(newBytes, inputFileStruct)
+	err := json.Unmarshal(newBytes, inputFileStruct)
 	if err != nil {
 		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to unmarshal json input file %s: %v", filePath, err)
 	}

--- a/cli/samples/insert-workload-into-pattern.json
+++ b/cli/samples/insert-workload-into-pattern.json
@@ -1,0 +1,41 @@
+/* Sample json for adding/replacing a workload in an existing pattern. */
+    {
+      "workloadUrl": "https://bluehorizon.network/workloads/netspeed-docker",
+      "workloadOrgid": "IBM",
+      "workloadArch": "amd64",
+      "workloadVersions": [
+        {
+          "version": "2.5",
+          "deployment_overrides": "{\"services\":{\"netspeed5\":{\"environment\":[\"USE_NEW_STAGING_URL=false\"]}}}",
+          "deployment_overrides_signature": "",
+          "priority": {
+            "priority_value": 50,
+            "retries": 1,
+            "retry_durations": 3600,
+            "verified_durations": 52
+          },
+          "upgradePolicy": {
+            "lifecycle": "immediate",
+            "time": "01:00AM"
+          }
+        }
+      ],
+      "dataVerification": {
+        "enabled": true,
+        "URL": "",
+        "user": "",
+        "password": "",
+        "interval": 480,
+        "check_rate": 15,
+        "metering": {
+          "tokens": 1,
+          "per_time_unit": "min",
+          "notification_interval": 30
+        }
+      },
+      "nodeHealth": {
+        "missing_heartbeat_interval": 600,
+        "check_agreement_status": 120
+      }
+    }
+

--- a/cli/samples/microservice.json
+++ b/cli/samples/microservice.json
@@ -1,0 +1,19 @@
+{
+  "label": "CPU for x86_64",
+  "description": "Provides a REST API to query the CPU load",
+  "public": true,
+  "specRef": "https://internetofthings.ibmcloud.com/microservices/cpu",
+  "version": "1.2.2",
+  "arch": "amd64",
+  "sharable": "single",
+  "downloadUrl": "not used yet",
+  "matchHardware": {},
+  "userInput": [],
+  "workloads": [
+    {
+      "deployment": "{\"services\":{\"cpu\":{\"image\":\"openhorizon/example_ms_x86_cpu:1.2.2\"}}}",
+      "deployment_signature": "",
+      "torrent": "{\"url\":\"\",\"signature\":\"\"}"
+    }
+  ]
+}

--- a/cli/samples/minimal.json
+++ b/cli/samples/minimal.json
@@ -1,0 +1,20 @@
+/*
+Minimal input file for the 'hzn register -f' flag. If you need to specify variable values for workloads and microservices.
+see /usr/horizon/samples/input.json instead.
+This sample will work as-is with the IBM netspeed pattern.
+(These comments are allowed in the file.)
+*/
+{
+	/* Variables that are passed to all containers, or settings for Horizon (depending on the type). */
+	"global": [
+		{
+			"type": "LocationAttributes",   /* required to tell horizon where this node is */
+			"variables": {
+				"lat": 43.123,     /* this is passed to each container as HZN_LAT */
+				"lon": -72.123,    /* this is passed to each container as HZN_LON */
+				"use_gps": false,    /* true if you have, and want to use, an attached GPS sensor. Passed to each container as HZN_USE_GPS. */
+				"location_accuracy_km": 0.0   /* Make the node location inaccurate by this number of KM to protect privacy. */
+			}
+		}
+	]
+}

--- a/cli/samples/pattern.json
+++ b/cli/samples/pattern.json
@@ -1,0 +1,51 @@
+{
+  "label": "Cpu2wiotp for amd64 and arm",
+  "description": "Horizon deployment pattern that runs the cpu2wiotp workload",
+  "public": true,
+  "workloads": [
+    {
+      "workloadUrl": "https://internetofthings.ibmcloud.com/workloads/cpu2wiotp",
+      "workloadOrgid": "IBM",
+      "workloadArch": "amd64",
+      "workloadVersions": [
+        {
+          "version": "1.1.3",
+          "deployment_overrides": "",
+          "deployment_overrides_signature": "",
+          "priority": {},
+          "upgradePolicy": {}
+        }
+      ],
+      "nodeHealth": {
+        "missing_heartbeat_interval": 600,
+        "check_agreement_status": 120
+      }
+    },
+    {
+      "workloadUrl": "https://internetofthings.ibmcloud.com/workloads/cpu2wiotp",
+      "workloadOrgid": "IBM",
+      "workloadArch": "arm",
+      "workloadVersions": [
+        {
+          "version": "1.1.3",
+          "deployment_overrides": "",
+          "deployment_overrides_signature": "",
+          "priority": {},
+          "upgradePolicy": {}
+        }
+      ],
+      "nodeHealth": {
+        "missing_heartbeat_interval": 600,
+        "check_agreement_status": 120
+      }
+    }
+  ],
+  "agreementProtocols": [
+    {
+      "name": "Basic"
+    },
+    {
+      "name": "Citizen Scientist"
+    }
+  ]
+}

--- a/cli/samples/workload.json
+++ b/cli/samples/workload.json
@@ -1,0 +1,41 @@
+{
+  "label": "Cpu2wiotp for x86_64",
+  "description": "Sample Horizon workload that repeatedly reads the CPU load and sends it to WIoTP",
+  "public": true,
+  "workloadUrl": "https://internetofthings.ibmcloud.com/workloads/cpu2wiotp",
+  "version": "1.1.3",
+  "arch": "amd64",
+  "downloadUrl": "not used yet",
+  "apiSpec": [
+    {
+      "specRef": "https://internetofthings.ibmcloud.com/microservices/cpu",
+      "org": "IBM",
+      "version": "[0.0.0,INFINITY)",
+      "arch": "amd64"
+    }
+  ],
+  "userInput": [
+    {
+      "name": "WIOTP_ORG_ID",
+      "label": "The WIoTP organization ID of your instance of the WIoTP service",
+      "type": "string"
+    },
+    {
+      "name": "WIOTP_DEVICE_TYPE",
+      "label": "The device or gateway type that you created in the WIoTP UI",
+      "type": "string"
+    },
+    {
+      "name": "WIOTP_DEVICE_AUTH_TOKEN",
+      "label": "The token you gave to the device or gateway you created in the WIoTP UI",
+      "type": "string"
+    }
+  ],
+  "workloads": [
+    {
+      "deployment": "{\"services\":{\"cpu2wiotp\":{\"image\":\"openhorizon/example_wl_x86_cpu2wiotp:1.1.3\",\"environment\":[\"WIOTP_DOMAIN=internetofthings.ibmcloud.com\"]}}}",
+      "deployment_signature": "",
+      "torrent": "{\"url\":\"\",\"signature\":\"\"}"
+    }
+  ]
+}

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -60,7 +60,7 @@ func List() {
 	// Convert to json and output
 	jsonBytes, err := json.MarshalIndent(services, "", cliutils.JSON_INDENT)
 	if err != nil {
-		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'show services' output: %v", err)
+		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn service list' output: %v", err)
 	}
 	fmt.Printf("%s\n", jsonBytes)
 }

--- a/cli/workload/workload.go
+++ b/cli/workload/workload.go
@@ -59,7 +59,7 @@ func List() {
 	// Convert to json and output
 	jsonBytes, err := json.MarshalIndent(workloads, "", cliutils.JSON_INDENT)
 	if err != nil {
-		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'show workloads' output: %v", err)
+		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn workload list' output: %v", err)
 	}
 	fmt.Printf("%s\n", jsonBytes)
 }


### PR DESCRIPTION
- changed all 'hzn exchange' cmds to use -u creds instead of -n
- added short flag -N for --names-only
- added signing of ms, workload, pattern for the case in which the images are stored in a docker registry
- supported optionally getting exchange url from HORIZON_EXCHANGE_URL_BASE
- added patter insertworkload
