### PR TITLE
Hzn usability

### DIFF
--- a/cli/attribute/attribute.go
+++ b/cli/attribute/attribute.go
@@ -31,7 +31,7 @@ func List() {
 	apiAttrs := apiOutput["attributes"]
 
 	// Only include interesting fields in our output
-	var attrs []OurAttributes
+	attrs := []OurAttributes{}
 	for _, a := range apiAttrs {
 		if len(*a.SensorUrls) == 0 {
 			attrs = append(attrs, OurAttributes{Type: *a.Type, Label: *a.Label, Variables: *a.Mappings})

--- a/cli/exchange/agbot.go
+++ b/cli/exchange/agbot.go
@@ -18,11 +18,11 @@ func AgbotList(org string, userPw string, agbot string, namesOnly bool) {
 	if agbot != "" {
 		agbot = "/" + agbot
 	}
-	if namesOnly {
+	if namesOnly && agbot == "" {
 		// Only display the names
 		var resp ExchangeAgbots
 		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/agbots"+agbot, cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &resp)
-		var agbots []string
+		agbots := []string{}
 		for a := range resp.Agbots {
 			agbots = append(agbots, a)
 		}

--- a/cli/exchange/microservice.go
+++ b/cli/exchange/microservice.go
@@ -52,11 +52,11 @@ func MicroserviceList(org string, userPw string, microservice string, namesOnly 
 	if microservice != "" {
 		microservice = "/" + microservice
 	}
-	if namesOnly {
+	if namesOnly && microservice == "" {
 		// Only display the names
 		var resp ExchangeMicroservices
 		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/microservices"+microservice, cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &resp)
-		var microservices []string
+		microservices := []string{}
 		for k := range resp.Microservices {
 			microservices = append(microservices, k)
 		}
@@ -81,11 +81,33 @@ func MicroserviceList(org string, userPw string, microservice string, namesOnly 
 	}
 }
 
+func AppendImagesFromDeploymentField(deployment string, deploymentNum int, imageList []string) []string {
+	// The deployment string should include: "deployment": "{"services":{"cpu2wiotp":{"image":"openhorizon/example_wl_x86_cpu2wiotp:1.1.2",...}}}"
+	var deploymentMap map[string]map[string]map[string]interface{}
+	if err := json.Unmarshal([]byte(deployment), &deploymentMap); err != nil {
+		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "failed to unmarshal deployment string number %d: %v", deploymentNum+1, err)
+	}
+	if services, ok := deploymentMap["services"]; ok {
+		for s := range services {
+			if image, ok := services[s]["image"]; ok {
+				switch s := image.(type) {
+				case string:
+					imageList = append(imageList, s)
+				default:
+					cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "in the deployment string, the value of the image key of %s is not of type string", s)
+				}
+			}
+		}
+	}
+	return imageList
+}
+
 func CheckTorrentField(torrent string, index int) {
-	// Verify the torrent field is the form necessary for the containers that are stored in a docker registry (because that is all we support right now)
-	torrentErrorString := `currently the torrent field must be like this to indicate the images are stored in a docker registry: {\"url\":\"\",\"signature\":\"\"}`
+	// Verify the torrent field is the form necessary for the containers that are stored in a docker registry (because that is all we support from hzn right now)
+	torrentErrorString := `currently the torrent field must either be empty or be like this to indicate the images are stored in a docker registry: {\"url\":\"\",\"signature\":\"\"}`
 	if torrent == "" {
-		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, torrentErrorString)
+		//cliutils.Fatal(cliutils.CLI_INPUT_ERROR, torrentErrorString)
+		return
 	}
 	var torrentMap map[string]string
 	if err := json.Unmarshal([]byte(torrent), &torrentMap); err != nil {
@@ -111,6 +133,7 @@ func MicroservicePublish(org string, userPw string, jsonFilePath string, keyFile
 
 	// Loop thru the workloads array and sign the deployment strings
 	fmt.Println("Signing microservice...")
+	var imageList []string
 	for i := range microInput.Workloads {
 		cliutils.Verbose("signing deployment string %d", i+1)
 		var err error
@@ -118,7 +141,8 @@ func MicroservicePublish(org string, userPw string, jsonFilePath string, keyFile
 		if err != nil {
 			cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem signing the deployment string with %s: %v", keyFilePath, err)
 		}
-		//todo: gather the docker image paths to instruct to docker push at the end
+		// Gather the docker image paths to instruct to docker push at the end
+		imageList = AppendImagesFromDeploymentField(microInput.Workloads[i].Deployment, i+1, imageList)
 
 		CheckTorrentField(microInput.Workloads[i].Torrent, i)
 	}
@@ -135,6 +159,15 @@ func MicroservicePublish(org string, userPw string, jsonFilePath string, keyFile
 		// MS not there, create it
 		fmt.Printf("Creating %s in the exchange...\n", exchId)
 		cliutils.ExchangePutPost(http.MethodPost, cliutils.GetExchangeUrl(), "orgs/"+org+"/microservices", cliutils.OrgAndCreds(org, userPw), []int{201}, microInput)
+	}
+
+	// Tell the to push the images to the docker registry
+	if len(imageList) > 0 {
+		//todo: should we just push the docker images for them?
+		fmt.Println("If you haven't already, push your docker images to the registry:")
+		for _, image := range imageList {
+			fmt.Printf("  docker push %s\n", image)
+		}
 	}
 }
 

--- a/cli/exchange/node.go
+++ b/cli/exchange/node.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// We only care about handling the microservice names, so the rest is left as interface{} and will be passed from the exchange to the display
+// We only care about handling the node names, so the rest is left as interface{} and will be passed from the exchange to the display
 type ExchangeNodes struct {
 	LastIndex int                    `json:"lastIndex"`
 	Nodes     map[string]interface{} `json:"nodes"`
@@ -46,18 +46,34 @@ func NodeList(org string, userPw string, node string, namesOnly bool) {
 func NodeCreate(org string, nodeIdTok string, userPw string, email string) {
 	nodeId, nodeToken := cliutils.SplitIdToken(nodeIdTok)
 	exchUrlBase := cliutils.GetExchangeUrl()
+
+	// Assume the user exists and try to create the node, but handle the error cases
 	putNodeReq := exchange.PutDeviceRequest{Token: nodeToken, Name: nodeId, SoftwareVersions: make(map[string]string), PublicKey: []byte("")} // we only need to set the token
-	httpCode := cliutils.ExchangePutPost(http.MethodPut, exchUrlBase, "orgs/"+org+"/nodes/"+nodeId, cliutils.OrgAndCreds(org, userPw), []int{201, 401}, putNodeReq)
+	httpCode := cliutils.ExchangePutPost(http.MethodPut, exchUrlBase, "orgs/"+org+"/nodes/"+nodeId, cliutils.OrgAndCreds(org, userPw), []int{201, 401, 403}, putNodeReq)
+
 	if httpCode == 401 {
+		// Invalid creds means the user doesn't exist, or pw is wrong, try to create it if we are in the public org
 		user, pw := cliutils.SplitIdToken(userPw)
 		if org == "public" && email != "" {
 			// In the public org we can create a user anonymously, so try that
 			fmt.Printf("User %s/%s does not exist in the exchange with the specified password, creating it...\n", org, user)
 			postUserReq := cliutils.UserExchangeReq{Password: pw, Admin: false, Email: email}
 			httpCode = cliutils.ExchangePutPost(http.MethodPost, exchUrlBase, "orgs/"+org+"/users/"+user, "", []int{201}, postUserReq)
+
+			// User created, now try to create the node again
 			httpCode = cliutils.ExchangePutPost(http.MethodPut, exchUrlBase, "orgs/"+org+"/nodes/"+nodeId, cliutils.OrgAndCreds(org, userPw), []int{201}, putNodeReq)
 		} else {
 			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "user '%s/%s' does not exist with the specified password or -e was not specified to be able to create it in the 'public' org.", org, user)
 		}
+	} else if httpCode == 403 {
+		// Access denied means the node exists and is owned by another user. Figure out who and tell the user
+		var nodesOutput exchange.GetDevicesResponse
+		httpCode = cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/nodes/"+nodeId, cliutils.OrgAndCreds(org, userPw), []int{200}, &nodesOutput)
+		var ok bool
+		var ourNode exchange.Device
+		if ourNode, ok = nodesOutput.Devices[cliutils.OrgAndCreds(org, nodeId)]; !ok {
+			cliutils.Fatal(cliutils.INTERNAL_ERROR, "key '%s' not found in exchange nodes output", cliutils.OrgAndCreds(org, nodeId))
+		}
+		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "can not update existing node %s because it is owned by another user (%s)", nodeId, ourNode.Owner)
 	}
 }

--- a/cli/exchange/node.go
+++ b/cli/exchange/node.go
@@ -19,11 +19,11 @@ func NodeList(org string, userPw string, node string, namesOnly bool) {
 	if node != "" {
 		node = "/" + node
 	}
-	if namesOnly {
+	if namesOnly && node == "" {
 		// Only display the names
 		var resp ExchangeNodes
 		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/nodes"+node, cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &resp)
-		var nodes []string
+		nodes := []string{}
 		for n := range resp.Nodes {
 			nodes = append(nodes, n)
 		}

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -37,14 +37,15 @@ Environment Variables:
 
 	userCmd := exchangeCmd.Command("user", "List and manage users in the Horizon Exchange")
 	//exUserPw := userCmd.Flag("user-pw", "User credentials in the Horizon exchange.").Short('u').PlaceHolder("USER:PW").Required().String()
-	userListCmd := userCmd.Command("list", "Display the user resource from the Horizon Exchange.")
+	userListCmd := userCmd.Command("list", "Display the user resource from the Horizon Exchange. (You can only display your own user. If the user does not exist, you will get an invalid credentials error.)")
 	userCreateCmd := userCmd.Command("create", "Create the user resource in the Horizon Exchange.")
 	userCreateEmail := userCreateCmd.Flag("email", "Your email address that should be associated with this user account when creating it in the Horizon exchange.").Short('e').Required().String()
 
 	exNodeCmd := exchangeCmd.Command("node", "List and manage nodes in the Horizon Exchange")
 	exNodeListCmd := exNodeCmd.Command("list", "Display the node resources from the Horizon Exchange.")
 	exNode := exNodeListCmd.Arg("node", "List just this one node.").String()
-	exNodeNames := exNodeListCmd.Flag("names-only", "Only list the names (IDs) of the nodes.").Short('N').Bool()
+	//exNodeNames := exNodeListCmd.Flag("names-only", "Only list the names (IDs) of the nodes.").Short('N').Bool()
+	exNodeLong := exNodeListCmd.Flag("long", "When listing all of the nodes, show the entire resource of each nodes, instead of just the name.").Short('l').Bool()
 	exNodeCreateCmd := exNodeCmd.Command("create", "Create the node resource in the Horizon Exchange.")
 	exNodeIdTok := exNodeCreateCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token. The node ID must be unique within the organization.").Short('n').PlaceHolder("ID:TOK").Required().String()
 	//exNodeUserPw := exNodeCreateCmd.Flag("user-pw", "User credentials to create the node resource in the Horizon exchange.").Short('u').PlaceHolder("USER:PW").Required().String()
@@ -53,7 +54,8 @@ Environment Variables:
 	exAgbotCmd := exchangeCmd.Command("agbot", "List and manage agbots in the Horizon Exchange")
 	exAgbotListCmd := exAgbotCmd.Command("list", "Display the agbot resources from the Horizon Exchange.")
 	exAgbot := exAgbotListCmd.Arg("agbot", "List just this one agbot.").String()
-	exAgbotNames := exAgbotListCmd.Flag("names-only", "Only list the names (IDs) of the agbots.").Short('N').Bool()
+	//exAgbotNames := exAgbotListCmd.Flag("names-only", "Only list the names (IDs) of the agbots.").Short('N').Bool()
+	exAgbotLong := exAgbotListCmd.Flag("long", "When listing all of the agbots, show the entire resource of each agbots, instead of just the name.").Short('l').Bool()
 	exAgbotListPatsCmd := exAgbotCmd.Command("listpattern", "Display the patterns that this agbot is serving.")
 	exAgbotLP := exAgbotListPatsCmd.Arg("agbot", "The agbot to list the patterns for.").Required().String()
 	exAgbotLPPatOrg := exAgbotListPatsCmd.Arg("patternorg", "The organization of the 1 pattern to list.").String()
@@ -71,7 +73,8 @@ Environment Variables:
 	//exPatNodeIdTok := exPatternCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token to use to query the exchange. Create with 'hzn exchange node create'.").Short('n').PlaceHolder("ID:TOK").Required().String()
 	exPatternListCmd := exPatternCmd.Command("list", "Display the pattern resources from the Horizon Exchange.")
 	exPattern := exPatternListCmd.Arg("pattern", "List just this one pattern.").String()
-	exPatternNames := exPatternListCmd.Flag("names-only", "Only list the names (IDs) of the patterns.").Short('N').Bool()
+	//exPatternNames := exPatternListCmd.Flag("names-only", "Only list the names (IDs) of the patterns.").Short('N').Bool()
+	exPatternLong := exPatternListCmd.Flag("long", "When listing all of the patterns, show the entire resource of each pattern, instead of just the name.").Short('l').Bool()
 	exPatternPublishCmd := exPatternCmd.Command("publish", "Sign and create/update the pattern resource in the Horizon Exchange.")
 	exPatJsonFile := exPatternPublishCmd.Flag("json-file", "The path of a JSON file containing the metadata necessary to create/update the pattern in the Horizon exchange. See /usr/horizon/samples/pattern.json. Specify -f- to read from stdin.").Short('f').Required().String()
 	exPatKeyFile := exPatternPublishCmd.Flag("private-key-file", "The path of a private key file to be used to sign the pattern. ").Short('k').Required().ExistingFile()
@@ -85,13 +88,18 @@ Environment Variables:
 	exPatAddWork := exPatternAddWorkCmd.Arg("pattern", "The existing pattern that the workload should be inserted into.").Required().String()
 	exPatAddWorkJsonFile := exPatternAddWorkCmd.Flag("json-file", "The path of a JSON file containing the additional workload metadata. See /usr/horizon/samples/insert-workload-into-pattern.json. Specify -f- to read from stdin.").Short('f').Required().String()
 	exPatAddWorkKeyFile := exPatternAddWorkCmd.Flag("private-key-file", "The path of a private key file to be used to sign the inserted workload. ").Short('k').Required().ExistingFile()
-	//todo: add pattern removeworkload
+	exPatternDelWorkCmd := exPatternCmd.Command("removeworkload", "Remove a workload from an existing pattern resource in the Horizon Exchange.")
+	exPatDelWorkPat := exPatternDelWorkCmd.Arg("pattern", "The existing pattern that the workload should be removed from.").Required().String()
+	exPatDelWorkOrg := exPatternDelWorkCmd.Arg("workload-org", "The org of the workload to remove.").Required().String()
+	exPatDelWorkUrl := exPatternDelWorkCmd.Arg("workload-url", "The URL of the workload to remove.").Required().String()
+	exPatDelWorkArch := exPatternDelWorkCmd.Arg("workload-arch", "The arch of the workload to remove.").Required().String()
 
 	exWorkloadCmd := exchangeCmd.Command("workload", "List and manage workloads in the Horizon Exchange")
 	//exWorkNodeIdTok := exWorkloadCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token to use to query the exchange. Create with 'hzn exchange node create'.").Short('n').PlaceHolder("ID:TOK").Required().String()
 	exWorkloadListCmd := exWorkloadCmd.Command("list", "Display the workload resources from the Horizon Exchange.")
 	exWorkload := exWorkloadListCmd.Arg("workload", "List just this one workload.").String()
-	exWorkloadNames := exWorkloadListCmd.Flag("names-only", "Only list the names (IDs) of the workloads.").Short('N').Bool()
+	//exWorkloadNames := exWorkloadListCmd.Flag("names-only", "Only list the names (IDs) of the workloads.").Short('N').Bool()
+	exWorkloadLong := exWorkloadListCmd.Flag("long", "When listing all of the workloads, show the entire resource of each workloads, instead of just the name.").Short('l').Bool()
 	exWorkloadPublishCmd := exWorkloadCmd.Command("publish", "Sign and create/update the workload resource in the Horizon Exchange.")
 	exWorkJsonFile := exWorkloadPublishCmd.Flag("json-file", "The path of a JSON file containing the metadata necessary to create/update the workload in the Horizon exchange. See /usr/horizon/samples/workload.json. Specify -f- to read from stdin.").Short('f').Required().String()
 	exWorkPrivKeyFile := exWorkloadPublishCmd.Flag("private-key-file", "The path of a private key file to be used to sign the workload. ").Short('k').Required().ExistingFile()
@@ -106,7 +114,8 @@ Environment Variables:
 	//exMicroNodeIdTok := exMicroserviceCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token to use to query the exchange. Create with 'hzn exchange node create'.").Short('n').PlaceHolder("ID:TOK").Required().String()
 	exMicroserviceListCmd := exMicroserviceCmd.Command("list", "Display the microservice resources from the Horizon Exchange.")
 	exMicroservice := exMicroserviceListCmd.Arg("microservice", "List just this one microservice.").String()
-	exMicroserviceNames := exMicroserviceListCmd.Flag("names-only", "Only list the names (IDs) of the microservices.").Short('N').Bool()
+	//exMicroserviceNames := exMicroserviceListCmd.Flag("names-only", "Only list the names (IDs) of the microservices.").Short('N').Bool()
+	exMicroserviceLong := exMicroserviceListCmd.Flag("long", "When listing all of the microservices, show the entire resource of each microservices, instead of just the name.").Short('l').Bool()
 	exMicroservicePublishCmd := exMicroserviceCmd.Command("publish", "Sign and create/update the microservice resource in the Horizon Exchange.")
 	exMicroJsonFile := exMicroservicePublishCmd.Flag("json-file", "The path of a JSON file containing the metadata necessary to create/update the microservice in the Horizon exchange. See /usr/horizon/samples/microservice.json. Specify -f- to read from stdin.").Short('f').Required().String()
 	exMicroKeyFile := exMicroservicePublishCmd.Flag("private-key-file", "The path of a private key file to be used to sign the microservice. ").Short('k').Required().ExistingFile()
@@ -210,11 +219,11 @@ Environment Variables:
 	case userCreateCmd.FullCommand():
 		exchange.UserCreate(*exOrg, *exUserPw, *userCreateEmail)
 	case exNodeListCmd.FullCommand():
-		exchange.NodeList(*exOrg, *exUserPw, *exNode, *exNodeNames)
+		exchange.NodeList(*exOrg, *exUserPw, *exNode, !*exNodeLong)
 	case exNodeCreateCmd.FullCommand():
 		exchange.NodeCreate(*exOrg, *exNodeIdTok, *exUserPw, *exNodeEmail)
 	case exAgbotListCmd.FullCommand():
-		exchange.AgbotList(*exOrg, *exUserPw, *exAgbot, *exAgbotNames)
+		exchange.AgbotList(*exOrg, *exUserPw, *exAgbot, !*exAgbotLong)
 	case exAgbotListPatsCmd.FullCommand():
 		exchange.AgbotListPatterns(*exOrg, *exUserPw, *exAgbotLP, *exAgbotLPPatOrg, *exAgbotLPPat)
 	case exAgbotAddPatCmd.FullCommand():
@@ -222,7 +231,7 @@ Environment Variables:
 	case exAgbotDelPatCmd.FullCommand():
 		exchange.AgbotRemovePattern(*exOrg, *exUserPw, *exAgbotDP, *exAgbotDPPatOrg, *exAgbotDPPat)
 	case exPatternListCmd.FullCommand():
-		exchange.PatternList(*exOrg, *exUserPw, *exPattern, *exPatternNames)
+		exchange.PatternList(*exOrg, *exUserPw, *exPattern, !*exPatternLong)
 	case exPatternPublishCmd.FullCommand():
 		exchange.PatternPublish(*exOrg, *exUserPw, *exPatJsonFile, *exPatKeyFile)
 	case exPatternVerifyCmd.FullCommand():
@@ -231,8 +240,10 @@ Environment Variables:
 		exchange.PatternRemove(*exOrg, *exUserPw, *exDelPat, *exPatDelForce)
 	case exPatternAddWorkCmd.FullCommand():
 		exchange.PatternAddWorkload(*exOrg, *exUserPw, *exPatAddWork, *exPatAddWorkJsonFile, *exPatAddWorkKeyFile)
+	case exPatternDelWorkCmd.FullCommand():
+		exchange.PatternDelWorkload(*exOrg, *exUserPw, *exPatDelWorkPat, *exPatDelWorkOrg, *exPatDelWorkUrl, *exPatDelWorkArch)
 	case exWorkloadListCmd.FullCommand():
-		exchange.WorkloadList(*exOrg, *exUserPw, *exWorkload, *exWorkloadNames)
+		exchange.WorkloadList(*exOrg, *exUserPw, *exWorkload, !*exWorkloadLong)
 	case exWorkloadPublishCmd.FullCommand():
 		exchange.WorkloadPublish(*exOrg, *exUserPw, *exWorkJsonFile, *exWorkPrivKeyFile)
 	case exWorkloadVerifyCmd.FullCommand():
@@ -240,7 +251,7 @@ Environment Variables:
 	case exWorkDelCmd.FullCommand():
 		exchange.WorkloadRemove(*exOrg, *exUserPw, *exDelWork, *exWorkDelForce)
 	case exMicroserviceListCmd.FullCommand():
-		exchange.MicroserviceList(*exOrg, *exUserPw, *exMicroservice, *exMicroserviceNames)
+		exchange.MicroserviceList(*exOrg, *exUserPw, *exMicroservice, !*exMicroserviceLong)
 	case exMicroservicePublishCmd.FullCommand():
 		exchange.MicroservicePublish(*exOrg, *exUserPw, *exMicroJsonFile, *exMicroKeyFile)
 	case exMicroVerifyCmd.FullCommand():

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -8,6 +8,7 @@ import (
 	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/exchange"
 	"net/http"
+	cliexchange "github.com/open-horizon/anax/cli/exchange"
 )
 
 // These structs are used to parse the registration input file
@@ -52,7 +53,7 @@ func DoIt(org string, pattern string, nodeIdTok string, userPw string, email str
 	exchUrlBase := cliutils.GetExchangeUrl()
 	fmt.Printf("Horizon Exchange base URL: %s\n", exchUrlBase)
 
-	// See if the node exists in the exchange, and create if it doesn't
+	// Default node id and token if necessary
 	nodeId, nodeToken := cliutils.SplitIdToken(nodeIdTok)
 	if nodeId == "" {
 		// Get the id from anax
@@ -70,6 +71,8 @@ func DoIt(org string, pattern string, nodeIdTok string, userPw string, email str
 		}
 		fmt.Println("Generated random node token")
 	}
+
+	// See if the node exists in the exchange, and create if it doesn't
 	node := exchange.GetDevicesResponse{}
 	httpCode := cliutils.ExchangeGet(exchUrlBase, "orgs/"+org+"/nodes/"+nodeId, org+"/"+nodeId+":"+nodeToken, nil, &node)
 	if httpCode != 200 {
@@ -77,6 +80,8 @@ func DoIt(org string, pattern string, nodeIdTok string, userPw string, email str
 			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "node '%s/%s' does not exist in the exchange with the specified token and the -u flag was not specified to provide exchange user credentials to create/update it.", org, nodeId)
 		}
 		fmt.Printf("Node %s/%s does not exist in the exchange with the specified token, creating/updating it...\n", org, nodeId)
+		cliexchange.NodeCreate(org, nodeIdTok, userPw, email)
+		/* this is now done in NodeCreate() above...
 		putNodeReq := exchange.PutDeviceRequest{Token: nodeToken, Name: nodeId, SoftwareVersions: make(map[string]string), PublicKey: []byte("")} // we only need to set the token
 		httpCode = cliutils.ExchangePutPost(http.MethodPut, exchUrlBase, "orgs/"+org+"/nodes/"+nodeId, org+"/"+userPw, []int{201, 401}, putNodeReq)
 		if httpCode == 401 {
@@ -92,6 +97,7 @@ func DoIt(org string, pattern string, nodeIdTok string, userPw string, email str
 				cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "node '%s/%s' does not exist in the exchange with the specified token and user '%s/%s' does not exist with the specified password.", org, nodeId, org, user)
 			}
 		}
+		*/
 	} else {
 		fmt.Printf("Node %s/%s exists in the exchange\n", org, nodeId)
 	}


### PR DESCRIPTION
- make --names-only the default behavior for exchange list cmds, remove --names-only|-N flag, and add --long|-l instead
- add hzn exchange pattern removeworkload sub-cmd
- add instructions at the end of ms/wk publish to docker push
- have node create check if node is owned by another user
