### PR TITLE
feature/cli list certs

### DIFF
--- a/api/api_publickey.go
+++ b/api/api_publickey.go
@@ -35,7 +35,7 @@ func (a *API) publickey(w http.ResponseWriter, r *http.Request) {
 				errorHandler(NewSystemError(fmt.Sprintf("Error returning content of %v/%v, error %v", resource, fileName, err)))
 			}
 		} else {
-			if out, err := FindPublicKeysForOutput(a.Config, verbose != ""); err != nil {
+			if out, err := FindPublicKeysForOutput(a.Config, verbose == "true"); err != nil {
 				errorHandler(NewSystemError(fmt.Sprintf("Error getting %v for output, error %v", resource, err)))
 			} else {
 				writeResponse(w, out, http.StatusOK)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -446,16 +446,16 @@
 			"revisionTime": "2018-01-12T22:35:35Z"
 		},
 		{
-			"checksumSHA1": "MHPzwVcYlCJOKBWkLrCinoi4UWs=",
+			"checksumSHA1": "HNPzDhM7PdITnf8qwgGVTBj+C1c=",
 			"path": "github.com/open-horizon/rsapss-tool/generatekeys",
-			"revision": "6ba7332b69320cf75832769fa63a439b8bb56767",
-			"revisionTime": "2018-01-12T22:35:35Z"
+			"revision": "064e62a61118dc418ca20d119687580354856578",
+			"revisionTime": "2018-01-18T19:12:44Z"
 		},
 		{
-			"checksumSHA1": "ojqYnlGfGuduc/0DF53+q2zx5qc=",
+			"checksumSHA1": "J5hjBJsF7yJrRBAcPhIu7o2TIRM=",
 			"path": "github.com/open-horizon/rsapss-tool/listkeys",
-			"revision": "6ba7332b69320cf75832769fa63a439b8bb56767",
-			"revisionTime": "2018-01-12T22:35:35Z"
+			"revision": "064e62a61118dc418ca20d119687580354856578",
+			"revisionTime": "2018-01-18T19:12:44Z"
 		},
 		{
 			"checksumSHA1": "6Ejtwv2PlXR8sT203iR38S7Y5qQ=",
@@ -472,8 +472,8 @@
 		{
 			"checksumSHA1": "xNByXJDmg34A1Fc/yeikYxZdkcc=",
 			"path": "github.com/open-horizon/rsapss-tool/verify",
-			"revision": "6ba7332b69320cf75832769fa63a439b8bb56767",
-			"revisionTime": "2018-01-12T22:35:35Z"
+			"revision": "064e62a61118dc418ca20d119687580354856578",
+			"revisionTime": "2018-01-18T19:12:44Z"
 		},
 		{
 			"checksumSHA1": "3AoPMXlmVq2+iWMpsdJZkcUKHB8=",


### PR DESCRIPTION
API docs were updated, `/trust?verbose=true` was made a little more predictable, and the CLI can list trusted certs and their attributes (using `hzn key list`).

See attached doc for some detailed use examples including exporting a cert and public key from the API and using the rsapss tool to verify a signature.

[hzn_and_api_key_and_cert_examples.txt](https://github.com/open-horizon/anax/files/1644898/hzn_and_api_key_and_cert_examples.txt)
