### PR TITLE
Issue 521 - Microservice version range should be determined by the pa…

### DIFF
--- a/api/input.go
+++ b/api/input.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/open-horizon/anax/microservice"
 	"github.com/open-horizon/anax/persistence"
 	"reflect"
 	"strconv"
@@ -178,8 +179,8 @@ func (s *Service) String() string {
 
 // Constructor used to create service objects for programmatic creation of services.
 func NewService(url string, org string, name string, v string) *Service {
-	autoUpgrade := true
-	activeUpgrade := false
+	autoUpgrade := microservice.MS_DEFAULT_AUTOUPGRADE
+	activeUpgrade := microservice.MS_DEFAULT_ACTIVEUPGRADE
 
 	return &Service{
 		SensorUrl:     &url,

--- a/basicprotocol/protocol.go
+++ b/basicprotocol/protocol.go
@@ -376,7 +376,7 @@ func DecodeReasonCode(code uint64) string {
 		CANCEL_MS_IMAGE_LOAD_FAILURE:    "microservice image loading failed",
 		CANCEL_MS_IMAGE_FETCH_FAILURE:   "microservice image fetching failed",
 		CANCEL_MS_UPGRADE_REQUIRED:      "required by microservice upgrade process",
-		CANCEL_MS_DOWNGRADE_REQUIRED:    "required by microservice downgrade process",
+		CANCEL_MS_DOWNGRADE_REQUIRED:    "microservice failed, need downgrading to lower version",
 		CANCEL_IMAGE_DATA_ERROR:         "image data error",
 		CANCEL_IMAGE_FETCH_FAILURE:      "image fetching failed",
 		CANCEL_IMAGE_FETCH_AUTH_FAILURE: "authorization failed for image fetching",

--- a/citizenscientist/protocol.go
+++ b/citizenscientist/protocol.go
@@ -812,7 +812,7 @@ func DecodeReasonCode(code uint64) string {
 		CANCEL_MS_IMAGE_LOAD_FAILURE:    "microservice image loading failed",
 		CANCEL_MS_IMAGE_FETCH_FAILURE:   "microservice image fetching failed",
 		CANCEL_MS_UPGRADE_REQUIRED:      "required by microservice upgrade process",
-		CANCEL_MS_DOWNGRADE_REQUIRED:    "required by microservice downgrade process",
+		CANCEL_MS_DOWNGRADE_REQUIRED:    "microservice failed, need downgrading to lower version",
 		CANCEL_IMAGE_DATA_ERROR:         "image data error",
 		CANCEL_IMAGE_FETCH_FAILURE:      "image fetching failed",
 		CANCEL_IMAGE_FETCH_AUTH_FAILURE: "authorization failed for image fetching",

--- a/microservice/microservice.go
+++ b/microservice/microservice.go
@@ -15,6 +15,10 @@ import (
 	"strings"
 )
 
+// microservice defaults
+const MS_DEFAULT_AUTOUPGRADE = true
+const MS_DEFAULT_ACTIVEUPGRADE = false
+
 // microservice instance termiated reason code
 const MS_UNREG_EXCH_FAILED = 200
 const MS_CLEAR_OLD_AGS_FAILED = 201
@@ -99,8 +103,8 @@ func ConvertToPersistent(ems *exchange.MicroserviceDefinition, org string) (*per
 
 	pms.Name = ""
 	pms.UpgradeVersionRange = "0.0.0"
-	pms.AutoUpgrade = true
-	pms.ActiveUpgrade = false
+	pms.AutoUpgrade = MS_DEFAULT_AUTOUPGRADE
+	pms.ActiveUpgrade = MS_DEFAULT_ACTIVEUPGRADE
 
 	// Hash the metadata and save it
 	if serial, err := json.Marshal(*ems); err != nil {

--- a/persistence/microservices.go
+++ b/persistence/microservices.go
@@ -369,6 +369,13 @@ func MSDefUpgradeNewMsId(db *bolt.DB, key string, new_id string) (*MicroserviceD
 	})
 }
 
+func MSDefNewUpgradeVersionRange(db *bolt.DB, key string, version_range string) (*MicroserviceDefinition, error) {
+	return microserviceDefStateUpdate(db, key, func(c MicroserviceDefinition) *MicroserviceDefinition {
+		c.UpgradeVersionRange = version_range
+		return &c
+	})
+}
+
 // update the micorserive definition
 func microserviceDefStateUpdate(db *bolt.DB, key string, fn func(MicroserviceDefinition) *MicroserviceDefinition) (*MicroserviceDefinition, error) {
 
@@ -432,6 +439,10 @@ func persistUpdatedMicroserviceDef(db *bolt.DB, key string, update *Microservice
 
 				if mod.UpgradeNewMsId != update.UpgradeNewMsId {
 					mod.UpgradeNewMsId = update.UpgradeNewMsId
+				}
+
+				if mod.UpgradeVersionRange != update.UpgradeVersionRange {
+					mod.UpgradeVersionRange = update.UpgradeVersionRange
 				}
 
 				if serialized, err := json.Marshal(mod); err != nil {

--- a/policy/version.go
+++ b/policy/version.go
@@ -277,6 +277,10 @@ func (self *Version_Expression) ChangeCeiling(ceiling_version string, inclusive 
 			return err
 		} else if c < 0 {
 			return fmt.Errorf("The input ceiling version %v is lower than the start version %v.", ceiling_version, self.start)
+		} else if c == 0 {
+			if !(inclusive && self.start_inclusive) {
+				return fmt.Errorf("The input ceiling version %v is the same as the start version, but either the start or the end is not inclusive.", ceiling_version)
+			}
 		}
 
 		self.end = ceiling_version

--- a/policy/version_test.go
+++ b/policy/version_test.go
@@ -436,6 +436,13 @@ func TestLimitCeiling(t *testing.T) {
 	err = v1.ChangeCeiling("0.1", false)
 	assert.NotNil(t, err, "ChangeCeiling shold return error, but it did not. %v", v1.Get_expression())
 
+	err = v1.ChangeCeiling("1.0", false)
+	assert.NotNil(t, err, "ChangeCeiling shold return error, but it did not. %v", v1.Get_expression())
+
+	err = v1.ChangeCeiling("1.0", true)
+	assert.Nil(t, err, fmt.Sprintf("ChangeCeiling returned error, but should not. Error: %v \n", err))
+	assert.Equal(t, "[1.0.0,1.0.0]", v1.Get_expression(), "Version range should be [1.0.0,1.0.0]")
+
 }
 
 // This series of tests version comparison


### PR DESCRIPTION
…ttern
1). microservice upgrade range should be determined by pattern in pattern case. The use defined version range is ignored.
2). change the agreement termination description text.
3). /microservice api should return microservice objects even if there is no active msdef.
4). fix ChangeCeiling in version.go so that [1.0.0,1.0.0) is an invalid version.
