### PR TITLE
rework dependency model for hzn dev

### DIFF
--- a/cli/dev/microservice.go
+++ b/cli/dev/microservice.go
@@ -37,7 +37,7 @@ func MicroserviceNew(homeDirectory string, org string) {
 	cmd := fmt.Sprintf("%v %v", MICROSERVICE_COMMAND, MICROSERVICE_CREATION_COMMAND)
 	FileNotExist(dir, cmd, USERINPUT_FILE, UserInputExists)
 	FileNotExist(dir, cmd, MICROSERVICE_DEFINITION_FILE, MicroserviceDefinitionExists)
-	FileNotExist(dir, cmd, DEPENDENCIES_FILE, DependenciesExists)
+	//FileNotExist(dir, cmd, DEPENDENCIES_FILE, DependenciesExists)
 
 	if org == "" {
 		org = os.Getenv(DEVTOOL_HZN_ORG)
@@ -48,9 +48,10 @@ func MicroserviceNew(homeDirectory string, org string) {
 		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "'%v %v' %v", MICROSERVICE_COMMAND, MICROSERVICE_CREATION_COMMAND, err)
 	} else if err := CreateMicroserviceDefinition(dir, org); err != nil {
 		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "'%v %v' %v", MICROSERVICE_COMMAND, MICROSERVICE_CREATION_COMMAND, err)
-	} else if err := CreateDependencies(dir); err != nil {
-		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "'%v %v' %v", MICROSERVICE_COMMAND, MICROSERVICE_CREATION_COMMAND, err)
 	}
+	// } else if err := CreateDependencies(dir); err != nil {
+	// 	cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "'%v %v' %v", MICROSERVICE_COMMAND, MICROSERVICE_CREATION_COMMAND, err)
+	// }
 
 	fmt.Printf("Created horizon metadata files in %v. Edit these files to define and configure your new %v.\n", dir, MICROSERVICE_COMMAND)
 }
@@ -64,7 +65,7 @@ func MicroserviceStartTest(homeDirectory string, userInputFile string) {
 	dir, userInputs, cw := commonExecutionSetup(homeDirectory, userInputFile, MICROSERVICE_COMMAND, MICROSERVICE_START_COMMAND)
 
 	// Get the microservice definition, so that we can look at the user input variable definitions.
-	microserviceDef, wderr := GetMicroserviceDefinition(dir)
+	microserviceDef, wderr := GetMicroserviceDefinition(dir, MICROSERVICE_DEFINITION_FILE)
 	if wderr != nil {
 		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "'%v %v' %v", MICROSERVICE_COMMAND, MICROSERVICE_START_COMMAND, wderr)
 	}
@@ -89,7 +90,7 @@ func MicroserviceStopTest(homeDirectory string) {
 	dir, _, cw := commonExecutionSetup(homeDirectory, "", MICROSERVICE_COMMAND, MICROSERVICE_STOP_COMMAND)
 
 	// Get the microservice definition.
-	microserviceDef, wderr := GetMicroserviceDefinition(dir)
+	microserviceDef, wderr := GetMicroserviceDefinition(dir, MICROSERVICE_DEFINITION_FILE)
 	if wderr != nil {
 		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "'%v %v' %v", MICROSERVICE_COMMAND, MICROSERVICE_STOP_COMMAND, wderr)
 	}
@@ -123,7 +124,7 @@ func MicroserviceValidate(homeDirectory string, userInputFile string) {
 	}
 
 	// Validate Microservice Definition
-	if verr := ValidateMicroserviceDefinition(dir); verr != nil {
+	if verr := ValidateMicroserviceDefinition(dir, MICROSERVICE_DEFINITION_FILE); verr != nil {
 		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "'%v %v' project does not validate. %v ", MICROSERVICE_COMMAND, MICROSERVICE_VERIFY_COMMAND, verr)
 	}
 
@@ -160,7 +161,7 @@ func MicroserviceDeploy(homeDirectory string, keyFile string, userCreds string) 
 	// Now we can deploy it.
 
 	// First get the microservice definition.
-	microserviceDef, wderr := GetMicroserviceDefinition(dir)
+	microserviceDef, wderr := GetMicroserviceDefinition(dir, MICROSERVICE_DEFINITION_FILE)
 	if wderr != nil {
 		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "'%v %v' %v", MICROSERVICE_COMMAND, MICROSERVICE_DEPLOY_COMMAND, wderr)
 	}

--- a/cli/dev/microservicedefinition.go
+++ b/cli/dev/microservicedefinition.go
@@ -17,12 +17,12 @@ const DEFAULT_MSDEF_URL = ""
 
 // Sort of like a constructor, it creates an in memory object except that it is created from the microservice definition config
 // file in the current project. This function assumes the caller has determined the exact location of the file.
-func GetMicroserviceDefinition(directory string) (*cliexchange.MicroserviceFile, error) {
+func GetMicroserviceDefinition(directory string, name string) (*cliexchange.MicroserviceFile, error) {
 
 	res := new(cliexchange.MicroserviceFile)
 
 	// GetFile will write to the res object, demarshalling the bytes into a json object that can be returned.
-	if err := GetFile(directory, MICROSERVICE_DEFINITION_FILE, res); err != nil {
+	if err := GetFile(directory, name, res); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -79,14 +79,14 @@ func MicroserviceDefinitionExists(directory string) (bool, error) {
 
 // Validate that the microservice definition file is complete and coherent with the rest of the definitions in the project.
 // If the file is not valid the reason will be returned in the error.
-func ValidateMicroserviceDefinition(directory string) error {
+func ValidateMicroserviceDefinition(directory string, fileName string) error {
 
-	msDef, mserr := GetMicroserviceDefinition(directory)
+	msDef, mserr := GetMicroserviceDefinition(directory, fileName)
 	if mserr != nil {
 		return mserr
 	}
 
-	filePath := path.Join(directory, MICROSERVICE_DEFINITION_FILE)
+	filePath := path.Join(directory, fileName)
 	if msDef.SpecRef == DEFAULT_MSDEF_URL || msDef.SpecRef == "" {
 		return errors.New(fmt.Sprintf("%v: specRef must be set.", filePath))
 	} else if msDef.Version == DEFAULT_MSDEF_SPECIFIC_VERSION || msDef.Version == "" {

--- a/cli/dev/userinput.go
+++ b/cli/dev/userinput.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/open-horizon/anax/api"
 	"github.com/open-horizon/anax/cli/cliutils"
+	"github.com/open-horizon/anax/cli/register"
 	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/exchange"
 	"github.com/open-horizon/anax/persistence"
@@ -18,46 +19,9 @@ const USERINPUT_FILE = "userinput.json"
 
 const DEFAULT_GLOBALSET_TYPE = ""
 
-// These structs are used to parse the user input file
-type GlobalSet struct {
-	Type       string                 `json:"type"`
-	SensorUrls []string               `json:"sensor_urls"`
-	Variables  map[string]interface{} `json:"variables"`
-}
-
-func (g GlobalSet) String() string {
-	return fmt.Sprintf("Global Array element, type: %v, sensor_urls: %v, variables: %v", g.Type, g.SensorUrls, g.Variables)
-}
-
-// Use for both microservices and workloads
-type MicroWork struct {
-	Org          string                 `json:"org"`
-	Url          string                 `json:"url"`
-	VersionRange string                 `json:"versionRange"`
-	Variables    map[string]interface{} `json:"variables"`
-}
-
-func (m MicroWork) String() string {
-	return fmt.Sprintf("Org: %v, URL: %v, VersionRange: %v, Variables: %v", m.Org, m.Url, m.VersionRange, m.Variables)
-}
-
-type InputFile struct {
-	Global        []GlobalSet `json:"global"`
-	Microservices []MicroWork `json:"microservices"`
-	Workloads     []MicroWork `json:"workloads"`
-}
-
-func ReadInputFile(filePath string, inputFileStruct *InputFile) {
-	newBytes := cliutils.ReadJsonFile(filePath)
-	err := json.Unmarshal(newBytes, inputFileStruct)
-	if err != nil {
-		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to unmarshal json input file %s: %v", filePath, err)
-	}
-}
-
 // Sort of like a constructor, it creates an in memory object except that it is created from the user input config
 // file in the current project. This function assumes the caller has determined the exact location of the file.
-func GetUserInputs(homeDirectory string, userInputFile string) (*InputFile, string, error) {
+func GetUserInputs(homeDirectory string, userInputFile string) (*register.InputFile, string, error) {
 
 	userInputFilePath := path.Join(homeDirectory, USERINPUT_FILE)
 	if userInputFile != "" {
@@ -66,7 +30,7 @@ func GetUserInputs(homeDirectory string, userInputFile string) (*InputFile, stri
 			return nil, "", err
 		}
 	}
-	userInputs := new(InputFile)
+	userInputs := new(register.InputFile)
 
 	fileBytes := cliutils.ReadJsonFile(userInputFilePath)
 
@@ -88,9 +52,9 @@ func GetUserInputs(homeDirectory string, userInputFile string) (*InputFile, stri
 func CreateUserInputs(directory string, workload bool, org string) error {
 
 	// Create a skeletal user input config object with fillins/place-holders for configuration.
-	res := new(InputFile)
-	res.Global = []GlobalSet{
-		GlobalSet{
+	res := new(register.InputFile)
+	res.Global = []register.GlobalSet{
+		register.GlobalSet{
 			Type: "",
 			Variables: map[string]interface{}{
 				"attribute_variable": "some_value",
@@ -99,8 +63,8 @@ func CreateUserInputs(directory string, workload bool, org string) error {
 	}
 
 	if workload {
-		res.Workloads = []MicroWork{
-			MicroWork{
+		res.Workloads = []register.MicroWork{
+			register.MicroWork{
 				Org:          org,
 				Url:          "",
 				VersionRange: "[0.0.0,INFINITY)",
@@ -110,8 +74,8 @@ func CreateUserInputs(directory string, workload bool, org string) error {
 			},
 		}
 	} else {
-		res.Microservices = []MicroWork{
-			MicroWork{
+		res.Microservices = []register.MicroWork{
+			register.MicroWork{
 				Org:          org,
 				Url:          "",
 				VersionRange: "[0.0.0,INFINITY)",
@@ -157,7 +121,7 @@ func AddConfiguredUserInputs(configVars map[string]interface{}, envvars map[stri
 
 // Convert each attribute in the global set of attributes to a persistent attribute. This enables us to reuse the validation
 // logic and to reuse the logic that converts persistent attributes to environment variables.
-func GlobalSetAsAttributes(global []GlobalSet) ([]persistence.Attribute, error) {
+func GlobalSetAsAttributes(global []register.GlobalSet) ([]persistence.Attribute, error) {
 
 	// Establish an error handler to catch errors that occurr in the API functions.
 	var passthruError error
@@ -191,7 +155,7 @@ func GlobalSetAsAttributes(global []GlobalSet) ([]persistence.Attribute, error) 
 
 // Validate that the userinputs file is complete and coherent with the rest of the definitions in the project.
 // If the file is not valid the reason will be returned in the error.
-func (i *InputFile) Validate(directory string, originalUserInputFilePath string) error {
+func ValidateUserInput(i *register.InputFile, directory string, originalUserInputFilePath string) error {
 
 	// 1. type is non-empty and one of the valid types
 	// 2. workloads/microservices - variables refer to valid variable definitions.
@@ -233,7 +197,7 @@ func (i *InputFile) Validate(directory string, originalUserInputFilePath string)
 	} else {
 		// Validity check the microservice array.
 		// Get the microservice definition, so that we can look at the user input variable definitions.
-		msDef, mserr := GetMicroserviceDefinition(directory)
+		msDef, mserr := GetMicroserviceDefinition(directory, MICROSERVICE_DEFINITION_FILE)
 		if mserr != nil {
 			return mserr
 		}
@@ -281,7 +245,7 @@ func validateConfiguredVariables(variables map[string]interface{}, definesVar fu
 	return nil
 }
 
-func getConfiguredVariables(configEntries []MicroWork, url string) map[string]interface{} {
+func getConfiguredVariables(configEntries []register.MicroWork, url string) map[string]interface{} {
 	// Get the variables intended to configure this dependency from this project's userinput file.
 	var configVars map[string]interface{}
 

--- a/cli/dev/workloaddefinition.go
+++ b/cli/dev/workloaddefinition.go
@@ -9,7 +9,6 @@ import (
 	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/exchange"
 	"path"
-	"strings"
 )
 
 const WORKLOAD_DEFINITION_FILE = "workload.definition.json"
@@ -113,7 +112,7 @@ func ValidateWorkloadDefinition(directory string) error {
 }
 
 // Refresh the APISpec list dependencies in the definition. This is called when new dependencies are aded or removed.
-func RefreshWorkloadDependencies(homeDirectory string, deps Dependencies) error {
+func RefreshWorkloadDependencies(homeDirectory string) error {
 	// Update the workload definition dependencies to make sure the dependency is included. The APISpec array
 	// in the workload definition is rebuilt from the dependencies.
 	workloadDef, err := GetWorkloadDefinition(homeDirectory)
@@ -121,23 +120,18 @@ func RefreshWorkloadDependencies(homeDirectory string, deps Dependencies) error 
 		return err
 	}
 
-	// Get the current set of dependencies if not provided on input.
-	if deps == nil {
-		var err error
-		deps, err = GetDependencies(homeDirectory)
-		if err != nil {
-			return err
-		}
+	deps, err := GetDependencies(homeDirectory)
+	if err != nil {
+		return err
 	}
 
 	// Start with an empty array and then rebuild it.
 	workloadDef.APISpecs = make([]exchange.APISpec, 0, 10)
 
-	for id, dep := range deps {
-		org := strings.Split(id, "/")[0]
+	for _, dep := range deps {
 		newAPISpec := exchange.APISpec{
 			SpecRef: dep.SpecRef,
-			Org:     org,
+			Org:     dep.Org,
 			Version: dep.Version,
 			Arch:    dep.Arch,
 		}

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -285,7 +285,8 @@ Environment Variables:
 	devDependencyCmdArch := devDependencyCmd.Flag("arch", "(optional) The hardware Architecture of the microservice dependency in the exchange. Mutually exclusive with -p.").Short('a').String()
 	devDependencyFetchCmd := devDependencyCmd.Command("fetch", "Retrieving Horizon metadata for a new dependency.")
 	devDependencyFetchCmdUserPw := devDependencyFetchCmd.Flag("user-pw", "Horizon Exchange user credentials to query exchange resources. If you don't prepend it with the user's org, it will automatically be prepended with the value of the HZN_ORG_ID environment variable.").Short('u').PlaceHolder("USER:PW").String()
-	devDependencyFetchCmdKeyFile := devDependencyFetchCmd.Flag("private-key-file", "The path of a public key file to be used to verify a signature. ").Short('k').ExistingFile()
+	devDependencyFetchCmdKeyFile := devDependencyFetchCmd.Flag("private-key-file", "The path of a public key file to be used to verify a signature.").Short('k').ExistingFile()
+	devDependencyFetchCmdUserInputFile := devDependencyFetchCmd.Flag("userInputFile", "File containing user input values for configuring the new dependency.").Short('f').ExistingFile()
 	devDependencyListCmd := devDependencyCmd.Command("list", "List all dependencies.")
 	devDependencyRemoveCmd := devDependencyCmd.Command("remove", "Remove a project dependency.")
 
@@ -458,7 +459,7 @@ Environment Variables:
 	case devMicroserviceDeployCmd.FullCommand():
 		dev.MicroserviceDeploy(*devHomeDirectory, *devMicroserviceKeyfile, *devMicroserviceDeployCmdUserPw)
 	case devDependencyFetchCmd.FullCommand():
-		dev.DependencyFetch(*devHomeDirectory, *devDependencyCmdProject, *devDependencyCmdSpecRef, *devDependencyCmdOrg, *devDependencyCmdVersion, *devDependencyCmdArch, *devDependencyFetchCmdUserPw, *devDependencyFetchCmdKeyFile)
+		dev.DependencyFetch(*devHomeDirectory, *devDependencyCmdProject, *devDependencyCmdSpecRef, *devDependencyCmdOrg, *devDependencyCmdVersion, *devDependencyCmdArch, *devDependencyFetchCmdUserPw, *devDependencyFetchCmdKeyFile, *devDependencyFetchCmdUserInputFile)
 	case devDependencyListCmd.FullCommand():
 		dev.DependencyList(*devHomeDirectory)
 	case devDependencyRemoveCmd.FullCommand():

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -20,12 +20,20 @@ type GlobalSet struct {
 	Variables  map[string]interface{} `json:"variables"`
 }
 
+func (g GlobalSet) String() string {
+	return fmt.Sprintf("Global Array element, type: %v, sensor_urls: %v, variables: %v", g.Type, g.SensorUrls, g.Variables)
+}
+
 // Use for both microservices and workloads
 type MicroWork struct {
 	Org          string                 `json:"org"`
 	Url          string                 `json:"url"`
 	VersionRange string                 `json:"versionRange"`
 	Variables    map[string]interface{} `json:"variables"`
+}
+
+func (m MicroWork) String() string {
+	return fmt.Sprintf("Org: %v, URL: %v, VersionRange: %v, Variables: %v", m.Org, m.Url, m.VersionRange, m.Variables)
 }
 
 type InputFile struct {


### PR DESCRIPTION
For hzn dev based projects, removed dependency.definitions.json and moved all project dependencies into dependencies directory.