### PR TITLE
fix empty key list, add exch version, allow exch id prefixed by org

### DIFF
--- a/cli/exchange/pattern.go
+++ b/cli/exchange/pattern.go
@@ -89,13 +89,11 @@ type PatternInput struct {
 
 func PatternList(org string, userPw string, pattern string, namesOnly bool) {
 	cliutils.SetWhetherUsingApiKey(userPw)
-	if pattern != "" {
-		pattern = "/" + pattern
-	}
+	org, pattern = cliutils.TrimOrg(org, pattern)
 	if namesOnly && pattern == "" {
 		// Only display the names
 		var resp ExchangePatterns
-		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns"+pattern, cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &resp)
+		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns"+cliutils.AddSlash(pattern), cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &resp)
 		patterns := []string{} // this is important (instead of leaving it nil) so json marshaling displays it as [] instead of null
 		for p := range resp.Patterns {
 			patterns = append(patterns, p)
@@ -109,9 +107,9 @@ func PatternList(org string, userPw string, pattern string, namesOnly bool) {
 		// Display the full resources
 		//var output string
 		var output ExchangePatterns
-		httpCode := cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns"+pattern, cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &output)
+		httpCode := cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns"+cliutils.AddSlash(pattern), cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &output)
 		if httpCode == 404 && pattern != "" {
-			cliutils.Fatal(cliutils.NOT_FOUND, "pattern '%s' not found in org %s", strings.TrimPrefix(pattern, "/"), org)
+			cliutils.Fatal(cliutils.NOT_FOUND, "pattern '%s' not found in org %s", pattern, org)
 		}
 		jsonBytes, err := json.MarshalIndent(output, "", cliutils.JSON_INDENT)
 		if err != nil {
@@ -241,6 +239,7 @@ func PatternPublish(org, userPw, jsonFilePath, keyFilePath, pubKeyFilePath strin
 
 func PatternVerify(org, userPw, pattern, keyFilePath string) {
 	cliutils.SetWhetherUsingApiKey(userPw)
+	org, pattern = cliutils.TrimOrg(org, pattern)
 	// Get pattern resource from exchange
 	var output ExchangePatterns
 	httpCode := cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns/"+pattern, cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &output)
@@ -277,6 +276,7 @@ func PatternVerify(org, userPw, pattern, keyFilePath string) {
 
 func PatternRemove(org, userPw, pattern string, force bool) {
 	cliutils.SetWhetherUsingApiKey(userPw)
+	org, pattern = cliutils.TrimOrg(org, pattern)
 	if !force {
 		cliutils.ConfirmRemove("Are you sure you want to remove pattern '" + org + "/" + pattern + "' from the Horizon Exchange?")
 	}
@@ -301,6 +301,7 @@ func copyPatternOutputToInput(output *PatternOutput, input *PatternInput) {
 // exchange, and then either replaces that workload array element (if it already exists), or adds it.
 func PatternAddWorkload(org, userPw, pattern, workloadFilePath, keyFilePath, pubKeyFilePath string) {
 	cliutils.SetWhetherUsingApiKey(userPw)
+	org, pattern = cliutils.TrimOrg(org, pattern)
 	// Read in the workload metadata
 	newBytes := cliutils.ReadJsonFile(workloadFilePath)
 	var workFile WorkloadReferenceFile
@@ -403,6 +404,7 @@ func PatternAddWorkload(org, userPw, pattern, workloadFilePath, keyFilePath, pub
 
 func PatternDelWorkload(org, userPw, pattern, workloadOrg, workloadUrl, workloadArch string) {
 	cliutils.SetWhetherUsingApiKey(userPw)
+	org, pattern = cliutils.TrimOrg(org, pattern)
 	// Get the pattern from the exchange
 	var output ExchangePatterns
 	cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns/"+pattern, cliutils.OrgAndCreds(org, userPw), []int{200}, &output)
@@ -437,6 +439,7 @@ func PatternDelWorkload(org, userPw, pattern, workloadOrg, workloadUrl, workload
 
 func PatternListKey(org, userPw, pattern, keyName string) {
 	cliutils.SetWhetherUsingApiKey(userPw)
+	org, pattern = cliutils.TrimOrg(org, pattern)
 	if keyName == "" {
 		// Only display the names
 		var output string
@@ -455,6 +458,7 @@ func PatternListKey(org, userPw, pattern, keyName string) {
 
 func PatternRemoveKey(org, userPw, pattern, keyName string) {
 	cliutils.SetWhetherUsingApiKey(userPw)
+	org, pattern = cliutils.TrimOrg(org, pattern)
 	httpCode := cliutils.ExchangeDelete(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns/"+pattern+"/keys/"+keyName, cliutils.OrgAndCreds(org, userPw), []int{204, 404})
 	if httpCode == 404 {
 		cliutils.Fatal(cliutils.NOT_FOUND, "key '%s' not found", keyName)

--- a/cli/exchange/service.go
+++ b/cli/exchange/service.go
@@ -218,7 +218,7 @@ func (sf *ServiceFile) SignAndPublish(org, userPw, keyFilePath string) (exchId s
 	fmt.Println("Signing service...")
 	var imageList []string
 	//cliutils.Verbose("signing deployment string %d", i+1)
-	//todo: i think treating the deployment field as type DeploymentConfig is too inflexible for future additions
+	// Convert the deployment field from map[string]interface{} to []byte (i think treating it as type DeploymentConfig is too inflexible for future additions)
 	deployment, err := json.Marshal(sf.Deployment)
 	if err != nil {
 		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal deployment string: %v", err)

--- a/cli/exchange/version.go
+++ b/cli/exchange/version.go
@@ -1,0 +1,12 @@
+package exchange
+
+import (
+	"fmt"
+	"github.com/open-horizon/anax/cli/cliutils"
+)
+
+func Version() {
+	var output []byte
+	cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "admin/version", "", []int{200}, &output)
+	fmt.Print(string(output))
+}

--- a/cli/exchange/workload.go
+++ b/cli/exchange/workload.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 )
 
 // This is used when reading json file the user gives us as input to create the workload struct
@@ -85,13 +84,11 @@ type WorkloadInput struct {
 
 func WorkloadList(org, userPw, workload string, namesOnly bool) {
 	cliutils.SetWhetherUsingApiKey(userPw)
-	if workload != "" {
-		workload = "/" + workload
-	}
+	org, workload = cliutils.TrimOrg(org, workload)
 	if namesOnly && workload == "" {
 		// Only display the names
 		var resp exchange.GetWorkloadsResponse
-		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads"+workload, cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &resp)
+		cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads"+cliutils.AddSlash(workload), cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &resp)
 		workloads := []string{}
 
 		for k := range resp.Workloads {
@@ -107,9 +104,9 @@ func WorkloadList(org, userPw, workload string, namesOnly bool) {
 		//var output string
 		var output exchange.GetWorkloadsResponse
 
-		httpCode := cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads"+workload, cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &output)
+		httpCode := cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads"+cliutils.AddSlash(workload), cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &output)
 		if httpCode == 404 && workload != "" {
-			cliutils.Fatal(cliutils.NOT_FOUND, "workload '%s' not found in org %s", strings.TrimPrefix(workload, "/"), org)
+			cliutils.Fatal(cliutils.NOT_FOUND, "workload '%s' not found in org %s", workload, org)
 		}
 		jsonBytes, err := json.MarshalIndent(output, "", cliutils.JSON_INDENT)
 		if err != nil {
@@ -217,6 +214,7 @@ func (wf *WorkloadFile) SignAndPublish(org, userPw, keyFilePath string) (exchId 
 // WorkloadVerify verifies the deployment strings of the specified workload resource in the exchange.
 func WorkloadVerify(org, userPw, workload, keyFilePath string) {
 	cliutils.SetWhetherUsingApiKey(userPw)
+	org, workload = cliutils.TrimOrg(org, workload)
 	// Get workload resource from exchange
 	var output exchange.GetWorkloadsResponse
 	httpCode := cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads/"+workload, cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &output)
@@ -251,6 +249,7 @@ func WorkloadVerify(org, userPw, workload, keyFilePath string) {
 
 func WorkloadRemove(org, userPw, workload string, force bool) {
 	cliutils.SetWhetherUsingApiKey(userPw)
+	org, workload = cliutils.TrimOrg(org, workload)
 	if !force {
 		cliutils.ConfirmRemove("Are you sure you want to remove workload '" + org + "/" + workload + "' from the Horizon Exchange?")
 	}
@@ -263,6 +262,7 @@ func WorkloadRemove(org, userPw, workload string, force bool) {
 
 func WorkloadListKey(org, userPw, workload, keyName string) {
 	cliutils.SetWhetherUsingApiKey(userPw)
+	org, workload = cliutils.TrimOrg(org, workload)
 	if keyName == "" {
 		// Only display the names
 		var output string
@@ -281,6 +281,7 @@ func WorkloadListKey(org, userPw, workload, keyName string) {
 
 func WorkloadRemoveKey(org, userPw, workload, keyName string) {
 	cliutils.SetWhetherUsingApiKey(userPw)
+	org, workload = cliutils.TrimOrg(org, workload)
 	httpCode := cliutils.ExchangeDelete(cliutils.GetExchangeUrl(), "orgs/"+org+"/workloads/"+workload+"/keys/"+keyName, cliutils.OrgAndCreds(org, userPw), []int{204, 404})
 	if httpCode == 404 {
 		cliutils.Fatal(cliutils.NOT_FOUND, "key '%s' not found", keyName)

--- a/cli/exchange/workload.go
+++ b/cli/exchange/workload.go
@@ -146,7 +146,7 @@ func (wf *WorkloadFile) SignAndPublish(org, userPw, keyFilePath string) (exchId 
 	workInput := WorkloadInput{Label: wf.Label, Description: wf.Description, Public: wf.Public, WorkloadURL: wf.WorkloadURL, Version: wf.Version, Arch: wf.Arch, DownloadURL: wf.DownloadURL, APISpecs: wf.APISpecs, UserInputs: wf.UserInputs, Workloads: make([]exchange.WorkloadDeployment, len(wf.Workloads))}
 
 	// Loop thru the workloads array and sign the deployment strings
-	fmt.Println("Signing workload...")
+	//fmt.Println("Signing workload...")  // <- do not print this because it might be pre-signed
 	var imageList []string
 	if len(wf.Workloads) > 1 {
 		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "the 'workloads' array can not have more than 1 element in it")
@@ -162,7 +162,7 @@ func (wf *WorkloadFile) SignAndPublish(org, userPw, keyFilePath string) (exchId 
 			workInput.Workloads[i].Deployment = ""
 			workInput.Workloads[i].DeploymentSignature = ""
 		} else {
-			cliutils.Verbose("signing deployment string %d", i+1)
+			cliutils.Verbose("Signing deployment string %d", i+1)
 			deployment, err = json.Marshal(depConfig)
 			if err != nil {
 				cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal deployment string %d: %v", i+1, err)

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -45,10 +45,12 @@ Environment Variables:
 	versionCmd := app.Command("version", "Show the Horizon version.") // using a cmd for this instead of --version flag, because kingpin takes over the latter and can't get version only when it is needed
 
 	exchangeCmd := app.Command("exchange", "List and manage Horizon Exchange resources.")
-	exOrg := exchangeCmd.Flag("org", "The Horizon exchange organization ID.").Short('o').String()
-	exUserPw := exchangeCmd.Flag("user-pw", "Horizon Exchange user credentials to query and create exchange resources. If you don't prepend it with the user's org, it will automatically be prepended with the -o value.").Short('u').PlaceHolder("USER:PW").String()
+	exOrg := exchangeCmd.Flag("org", "The Horizon exchange organization ID. If not specified, HZN_ORG_ID will be used as a default.").Short('o').String()
+	exUserPw := exchangeCmd.Flag("user-pw", "Horizon Exchange user credentials to query and create exchange resources. If not specified, HZN_EXCHANGE_USER_AUTH will be used as a default. If you don't prepend it with the user's org, it will automatically be prepended with the -o value.").Short('u').PlaceHolder("USER:PW").String()
 
-	exUserCmd := exchangeCmd.Command("user", "List and manage users in the Horizon Exchange")
+	exVersionCmd := exchangeCmd.Command("version", "Display the version of the Horizon Exchange.")
+
+	exUserCmd := exchangeCmd.Command("user", "List and manage users in the Horizon Exchange.")
 	exUserListCmd := exUserCmd.Command("list", "Display the user resource from the Horizon Exchange. (You can only display your own user. If the user does not exist, you will get an invalid credentials error.)")
 	exUserCreateCmd := exUserCmd.Command("create", "Create the user resource in the Horizon Exchange.")
 	exUserCreateEmail := exUserCreateCmd.Flag("email", "Your email address that should be associated with this user account when creating it in the Horizon exchange.").Short('e').Required().String()
@@ -179,8 +181,8 @@ Environment Variables:
 	exSvcRemKeyKey := exServiceRemKeyCmd.Arg("key-name", "The existing key name to remove.").Required().String()
 
 	wiotpCmd := app.Command("wiotp", "List and manage WIoTP objects.")
-	wiotpOrg := wiotpCmd.Flag("org", "The WIoTP organization ID.").Short('o').String()
-	wiotpApiKeyToken := wiotpCmd.Flag("apikey-token", "WIoTP API key and token to query and create WIoTP objects.").Short('A').PlaceHolder("APIKEY:TOKEN").String()
+	wiotpOrg := wiotpCmd.Flag("org", "The WIoTP organization ID. If not specified, HZN_ORG_ID will be used as a default.").Short('o').String()
+	wiotpApiKeyToken := wiotpCmd.Flag("apikey-token", "WIoTP API key and token to query and create WIoTP objects. If not specified, HZN_EXCHANGE_API_AUTH will be used as a default.").Short('A').PlaceHolder("APIKEY:TOKEN").String()
 
 	wiotpTypeCmd := wiotpCmd.Command("type", "List and manage types in WIoTP")
 	wiotpTypeListCmd := wiotpTypeCmd.Command("list", "Display the type objects from WIoTP.")
@@ -313,14 +315,14 @@ Environment Variables:
 
 	// Parse cmd and apply env var defaults
 	fullCmd := kingpin.MustParse(app.Parse(os.Args[1:]))
-	cliutils.Verbose("Full command: %s", fullCmd)
+	//cliutils.Verbose("Full command: %s", fullCmd)
 	if strings.HasPrefix(fullCmd, "exchange") {
 		exOrg = cliutils.RequiredWithDefaultEnvVar(exOrg, "HZN_ORG_ID", "organization ID must be specified with either the -o flag or HZN_ORG_ID")
-		exUserPw = cliutils.RequiredWithDefaultEnvVar(exUserPw, "HZN_EXCHANGE_USER_AUTH", "exchange user authenication must be specified with either the -u flag or HZN_EXCHANGE_USER_AUTH")
+		exUserPw = cliutils.RequiredWithDefaultEnvVar(exUserPw, "HZN_EXCHANGE_USER_AUTH", "exchange user authentication must be specified with either the -u flag or HZN_EXCHANGE_USER_AUTH")
 	}
 	if strings.HasPrefix(fullCmd, "wiotp") {
 		wiotpOrg = cliutils.RequiredWithDefaultEnvVar(wiotpOrg, "HZN_ORG_ID", "organization ID must be specified with either the -o flag or HZN_ORG_ID")
-		wiotpApiKeyToken = cliutils.RequiredWithDefaultEnvVar(wiotpApiKeyToken, "HZN_EXCHANGE_API_AUTH", "WIoTP API key authenication must be specified with either the -A flag or HZN_EXCHANGE_API_AUTH")
+		wiotpApiKeyToken = cliutils.RequiredWithDefaultEnvVar(wiotpApiKeyToken, "HZN_EXCHANGE_API_AUTH", "WIoTP API key authentication must be specified with either the -A flag or HZN_EXCHANGE_API_AUTH")
 	}
 	if strings.HasPrefix(fullCmd, "register") {
 		userPw = cliutils.WithDefaultEnvVar(userPw, "HZN_EXCHANGE_USER_AUTH")
@@ -330,6 +332,8 @@ Environment Variables:
 	switch fullCmd {
 	case versionCmd.FullCommand():
 		node.Version()
+	case exVersionCmd.FullCommand():
+		exchange.Version()
 	case exUserListCmd.FullCommand():
 		exchange.UserList(*exOrg, *exUserPw)
 	case exUserCreateCmd.FullCommand():

--- a/cli/key/key.go
+++ b/cli/key/key.go
@@ -27,15 +27,16 @@ func List(keyName string) {
 		var apiOutput map[string][]api.KeyPairSimpleRecord
 		// Note: it is allowed to get /trust before post /node is called, so we don't have to check for that error
 		cliutils.HorizonGet("trust?verbose=true", []int{200}, &apiOutput)
+		cliutils.Verbose("apiOutput: %v", apiOutput)
 
-		var output interface{}
+		var output []api.KeyPairSimpleRecord
 		var ok bool
 		if output, ok = apiOutput["pem"]; !ok {
 			cliutils.Fatal(cliutils.HTTP_ERROR, "horizon api trust output did not include 'pem' key")
 		}
 
-		var certsSimpleOutput []KeyPairSimpleOutput
-		for _, kps := range output.([]api.KeyPairSimpleRecord) {
+		certsSimpleOutput := []KeyPairSimpleOutput{}
+		for _, kps := range output {
 			certsSimpleOutput = append(certsSimpleOutput, KeyPairSimpleOutput{
 				ID:               kps.ID,
 				SerialNumber:     kps.SerialNumber,
@@ -82,7 +83,7 @@ func Create(x509Org, x509CN, outputDir string, keyLength, daysValid int, importK
 			cliutils.Fatal(cliutils.INTERNAL_ERROR, "asked to import the created public key, but can not determine the name.")
 		}
 		Import(pubKeyName)
-		fmt.Printf("%s imported to the Horizon agent", pubKeyName)
+		fmt.Printf("%s imported to the Horizon agent\n", pubKeyName)
 	}
 }
 

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -53,6 +53,7 @@ func ReadInputFile(filePath string, inputFileStruct *InputFile) {
 // DoIt registers this node to Horizon with a pattern
 func DoIt(org, pattern, nodeIdTok, userPw, email, inputFile string) {
 	cliutils.SetWhetherUsingApiKey(nodeIdTok) // if we have to use userPw later in NodeCreate(), it will set this appropriately for userPw
+	org, pattern = cliutils.TrimOrg(org, pattern)
 	// Read input file 1st, so we don't get half way thru registration before finding the problem
 	inputFileStruct := InputFile{}
 	if inputFile != "" {

--- a/cli/wiotp/wiotp.go
+++ b/cli/wiotp/wiotp.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/open-horizon/anax/cli/cliutils"
-	"strings"
 )
 
 // WIoTP API Reference: https://console.bluemix.net/docs/services/IoT/reference/api.html
@@ -20,13 +19,10 @@ type WiotpTypes struct {
 
 // TypeList returns a list of the type names, or if wType is specified, the details of that type.
 func TypeList(org, apiKeyTok, wType string) {
-	if wType != "" {
-		wType = "/" + wType
-	}
 	if wType == "" {
 		// Only display the names
 		var resp WiotpTypes
-		cliutils.WiotpGet(cliutils.GetWiotpUrl(org), "device/types"+wType, apiKeyTok, []int{200, 404}, &resp)
+		cliutils.WiotpGet(cliutils.GetWiotpUrl(org), "device/types"+cliutils.AddSlash(wType), apiKeyTok, []int{200, 404}, &resp)
 		wTypes := []string{}
 		for _, t := range resp.Results {
 			wTypes = append(wTypes, t.Id)
@@ -39,9 +35,9 @@ func TypeList(org, apiKeyTok, wType string) {
 	} else {
 		// Display the full resources
 		var output string
-		httpCode := cliutils.WiotpGet(cliutils.GetWiotpUrl(org), "device/types"+wType, apiKeyTok, []int{200, 404}, &output)
+		httpCode := cliutils.WiotpGet(cliutils.GetWiotpUrl(org), "device/types"+cliutils.AddSlash(wType), apiKeyTok, []int{200, 404}, &output)
 		if httpCode == 404 && wType != "" {
-			cliutils.Fatal(cliutils.NOT_FOUND, "type '%s' not found in org %s", strings.TrimPrefix(wType, "/"), org)
+			cliutils.Fatal(cliutils.NOT_FOUND, "type '%s' not found in org %s", wType, org)
 		}
 		fmt.Println(output)
 	}
@@ -60,13 +56,10 @@ type WiotpDevices struct {
 // DeviceList returns a list of the device/gateway names of this type, or if device is specified, the details of that device/gateway.
 func DeviceList(org, apiKeyTok, wType, device string) {
 	// Note: wType is a required arg
-	if device != "" {
-		device = "/" + device
-	}
 	if device == "" {
 		// Only display the names
 		var resp WiotpDevices
-		cliutils.WiotpGet(cliutils.GetWiotpUrl(org), "device/types/"+wType+"/devices"+device, apiKeyTok, []int{200, 404}, &resp)
+		cliutils.WiotpGet(cliutils.GetWiotpUrl(org), "device/types/"+wType+"/devices"+cliutils.AddSlash(device), apiKeyTok, []int{200, 404}, &resp)
 		devices := []string{}
 		for _, t := range resp.Results {
 			devices = append(devices, t.DeviceId)
@@ -79,9 +72,9 @@ func DeviceList(org, apiKeyTok, wType, device string) {
 	} else {
 		// Display the full resources
 		var output string
-		httpCode := cliutils.WiotpGet(cliutils.GetWiotpUrl(org), "device/types/"+wType+"/devices"+device, apiKeyTok, []int{200, 404}, &output)
+		httpCode := cliutils.WiotpGet(cliutils.GetWiotpUrl(org), "device/types/"+wType+"/devices"+cliutils.AddSlash(device), apiKeyTok, []int{200, 404}, &output)
 		if httpCode == 404 && device != "" {
-			cliutils.Fatal(cliutils.NOT_FOUND, "device '%s' of type '%s' not found in org %s", strings.TrimPrefix(device, "/"), wType, org)
+			cliutils.Fatal(cliutils.NOT_FOUND, "device '%s' of type '%s' not found in org %s", device, wType, org)
 		}
 		fmt.Println(output)
 	}


### PR DESCRIPTION
- 'hzn key list' was returning null when there are no cert-keys - fixed
- when publishing pre-signed ms/wl/svc, don't print that we are signing it
- document env vars in the help of -u, -A, and -o flags
- allow an exchange id to be passed in prefaced by the org (like it is displayed in list)
- add 'hzn exchange version' sub-cmd
