### PR TITLE
Issue 577 - Make exchange version checking and microservice upgrade c…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,10 @@ $(EXECUTABLE): $(shell find . -name '*.go' -not -path './vendor/*') $(CLI_EXECUT
 	cd $(PKGPATH) && \
 	  export GOPATH=$(TMPGOPATH); \
 	    $(COMPILE_ARGS) go build -o $(EXECUTABLE); 
-	exch_ver=$(shell grep "REQUIRED_EXCHANGE_VERSION =" $(PKGPATH)/version/version.go | awk -F '"' '{print $$2}') && \
-	    echo "The required minimum exchange version is $$exch_ver"
+	exch_min_ver=$(shell grep "MINIMUM_EXCHANGE_VERSION =" $(PKGPATH)/version/version.go | awk -F '"' '{print $$2}') && \
+	    echo "The required minimum exchange version is $$exch_min_ver";
+	exch_pref_ver=$(shell grep "PREFFERED_EXCHANGE_VERSION =" $(PKGPATH)/version/version.go | awk -F '"' '{print $$2}') && \
+	    echo "The preffered exchange version is $$exch_pref_ver"
 
 $(CLI_EXECUTABLE): $(shell find . -name '*.go' -not -path './vendor/*') gopathlinks
 	@echo "Producing $(CLI_EXECUTABLE) given arch: $(arch)"

--- a/api/api_node.go
+++ b/api/api_node.go
@@ -42,7 +42,7 @@ func (a *API) node(w http.ResponseWriter, r *http.Request) {
 		glog.V(5).Infof(apiLogString(fmt.Sprintf("Handling %v on resource %v", r.Method, resource)))
 
 		// make sure current exchange version meet the requirement
-		if err := version.VerifyExchangeVersion(a.Config.Collaborators.HTTPClientFactory, a.Config.Edge.ExchangeURL); err != nil {
+		if err := version.VerifyExchangeVersion(a.Config.Collaborators.HTTPClientFactory, a.Config.Edge.ExchangeURL, false); err != nil {
 			errorHandler(NewSystemError(fmt.Sprintf("Error verifiying exchange version. error: %v", err)))
 			return
 		}
@@ -72,7 +72,7 @@ func (a *API) node(w http.ResponseWriter, r *http.Request) {
 		glog.V(5).Infof(apiLogString(fmt.Sprintf("Handling %v on resource %v", r.Method, resource)))
 
 		// make sure current exchange version meet the requirement
-		if err := version.VerifyExchangeVersion(a.Config.Collaborators.HTTPClientFactory, a.Config.Edge.ExchangeURL); err != nil {
+		if err := version.VerifyExchangeVersion(a.Config.Collaborators.HTTPClientFactory, a.Config.Edge.ExchangeURL, false); err != nil {
 			errorHandler(NewSystemError(fmt.Sprintf("Error verifiying exchange version. error: %v", err)))
 			return
 		}
@@ -152,7 +152,7 @@ func (a *API) nodeconfigstate(w http.ResponseWriter, r *http.Request) {
 		glog.V(5).Infof(apiLogString(fmt.Sprintf("Handling %v on resource %v", r.Method, resource)))
 
 		// make sure current exchange version meet the requirement
-		if err := version.VerifyExchangeVersion(a.Config.Collaborators.HTTPClientFactory, a.Config.Edge.ExchangeURL); err != nil {
+		if err := version.VerifyExchangeVersion(a.Config.Collaborators.HTTPClientFactory, a.Config.Edge.ExchangeURL, false); err != nil {
 			errorHandler(NewSystemError(fmt.Sprintf("Error verifiying exchange version. error: %v", err)))
 			return
 		}

--- a/apicommon/status.go
+++ b/apicommon/status.go
@@ -20,7 +20,8 @@ import (
 type Configuration struct {
 	ExchangeAPI     string `json:"exchange_api"`
 	ExchangeVersion string `json:"exchange_version"`
-	ReqExchVersion  string `json:"required_exchange_version"`
+	MinExchVersion  string `json:"required_minimum_exchange_version"`
+	PrefExchVersion string `json:"preffered_exchange_version"`
 	Arch            string `json:"architecture"`
 	HorizonVersion  string `json:"horizon_version"`
 }
@@ -43,7 +44,8 @@ func NewInfo(httpClientFactory *config.HTTPClientFactory, exchangeUrl string) *I
 		Configuration: &Configuration{
 			ExchangeAPI:     exchangeUrl,
 			ExchangeVersion: exch_version,
-			ReqExchVersion:  version.REQUIRED_EXCHANGE_VERSION,
+			MinExchVersion:  version.MINIMUM_EXCHANGE_VERSION,
+			PrefExchVersion: version.PREFFERED_EXCHANGE_VERSION,
 			Arch:            runtime.GOARCH,
 			HorizonVersion:  version.HORIZON_VERSION,
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	DefaultHTTPClientTimeoutS     uint
 	PolicyPath                    string
 	ExchangeHeartbeat             int    // Seconds between heartbeats
+	ExchangeVersionCheckIntervalM int64  // Exchange version check interval in minutes. The default is 720.
 	AgreementTimeoutS             uint64 // Number of seconds to wait before declaring agreement not finalized in blockchain
 	DVPrefix                      string // When passing agreement ids into a workload container, add this prefix to the agreement id
 	RegistrationDelayS            uint64 // The number of seconds to wait after blockchain init before registering with the exchange. This is for testing initialization ONLY.
@@ -43,6 +44,7 @@ type Config struct {
 	UserPublicKeyPath             string // The location to store user keys uploaded through the REST API
 	ReportDeviceStatus            bool   // whether to report the device status to the exchange or not.
 	TrustCertUpdatesFromOrg       bool   // whether to trust the certs provided by the orgnization on the exchange or not. The default is true.
+	ServiceUpgradeCheckIntervalS  int64  // service upgrade check interval in seconds. The default is 300 seconds.
 
 	// these Ids could be provided in config or discovered after startup by the system
 	BlockchainAccountId        string
@@ -51,31 +53,32 @@ type Config struct {
 
 // This is the configuration options for Agreement bot flavor of Anax
 type AGConfig struct {
-	TxLostDelayTolerationSeconds int
-	AgreementWorkers             int
-	DBPath                       string
-	ProtocolTimeoutS             uint64 // Number of seconds to wait before declaring proposal response is lost
-	AgreementTimeoutS            uint64 // Number of seconds to wait before declaring agreement not finalized in blockchain
-	NoDataIntervalS              uint64 // default should be 15 mins == 15*60 == 900. Ignored if the policy has data verification disabled.
-	ActiveAgreementsURL          string // This field is used when policy files indicate they want data verification but they dont specify a URL
-	ActiveAgreementsUser         string // This is the userid the agbot uses to authenticate to the data verifivcation API
-	ActiveAgreementsPW           string // This is the password for the ActiveAgreementsUser
-	PolicyPath                   string // The directory where policy files are kept, default /etc/provider-tremor/policy/
-	NewContractIntervalS         uint64 // default should be 1
-	ProcessGovernanceIntervalS   uint64 // How long the gov sleeps before general gov checks (new payloads, interval payments, etc).
-	IgnoreContractWithAttribs    string // A comma seperated list of contract attributes. If set, the contracts that contain one or more of the attributes will be ignored. The default is "ethereum_account".
-	ExchangeURL                  string // The URL of the Horizon exchange. If not configured, the exchange will not be used.
-	ExchangeHeartbeat            int    // Seconds between heartbeats to the exchange
-	ExchangeId                   string // The id of the agbot, not the userid of the exchange user. Must be org qualified.
-	ExchangeToken                string // The agbot's authentication token
-	DVPrefix                     string // When looking for agreement ids in the data verification API response, look for agreement ids with this prefix.
-	ActiveDeviceTimeoutS         int    // The amount of time a device can go without heartbeating and still be considered active for the purposes of search
-	ExchangeMessageTTL           int    // The number of seconds the exchange will keep this message before automatically deleting it
-	MessageKeyPath               string // The path to the location of messaging keys
-	DefaultWorkloadPW            string // The default workload password if none is specified in the policy file
-	APIListen                    string // Host and port for the API to listen on
-	PurgeArchivedAgreementHours  int    // Number of hours to leave an archived agreement in the database before automatically deleting it
-	CheckUpdatedPolicyS          int    // The number of seconds to wait between checks for an updated policy file. Zero means auto checking is turned off.
+	TxLostDelayTolerationSeconds  int
+	AgreementWorkers              int
+	DBPath                        string
+	ProtocolTimeoutS              uint64 // Number of seconds to wait before declaring proposal response is lost
+	AgreementTimeoutS             uint64 // Number of seconds to wait before declaring agreement not finalized in blockchain
+	NoDataIntervalS               uint64 // default should be 15 mins == 15*60 == 900. Ignored if the policy has data verification disabled.
+	ActiveAgreementsURL           string // This field is used when policy files indicate they want data verification but they dont specify a URL
+	ActiveAgreementsUser          string // This is the userid the agbot uses to authenticate to the data verifivcation API
+	ActiveAgreementsPW            string // This is the password for the ActiveAgreementsUser
+	PolicyPath                    string // The directory where policy files are kept, default /etc/provider-tremor/policy/
+	NewContractIntervalS          uint64 // default should be 1
+	ProcessGovernanceIntervalS    uint64 // How long the gov sleeps before general gov checks (new payloads, interval payments, etc).
+	IgnoreContractWithAttribs     string // A comma seperated list of contract attributes. If set, the contracts that contain one or more of the attributes will be ignored. The default is "ethereum_account".
+	ExchangeURL                   string // The URL of the Horizon exchange. If not configured, the exchange will not be used.
+	ExchangeHeartbeat             int    // Seconds between heartbeats to the exchange
+	ExchangeVersionCheckIntervalM int64  // Exchange version check interval in minutes. The default is 5. 0 means no periodic checking.
+	ExchangeId                    string // The id of the agbot, not the userid of the exchange user. Must be org qualified.
+	ExchangeToken                 string // The agbot's authentication token
+	DVPrefix                      string // When looking for agreement ids in the data verification API response, look for agreement ids with this prefix.
+	ActiveDeviceTimeoutS          int    // The amount of time a device can go without heartbeating and still be considered active for the purposes of search
+	ExchangeMessageTTL            int    // The number of seconds the exchange will keep this message before automatically deleting it
+	MessageKeyPath                string // The path to the location of messaging keys
+	DefaultWorkloadPW             string // The default workload password if none is specified in the policy file
+	APIListen                     string // Host and port for the API to listen on
+	PurgeArchivedAgreementHours   int    // Number of hours to leave an archived agreement in the database before automatically deleting it
+	CheckUpdatedPolicyS           int    // The number of seconds to wait between checks for an updated policy file. Zero means auto checking is turned off.
 }
 
 func (c *HorizonConfig) UserPublicKeyPath() string {
@@ -131,6 +134,17 @@ func Read(file string) (*HorizonConfig, error) {
 
 		if err != nil {
 			return nil, fmt.Errorf("Unable to enrich content of config file with envvars: %v", err)
+		}
+
+		// set the defaults here in case the attributes are not setup by the user.
+		if config.Edge.ExchangeVersionCheckIntervalM == 0 {
+			config.Edge.ExchangeVersionCheckIntervalM = 720
+		}
+		if config.AgreementBot.ExchangeVersionCheckIntervalM == 0 {
+			config.AgreementBot.ExchangeVersionCheckIntervalM = 5
+		}
+		if config.Edge.ServiceUpgradeCheckIntervalS == 0 {
+			config.Edge.ServiceUpgradeCheckIntervalS = 300
 		}
 
 		// now make collaborators instance and assign it to member in this config

--- a/exchange/rpc.go
+++ b/exchange/rpc.go
@@ -1525,29 +1525,29 @@ func GetExchangeVersion(httpClientFactory *config.HTTPClientFactory, exchangeUrl
 
 	glog.V(3).Infof(rpclogString("Get exchange version."))
 
-	return "1.46.0", nil
+	var resp interface{}
+	resp = ""
+	targetURL := exchangeUrl + "admin/version"
+	for {
+		if err, tpErr := InvokeExchange(httpClientFactory.NewHTTPClient(nil), "GET", targetURL, "", "", nil, &resp); err != nil {
+			//glog.Errorf(err.Error())
+			//return "", err
+			// temporary return a version for wiotp
+			return "1.46.0", nil
+		} else if tpErr != nil {
+			glog.Warningf(tpErr.Error())
+			time.Sleep(10 * time.Second)
+			continue
+		} else {
+			// remove last return charactor if any
+			v := resp.(string)
+			if strings.HasSuffix(v, "\n") {
+				v = v[:len(v)-1]
+			}
 
-	//var resp interface{}
-	//resp = ""
-	//targetURL := exchangeUrl + "admin/version"
-	//for {
-	//	if err, tpErr := InvokeExchange(httpClientFactory.NewHTTPClient(nil), "GET", targetURL, "", "", nil, &resp); err != nil {
-	//		glog.Errorf(err.Error())
-	//		return "", err
-	//	} else if tpErr != nil {
-	//		glog.Warningf(tpErr.Error())
-	//		time.Sleep(10 * time.Second)
-	//		continue
-	//	} else {
-	// remove last return charactor if any
-	//		v := resp.(string)
-	//		if strings.HasSuffix(v, "\n") {
-	//			v = v[:len(v)-1]
-	//		}
-
-	//		return v, nil
-	//	}
-	//}
+			return v, nil
+		}
+	}
 }
 
 // This function gets the pattern/workload/microservice signing key names and their contents.

--- a/governance/governance.go
+++ b/governance/governance.go
@@ -46,17 +46,18 @@ const MICROSERVICE_GOVERNOR = "MicroserviceGovernor"
 const BC_GOVERNOR = "BlockchainGovernor"
 
 type GovernanceWorker struct {
-	worker.BaseWorker // embedded field
-	db                *bolt.DB
-	bc                *ethblockchain.BaseContracts
-	deviceId          string
-	deviceToken       string
-	devicePattern     string
-	pm                *policy.PolicyManager
-	producerPH        map[string]producer.ProducerProtocolHandler
-	deviceStatus      *DeviceStatus
-	ShuttingDownCmd   *NodeShutdownCommand
-	exchHandlers      *exchange.ExchangeApiHandlers
+	worker.BaseWorker   // embedded field
+	db                  *bolt.DB
+	bc                  *ethblockchain.BaseContracts
+	deviceId            string
+	deviceToken         string
+	devicePattern       string
+	pm                  *policy.PolicyManager
+	producerPH          map[string]producer.ProducerProtocolHandler
+	deviceStatus        *DeviceStatus
+	ShuttingDownCmd     *NodeShutdownCommand
+	exchHandlers        *exchange.ExchangeApiHandlers
+	lastSvcUpgradeCheck int64
 }
 
 func NewGovernanceWorker(name string, cfg *config.HorizonConfig, db *bolt.DB, pm *policy.PolicyManager) *GovernanceWorker {
@@ -71,16 +72,17 @@ func NewGovernanceWorker(name string, cfg *config.HorizonConfig, db *bolt.DB, pm
 	}
 
 	worker := &GovernanceWorker{
-		BaseWorker:      worker.NewBaseWorker(name, cfg),
-		db:              db,
-		pm:              pm,
-		deviceId:        id,
-		deviceToken:     token,
-		devicePattern:   pattern,
-		producerPH:      make(map[string]producer.ProducerProtocolHandler),
-		deviceStatus:    NewDeviceStatus(),
-		ShuttingDownCmd: nil,
-		exchHandlers:    exchange.NewExchangeApiHandlers(cfg),
+		BaseWorker:          worker.NewBaseWorker(name, cfg),
+		db:                  db,
+		pm:                  pm,
+		deviceId:            id,
+		deviceToken:         token,
+		devicePattern:       pattern,
+		producerPH:          make(map[string]producer.ProducerProtocolHandler),
+		deviceStatus:        NewDeviceStatus(),
+		ShuttingDownCmd:     nil,
+		exchHandlers:        exchange.NewExchangeApiHandlers(cfg),
+		lastSvcUpgradeCheck: time.Now().Unix(),
 	}
 
 	worker.Start(worker, 10)

--- a/version/version.go
+++ b/version/version.go
@@ -10,21 +10,30 @@ import (
 // the real version will be set by the horizon-deb-packager build process
 const HORIZON_VERSION = "local build"
 
-// the required exchange version
-const REQUIRED_EXCHANGE_VERSION = "1.46.0"
+// the minimum exchange version
+const MINIMUM_EXCHANGE_VERSION = "1.46.0"
+
+// the preffered exchange version
+const PREFFERED_EXCHANGE_VERSION = "1.49.0"
 
 // This function verifies the exchange version to make sure it meets the requirement.
 // It return nil if the exchange version is okay.
 // or error if there is an error or current version is not okay.
-func VerifyExchangeVersion(httpClientFactory *config.HTTPClientFactory, exchangeUrl string) error {
+// If a new feature needs the exchagne version higher than the minumum version, call this function with checkWithPreffered to true.
+func VerifyExchangeVersion(httpClientFactory *config.HTTPClientFactory, exchangeUrl string, checkWithPreffered bool) error {
+	version_for_check := MINIMUM_EXCHANGE_VERSION
+	if checkWithPreffered {
+		version_for_check = PREFFERED_EXCHANGE_VERSION
+	}
+
 	if exch_version, err := exchange.GetExchangeVersion(httpClientFactory, exchangeUrl); err != nil {
 		return fmt.Errorf("Failed to get exchange version from the exchange. %v", err)
 	} else if !policy.IsVersionString(exch_version) {
 		return fmt.Errorf("The current exchange version %v is not a valid version string.", exch_version)
-	} else if comp, err := policy.CompareVersions(exch_version, REQUIRED_EXCHANGE_VERSION); err != nil {
+	} else if comp, err := policy.CompareVersions(exch_version, version_for_check); err != nil {
 		return fmt.Errorf("Failed to compare the versions. %v", err)
 	} else if comp < 0 {
-		return fmt.Errorf("The current exchange version %v does not meet the requirement. The required minimum version is %v. Please upgrade the exchange.", exch_version, REQUIRED_EXCHANGE_VERSION)
+		return fmt.Errorf("The current exchange version %v does not meet the requirement. The required version is %v or above. Please upgrade the exchange.", exch_version, version_for_check)
 	} else {
 		return nil
 	}


### PR DESCRIPTION
…hecking less frequent

1. Made the exchange version checking interval configurable. 
2. Changed GetExchangeVersion so that when it is not working, do not return error, instead return a hard coded version number. This is for wiotp support.
3. Added preferred version in addition to the required version to handle the case where required the version works with old features and preferred version works with latest new features.
4. made microservice upgrade checking configurable. 