### PR TITLE
More hzn service support

### DIFF
--- a/cli/exchange/pattern.go
+++ b/cli/exchange/pattern.go
@@ -25,7 +25,7 @@ type PatternOutput struct {
 	Label              string                       `json:"label"`
 	Description        string                       `json:"description"`
 	Public             bool                         `json:"public"`
-	Services          []ServiceReference          `json:"services"`
+	Services           []ServiceReference           `json:"services"`
 	Workloads          []WorkloadReference          `json:"workloads"`
 	AgreementProtocols []exchange.AgreementProtocol `json:"agreementProtocols"`
 	LastUpdated        string                       `json:"lastUpdated"`
@@ -55,26 +55,26 @@ type WorkloadReferenceFile struct {
 	NodeH            exchange.NodeHealth       `json:"nodeHealth"`       // policy for determining when a node's health is violating its agreements
 }
 type ServiceChoiceFile struct {
-	Version  string                    `json:"version"`  // the version of the service
-	Priority exchange.WorkloadPriority `json:"priority"` // the highest priority service is tried first for an agreement, if it fails, the next priority is tried. Priority 1 is the highest, priority 2 is next, etc.
-	Upgrade  exchange.UpgradePolicy    `json:"upgradePolicy"`
-	DeploymentOverrides          interface{} `json:"deployment_overrides"`           // env var overrides for the service
-	DeploymentOverridesSignature string      `json:"deployment_overrides_signature"` // signature of env var overrides
+	Version                      string                    `json:"version"`  // the version of the service
+	Priority                     exchange.WorkloadPriority `json:"priority"` // the highest priority service is tried first for an agreement, if it fails, the next priority is tried. Priority 1 is the highest, priority 2 is next, etc.
+	Upgrade                      exchange.UpgradePolicy    `json:"upgradePolicy"`
+	DeploymentOverrides          interface{}               `json:"deployment_overrides"`           // env var overrides for the service
+	DeploymentOverridesSignature string                    `json:"deployment_overrides_signature"` // signature of env var overrides
 }
 type ServiceReferenceFile struct {
-	ServiceURL      string                    `json:"serviceUrl"`      // refers to a service definition in the exchange
-	ServiceOrg      string                    `json:"serviceOrgid"`    // the org holding the service definition
-	ServiceArch     string                    `json:"serviceArch"`     // the hardware architecture of the service definition
-	ServiceVersions []ServiceChoiceFile      `json:"serviceVersions"` // a list of service version for rollback
-	DataVerify       exchange.DataVerification `json:"dataVerification"` // policy for verifying that the node is sending data
-	NodeH            exchange.NodeHealth       `json:"nodeHealth"`       // policy for determining when a node's health is violating its agreements
+	ServiceURL      string                    `json:"serviceUrl"`       // refers to a service definition in the exchange
+	ServiceOrg      string                    `json:"serviceOrgid"`     // the org holding the service definition
+	ServiceArch     string                    `json:"serviceArch"`      // the hardware architecture of the service definition
+	ServiceVersions []ServiceChoiceFile       `json:"serviceVersions"`  // a list of service version for rollback
+	DataVerify      exchange.DataVerification `json:"dataVerification"` // policy for verifying that the node is sending data
+	NodeH           exchange.NodeHealth       `json:"nodeHealth"`       // policy for determining when a node's health is violating its agreements
 }
 type PatternFile struct {
 	Org                string                       `json:"org"` // optional
 	Label              string                       `json:"label"`
 	Description        string                       `json:"description"`
 	Public             bool                         `json:"public"`
-	Services          []ServiceReferenceFile      `json:"services"`
+	Services           []ServiceReferenceFile       `json:"services"`
 	Workloads          []WorkloadReferenceFile      `json:"workloads"`
 	AgreementProtocols []exchange.AgreementProtocol `json:"agreementProtocols"`
 }
@@ -104,18 +104,18 @@ type ServiceChoice struct {
 	DeploymentOverridesSignature string                    `json:"deployment_overrides_signature"` // signature of env var overrides
 }
 type ServiceReference struct {
-	ServiceURL      string                    `json:"serviceUrl"`      // refers to a service definition in the exchange
-	ServiceOrg      string                    `json:"serviceOrgid"`    // the org holding the service definition
-	ServiceArch     string                    `json:"serviceArch"`     // the hardware architecture of the service definition
-	ServiceVersions []ServiceChoice          `json:"serviceVersions"` // a list of service version for rollback
-	DataVerify       exchange.DataVerification `json:"dataVerification"` // policy for verifying that the node is sending data
-	NodeH            exchange.NodeHealth       `json:"nodeHealth"`       // policy for determining when a node's health is violating its agreements
+	ServiceURL      string                    `json:"serviceUrl"`       // refers to a service definition in the exchange
+	ServiceOrg      string                    `json:"serviceOrgid"`     // the org holding the service definition
+	ServiceArch     string                    `json:"serviceArch"`      // the hardware architecture of the service definition
+	ServiceVersions []ServiceChoice           `json:"serviceVersions"`  // a list of service version for rollback
+	DataVerify      exchange.DataVerification `json:"dataVerification"` // policy for verifying that the node is sending data
+	NodeH           exchange.NodeHealth       `json:"nodeHealth"`       // policy for determining when a node's health is violating its agreements
 }
 type PatternInput struct {
 	Label              string                       `json:"label"`
 	Description        string                       `json:"description"`
 	Public             bool                         `json:"public"`
-	Services          []ServiceReference          `json:"services"`
+	Services           []ServiceReference           `json:"services"`
 	Workloads          []WorkloadReference          `json:"workloads"`
 	AgreementProtocols []exchange.AgreementProtocol `json:"agreementProtocols"`
 }
@@ -337,7 +337,7 @@ func PatternVerify(org, userPw, pattern, keyFilePath string) {
 		for j := range pat.Services[i].ServiceVersions {
 			cliutils.Verbose("verifying deployment_overrides string in service %d, serviceVersion number %d", i+1, j+1)
 			if pat.Services[i].ServiceVersions[j].DeploymentOverrides == "" && pat.Services[i].ServiceVersions[j].DeploymentOverridesSignature == "" {
-				continue	// there was nothing to sign, so nothing to verify
+				continue // there was nothing to sign, so nothing to verify
 			}
 			verified, err := verify.Input(keyFilePath, pat.Services[i].ServiceVersions[j].DeploymentOverridesSignature, []byte(pat.Services[i].ServiceVersions[j].DeploymentOverrides))
 			if err != nil {
@@ -353,7 +353,7 @@ func PatternVerify(org, userPw, pattern, keyFilePath string) {
 		for j := range pat.Workloads[i].WorkloadVersions {
 			cliutils.Verbose("verifying deployment_overrides string in workload %d, workloadVersion number %d", i+1, j+1)
 			if pat.Workloads[i].WorkloadVersions[j].DeploymentOverrides == "" && pat.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature == "" {
-				continue	// there was nothing to sign, so nothing to verify
+				continue // there was nothing to sign, so nothing to verify
 			}
 			verified, err := verify.Input(keyFilePath, pat.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature, []byte(pat.Workloads[i].WorkloadVersions[j].DeploymentOverrides))
 			if err != nil {

--- a/cli/exchange/pattern.go
+++ b/cli/exchange/pattern.go
@@ -53,11 +53,27 @@ type WorkloadReferenceFile struct {
 	DataVerify       exchange.DataVerification `json:"dataVerification"` // policy for verifying that the node is sending data
 	NodeH            exchange.NodeHealth       `json:"nodeHealth"`       // policy for determining when a node's health is violating its agreements
 }
+type ServiceChoiceFile struct {
+	Version  string                    `json:"version"`  // the version of the service
+	Priority exchange.ServicePriority `json:"priority"` // the highest priority service is tried first for an agreement, if it fails, the next priority is tried. Priority 1 is the highest, priority 2 is next, etc.
+	Upgrade  exchange.UpgradePolicy    `json:"upgradePolicy"`
+	DeploymentOverrides          interface{} `json:"deployment_overrides"`           // env var overrides for the service
+	DeploymentOverridesSignature string      `json:"deployment_overrides_signature"` // signature of env var overrides
+}
+type ServiceReferenceFile struct {
+	ServiceURL      string                    `json:"serviceUrl"`      // refers to a service definition in the exchange
+	ServiceOrg      string                    `json:"serviceOrgid"`    // the org holding the service definition
+	ServiceArch     string                    `json:"serviceArch"`     // the hardware architecture of the service definition
+	ServiceVersions []ServiceChoiceFile      `json:"serviceVersions"` // a list of service version for rollback
+	DataVerify       exchange.DataVerification `json:"dataVerification"` // policy for verifying that the node is sending data
+	NodeH            exchange.NodeHealth       `json:"nodeHealth"`       // policy for determining when a node's health is violating its agreements
+}
 type PatternFile struct {
 	Org                string                       `json:"org"` // optional
 	Label              string                       `json:"label"`
 	Description        string                       `json:"description"`
 	Public             bool                         `json:"public"`
+	Services          []ServiceReferenceFile      `json:"services"`
 	Workloads          []WorkloadReferenceFile      `json:"workloads"`
 	AgreementProtocols []exchange.AgreementProtocol `json:"agreementProtocols"`
 }

--- a/cli/exchange/pattern.go
+++ b/cli/exchange/pattern.go
@@ -25,6 +25,7 @@ type PatternOutput struct {
 	Label              string                       `json:"label"`
 	Description        string                       `json:"description"`
 	Public             bool                         `json:"public"`
+	Services          []ServiceReference          `json:"services"`
 	Workloads          []WorkloadReference          `json:"workloads"`
 	AgreementProtocols []exchange.AgreementProtocol `json:"agreementProtocols"`
 	LastUpdated        string                       `json:"lastUpdated"`
@@ -55,7 +56,7 @@ type WorkloadReferenceFile struct {
 }
 type ServiceChoiceFile struct {
 	Version  string                    `json:"version"`  // the version of the service
-	Priority exchange.ServicePriority `json:"priority"` // the highest priority service is tried first for an agreement, if it fails, the next priority is tried. Priority 1 is the highest, priority 2 is next, etc.
+	Priority exchange.WorkloadPriority `json:"priority"` // the highest priority service is tried first for an agreement, if it fails, the next priority is tried. Priority 1 is the highest, priority 2 is next, etc.
 	Upgrade  exchange.UpgradePolicy    `json:"upgradePolicy"`
 	DeploymentOverrides          interface{} `json:"deployment_overrides"`           // env var overrides for the service
 	DeploymentOverridesSignature string      `json:"deployment_overrides_signature"` // signature of env var overrides
@@ -95,10 +96,26 @@ type WorkloadReference struct {
 	DataVerify       exchange.DataVerification `json:"dataVerification"` // policy for verifying that the node is sending data
 	NodeH            exchange.NodeHealth       `json:"nodeHealth"`       // policy for determining when a node's health is violating its agreements
 }
+type ServiceChoice struct {
+	Version                      string                    `json:"version"`  // the version of the service
+	Priority                     exchange.WorkloadPriority `json:"priority"` // the highest priority service is tried first for an agreement, if it fails, the next priority is tried. Priority 1 is the highest, priority 2 is next, etc.
+	Upgrade                      exchange.UpgradePolicy    `json:"upgradePolicy"`
+	DeploymentOverrides          string                    `json:"deployment_overrides"`           // env var overrides for the service
+	DeploymentOverridesSignature string                    `json:"deployment_overrides_signature"` // signature of env var overrides
+}
+type ServiceReference struct {
+	ServiceURL      string                    `json:"serviceUrl"`      // refers to a service definition in the exchange
+	ServiceOrg      string                    `json:"serviceOrgid"`    // the org holding the service definition
+	ServiceArch     string                    `json:"serviceArch"`     // the hardware architecture of the service definition
+	ServiceVersions []ServiceChoice          `json:"serviceVersions"` // a list of service version for rollback
+	DataVerify       exchange.DataVerification `json:"dataVerification"` // policy for verifying that the node is sending data
+	NodeH            exchange.NodeHealth       `json:"nodeHealth"`       // policy for determining when a node's health is violating its agreements
+}
 type PatternInput struct {
 	Label              string                       `json:"label"`
 	Description        string                       `json:"description"`
 	Public             bool                         `json:"public"`
+	Services          []ServiceReference          `json:"services"`
 	Workloads          []WorkloadReference          `json:"workloads"`
 	AgreementProtocols []exchange.AgreementProtocol `json:"agreementProtocols"`
 }
@@ -121,7 +138,6 @@ func PatternList(org string, userPw string, pattern string, namesOnly bool) {
 		fmt.Printf("%s\n", jsonBytes)
 	} else {
 		// Display the full resources
-		//var output string
 		var output ExchangePatterns
 		httpCode := cliutils.ExchangeGet(cliutils.GetExchangeUrl(), "orgs/"+org+"/patterns"+cliutils.AddSlash(pattern), cliutils.OrgAndCreds(org, userPw), []int{200, 404}, &output)
 		if httpCode == 404 && pattern != "" {
@@ -182,47 +198,95 @@ func PatternPublish(org, userPw, jsonFilePath, keyFilePath, pubKeyFilePath strin
 	if patFile.Org != "" && patFile.Org != org {
 		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "the org specified in the input file (%s) must match the org specified on the command line (%s)", patFile.Org, org)
 	}
-	patInput := PatternInput{Label: patFile.Label, Description: patFile.Description, Public: patFile.Public, Workloads: make([]WorkloadReference, len(patFile.Workloads)), AgreementProtocols: patFile.AgreementProtocols}
+	if patFile.Workloads != nil && len(patFile.Workloads) > 0 && patFile.Services != nil && len(patFile.Services) > 0 {
+		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "you can not specify both the 'workloads' and 'services' fields.")
+	}
+	patInput := PatternInput{Label: patFile.Label, Description: patFile.Description, Public: patFile.Public, AgreementProtocols: patFile.AgreementProtocols}
 
-	// Loop thru the workloads array and the workloadVersions array and sign the deployment_overrides strings
-	fmt.Println("Signing pattern...")
-	for i := range patFile.Workloads {
-		patInput.Workloads[i].WorkloadURL = patFile.Workloads[i].WorkloadURL
-		patInput.Workloads[i].WorkloadOrg = patFile.Workloads[i].WorkloadOrg
-		patInput.Workloads[i].WorkloadArch = patFile.Workloads[i].WorkloadArch
-		patInput.Workloads[i].WorkloadVersions = make([]WorkloadChoice, len(patFile.Workloads[i].WorkloadVersions))
-		patInput.Workloads[i].DataVerify = patFile.Workloads[i].DataVerify
-		patInput.Workloads[i].NodeH = patFile.Workloads[i].NodeH
-		for j := range patFile.Workloads[i].WorkloadVersions {
-			cliutils.Verbose("signing deployment_overrides string in workload %d, workloadVersion number %d", i+1, j+1)
-			patInput.Workloads[i].WorkloadVersions[j].Version = patFile.Workloads[i].WorkloadVersions[j].Version
-			patInput.Workloads[i].WorkloadVersions[j].Priority = patFile.Workloads[i].WorkloadVersions[j].Priority
-			patInput.Workloads[i].WorkloadVersions[j].Upgrade = patFile.Workloads[i].WorkloadVersions[j].Upgrade
+	// Loop thru the services/workloads array and the servicesVersions/workloadVersions array and sign the deployment_overrides fields
+	if patFile.Services != nil && len(patFile.Services) > 0 {
+		patInput.Services = make([]ServiceReference, len(patFile.Services))
+		for i := range patFile.Services {
+			patInput.Services[i].ServiceURL = patFile.Services[i].ServiceURL
+			patInput.Services[i].ServiceOrg = patFile.Services[i].ServiceOrg
+			patInput.Services[i].ServiceArch = patFile.Services[i].ServiceArch
+			patInput.Services[i].ServiceVersions = make([]ServiceChoice, len(patFile.Services[i].ServiceVersions))
+			patInput.Services[i].DataVerify = patFile.Services[i].DataVerify
+			patInput.Services[i].NodeH = patFile.Services[i].NodeH
+			for j := range patFile.Services[i].ServiceVersions {
+				patInput.Services[i].ServiceVersions[j].Version = patFile.Services[i].ServiceVersions[j].Version
+				patInput.Services[i].ServiceVersions[j].Priority = patFile.Services[i].ServiceVersions[j].Priority
+				patInput.Services[i].ServiceVersions[j].Upgrade = patFile.Services[i].ServiceVersions[j].Upgrade
 
-			var err error
-			var deployment []byte
-			depOver := ConvertToDeploymentOverrides(patFile.Workloads[i].WorkloadVersions[j].DeploymentOverrides)
-			// If the input deployment overrides are already in string form and signed, then use them as is.
-			if patFile.Workloads[i].WorkloadVersions[j].DeploymentOverrides != nil && reflect.TypeOf(patFile.Workloads[i].WorkloadVersions[j].DeploymentOverrides).String() == "string" && patFile.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature != "" {
-				patInput.Workloads[i].WorkloadVersions[j].DeploymentOverrides = patFile.Workloads[i].WorkloadVersions[j].DeploymentOverrides.(string)
-				patInput.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature = patFile.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature
-			} else if depOver == nil {
-				// If the input deployment override is an object that is nil, then there are no overrides.
-				patInput.Workloads[i].WorkloadVersions[j].DeploymentOverrides = ""
-				patInput.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature = ""
-			} else {
-				deployment, err = json.Marshal(depOver)
-				if err != nil {
-					cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal deployment_overrides field in workload %d, workloadVersion number %d: %v", i+1, j+1, err)
+				var err error
+				var deployment []byte
+				depOver := ConvertToDeploymentOverrides(patFile.Services[i].ServiceVersions[j].DeploymentOverrides)
+				// If the input deployment overrides are already in string form and signed, then use them as is.
+				if patFile.Services[i].ServiceVersions[j].DeploymentOverrides != nil && reflect.TypeOf(patFile.Services[i].ServiceVersions[j].DeploymentOverrides).String() == "string" && patFile.Services[i].ServiceVersions[j].DeploymentOverridesSignature != "" {
+					patInput.Services[i].ServiceVersions[j].DeploymentOverrides = patFile.Services[i].ServiceVersions[j].DeploymentOverrides.(string)
+					patInput.Services[i].ServiceVersions[j].DeploymentOverridesSignature = patFile.Services[i].ServiceVersions[j].DeploymentOverridesSignature
+				} else if depOver == nil {
+					// If the input deployment override is an object that is nil, then there are no overrides, so no signing necessary.
+					patInput.Services[i].ServiceVersions[j].DeploymentOverrides = ""
+					patInput.Services[i].ServiceVersions[j].DeploymentOverridesSignature = ""
+				} else {
+					fmt.Printf("Signing deployment_overrides field in service %d, serviceVersion number %d\n", i+1, j+1)
+					deployment, err = json.Marshal(depOver)
+					if err != nil {
+						cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal deployment_overrides field in service %d, serviceVersion number %d: %v", i+1, j+1, err)
+					}
+					patInput.Services[i].ServiceVersions[j].DeploymentOverrides = string(deployment)
+					// We know we need to sign the overrides, so make sure a real key file was provided.
+					if keyFilePath == "" {
+						cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "must specify --private-key-file so that the deployment_overrides can be signed")
+					}
+					patInput.Services[i].ServiceVersions[j].DeploymentOverridesSignature, err = sign.Input(keyFilePath, deployment)
+					if err != nil {
+						cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem signing the deployment_overrides string with %s: %v", keyFilePath, err)
+					}
 				}
-				patInput.Workloads[i].WorkloadVersions[j].DeploymentOverrides = string(deployment)
-				// We know we need to sign the overrides, so make sure a real key file was provided.
-				if keyFilePath == "" {
-					cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "must specify --private-key-file so that the deployment_overrides can be signed")
-				}
-				patInput.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature, err = sign.Input(keyFilePath, deployment)
-				if err != nil {
-					cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem signing the deployment_overrides string with %s: %v", keyFilePath, err)
+			}
+		}
+	} else if patFile.Workloads != nil && len(patFile.Workloads) > 0 {
+		patInput.Workloads = make([]WorkloadReference, len(patFile.Workloads))
+		for i := range patFile.Workloads {
+			patInput.Workloads[i].WorkloadURL = patFile.Workloads[i].WorkloadURL
+			patInput.Workloads[i].WorkloadOrg = patFile.Workloads[i].WorkloadOrg
+			patInput.Workloads[i].WorkloadArch = patFile.Workloads[i].WorkloadArch
+			patInput.Workloads[i].WorkloadVersions = make([]WorkloadChoice, len(patFile.Workloads[i].WorkloadVersions))
+			patInput.Workloads[i].DataVerify = patFile.Workloads[i].DataVerify
+			patInput.Workloads[i].NodeH = patFile.Workloads[i].NodeH
+			for j := range patFile.Workloads[i].WorkloadVersions {
+				patInput.Workloads[i].WorkloadVersions[j].Version = patFile.Workloads[i].WorkloadVersions[j].Version
+				patInput.Workloads[i].WorkloadVersions[j].Priority = patFile.Workloads[i].WorkloadVersions[j].Priority
+				patInput.Workloads[i].WorkloadVersions[j].Upgrade = patFile.Workloads[i].WorkloadVersions[j].Upgrade
+
+				var err error
+				var deployment []byte
+				depOver := ConvertToDeploymentOverrides(patFile.Workloads[i].WorkloadVersions[j].DeploymentOverrides)
+				// If the input deployment overrides are already in string form and signed, then use them as is.
+				if patFile.Workloads[i].WorkloadVersions[j].DeploymentOverrides != nil && reflect.TypeOf(patFile.Workloads[i].WorkloadVersions[j].DeploymentOverrides).String() == "string" && patFile.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature != "" {
+					patInput.Workloads[i].WorkloadVersions[j].DeploymentOverrides = patFile.Workloads[i].WorkloadVersions[j].DeploymentOverrides.(string)
+					patInput.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature = patFile.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature
+				} else if depOver == nil {
+					// If the input deployment override is an object that is nil, then there are no overrides, so no signing necessary.
+					patInput.Workloads[i].WorkloadVersions[j].DeploymentOverrides = ""
+					patInput.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature = ""
+				} else {
+					fmt.Printf("Signing deployment_overrides field in workload %d, workloadVersion number %d\n", i+1, j+1)
+					deployment, err = json.Marshal(depOver)
+					if err != nil {
+						cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal deployment_overrides field in workload %d, workloadVersion number %d: %v", i+1, j+1, err)
+					}
+					patInput.Workloads[i].WorkloadVersions[j].DeploymentOverrides = string(deployment)
+					// We know we need to sign the overrides, so make sure a real key file was provided.
+					if keyFilePath == "" {
+						cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "must specify --private-key-file so that the deployment_overrides can be signed")
+					}
+					patInput.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature, err = sign.Input(keyFilePath, deployment)
+					if err != nil {
+						cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem signing the deployment_overrides string with %s: %v", keyFilePath, err)
+					}
 				}
 			}
 		}
@@ -262,16 +326,35 @@ func PatternVerify(org, userPw, pattern, keyFilePath string) {
 	if httpCode == 404 {
 		cliutils.Fatal(cliutils.NOT_FOUND, "pattern '%s' not found in org %s", pattern, org)
 	}
-
-	// Loop thru workloads array, checking the deployment string signature
 	pat, ok := output.Patterns[org+"/"+pattern]
 	if !ok {
 		cliutils.Fatal(cliutils.INTERNAL_ERROR, "key '%s' not found in resources returned from exchange", org+"/"+pattern)
 	}
+
+	// Loop thru services array, checking the deployment string signature
 	someInvalid := false
+	for i := range pat.Services {
+		for j := range pat.Services[i].ServiceVersions {
+			cliutils.Verbose("verifying deployment_overrides string in service %d, serviceVersion number %d", i+1, j+1)
+			if pat.Services[i].ServiceVersions[j].DeploymentOverrides == "" && pat.Services[i].ServiceVersions[j].DeploymentOverridesSignature == "" {
+				continue	// there was nothing to sign, so nothing to verify
+			}
+			verified, err := verify.Input(keyFilePath, pat.Services[i].ServiceVersions[j].DeploymentOverridesSignature, []byte(pat.Services[i].ServiceVersions[j].DeploymentOverrides))
+			if err != nil {
+				cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem verifying deployment_overrides string in service %d, serviceVersion number %d with %s: %v", i+1, j+1, keyFilePath, err)
+			} else if !verified {
+				fmt.Printf("Deployment_overrides string in service %d, serviceVersion number %d was not signed with the private key associated with this public key.\n", i+1, j+1)
+				someInvalid = true
+			}
+			// else if they all turned out to be valid, we will tell them that at the end
+		}
+	}
 	for i := range pat.Workloads {
 		for j := range pat.Workloads[i].WorkloadVersions {
 			cliutils.Verbose("verifying deployment_overrides string in workload %d, workloadVersion number %d", i+1, j+1)
+			if pat.Workloads[i].WorkloadVersions[j].DeploymentOverrides == "" && pat.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature == "" {
+				continue	// there was nothing to sign, so nothing to verify
+			}
 			verified, err := verify.Input(keyFilePath, pat.Workloads[i].WorkloadVersions[j].DeploymentOverridesSignature, []byte(pat.Workloads[i].WorkloadVersions[j].DeploymentOverrides))
 			if err != nil {
 				cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem verifying deployment_overrides string in workload %d, workloadVersion number %d with %s: %v", i+1, j+1, keyFilePath, err)

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -214,6 +214,7 @@ Environment Variables:
 	keyCmd := app.Command("key", "List and manage keys for signing and verifying services.")
 	keyListCmd := keyCmd.Command("list", "List the signing keys that have been imported into this Horizon agent.")
 	keyName := keyListCmd.Arg("key-name", "The name of a specific key to show.").String()
+	keyListAll := keyListCmd.Flag("all", "List the names of all signing keys, even the older public keys not wrapped in a certificate.").Short('a').Bool()
 	keyCreateCmd := keyCmd.Command("create", "Generate a signing key pair.")
 	keyX509Org := keyCreateCmd.Arg("x509-org", "x509 certificate Organization (O) field (preferably a company name or other organization's name).").Required().String()
 	keyX509CN := keyCreateCmd.Arg("x509-cn", "x509 certificate Common Name (CN) field (preferably an email address issued by x509org).").Required().String()
@@ -422,7 +423,7 @@ Environment Variables:
 	case registerCmd.FullCommand():
 		register.DoIt(*org, *pattern, *nodeIdTok, *userPw, *email, *inputFile)
 	case keyListCmd.FullCommand():
-		key.List(*keyName)
+		key.List(*keyName, *keyListAll)
 	//case keyCmd.FullCommand():   // <- I'd like to just default to list in this case, but don't know how to do that yet
 	//	keyCmd.List()
 	case keyCreateCmd.FullCommand():

--- a/cli/key/key.go
+++ b/cli/key/key.go
@@ -21,8 +21,20 @@ type KeyPairSimpleOutput struct {
 	NotValidAfter    string `json:"not_valid_after"`
 }
 
-func List(keyName string) {
-	if keyName == "" {
+type KeyList struct {
+	Pem []string `json:"pem"`
+}
+
+func List(keyName string, listAll bool) {
+	if keyName == "" && listAll {
+		var apiOutput KeyList
+		cliutils.HorizonGet("trust", []int{200}, &apiOutput)
+		jsonBytes, err := json.MarshalIndent(apiOutput.Pem, "", cliutils.JSON_INDENT)
+		if err != nil {
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'key list' output: %v", err)
+		}
+		fmt.Printf("%s\n", jsonBytes)
+	} else if keyName == "" {
 		// Getting all of the keys only returns the names
 		var apiOutput map[string][]api.KeyPairSimpleRecord
 		// Note: it is allowed to get /trust before post /node is called, so we don't have to check for that error

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -38,7 +38,7 @@ func (m MicroWork) String() string {
 
 type InputFile struct {
 	Global        []GlobalSet `json:"global,omitempty"`
-	Services []MicroWork `json:"services,omitempty"`
+	Services      []MicroWork `json:"services,omitempty"`
 	Microservices []MicroWork `json:"microservices,omitempty"`
 	Workloads     []MicroWork `json:"workloads,omitempty"`
 }
@@ -144,7 +144,7 @@ func DoIt(org, pattern, nodeIdTok, userPw, email, inputFile string) {
 
 		// Set the microservice variables
 		attr = api.NewAttribute("UserInputAttributes", []string{}, "microservice", false, false, map[string]interface{}{}) // we reuse this for each microservice
-		microservice := api.MicroService{SensorName: &emptyStr} // we reuse this too
+		microservice := api.MicroService{SensorName: &emptyStr}                                                            // we reuse this too
 		if len(inputFileStruct.Microservices) > 0 {
 			fmt.Println("Setting microservice variables...")
 		}
@@ -297,11 +297,11 @@ func CreateInputFile(org, pattern, arch, nodeIdTok, inputFile string) {
 		} else {
 			versionRangeStr = versionRange.Get_expression()
 		}
-		micro, err := exchange.GetMicroservice(httpClientFactory, m.SpecRef, m.Org, versionRangeStr, m.Arch, exchangeUrl+"/", cliutils.OrgAndCreds(org, nodeId), nodeToken)
+		micro, err := exchange.GetMicroservice(httpClientFactory, m.Url, m.Org, versionRangeStr, m.Arch, exchangeUrl+"/", cliutils.OrgAndCreds(org, nodeId), nodeToken)
 		if err != nil {
-			cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem getting the highest version microservice for %s %s %s: %v", m.Org, m.SpecRef, m.Arch, err)
+			cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "problem getting the highest version microservice for %s %s %s: %v", m.Org, m.Url, m.Arch, err)
 		}
-		cliutils.Verbose("for %s %s %s selected %s for version range %s", m.Org, m.SpecRef, m.Arch, micro.Version, m.Version)
+		cliutils.Verbose("for %s %s %s selected %s for version range %s", m.Org, m.Url, m.Arch, micro.Version, m.Version)
 		*/
 
 		// Get the user input from this microservice

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -24,7 +24,7 @@ func (g GlobalSet) String() string {
 	return fmt.Sprintf("Global Array element, type: %v, sensor_urls: %v, variables: %v", g.Type, g.SensorUrls, g.Variables)
 }
 
-// Use for both microservices and workloads
+// Use for services, microservices, and workloads
 type MicroWork struct {
 	Org          string                 `json:"org"`
 	Url          string                 `json:"url"`
@@ -38,6 +38,7 @@ func (m MicroWork) String() string {
 
 type InputFile struct {
 	Global        []GlobalSet `json:"global,omitempty"`
+	Services []MicroWork `json:"services,omitempty"`
 	Microservices []MicroWork `json:"microservices,omitempty"`
 	Workloads     []MicroWork `json:"workloads,omitempty"`
 }
@@ -113,8 +114,10 @@ func DoIt(org, pattern, nodeIdTok, userPw, email, inputFile string) {
 	if inputFile != "" {
 		// Set the global variables as attributes with no url (or in the case of HTTPSBasicAuthAttributes, with url equal to image svr)
 		// Technically the AgreementProtocolAttributes can be set, but it has no effect on anax if a pattern is being used.
-		fmt.Println("Setting global variables...")
 		attr := api.NewAttribute("", []string{}, "Global variables", false, false, map[string]interface{}{}) // we reuse this for each GlobalSet
+		if len(inputFileStruct.Global) > 0 {
+			fmt.Println("Setting global variables...")
+		}
 		for _, g := range inputFileStruct.Global {
 			attr.Type = &g.Type
 			attr.SensorUrls = &g.SensorUrls
@@ -122,24 +125,44 @@ func DoIt(org, pattern, nodeIdTok, userPw, email, inputFile string) {
 			cliutils.HorizonPutPost(http.MethodPost, "attribute", []int{201, 200}, attr)
 		}
 
-		// Set the microservice variables
-		fmt.Println("Setting microservice variables...")
-		attr = api.NewAttribute("UserInputAttributes", []string{}, "microservice", false, false, map[string]interface{}{}) // we reuse this for each microservice
+		// Set the service variables
+		attr = api.NewAttribute("UserInputAttributes", []string{}, "service", false, false, map[string]interface{}{}) // we reuse this for each service
 		emptyStr := ""
-		service := api.MicroService{SensorName: &emptyStr} // we reuse this too
-		for _, m := range inputFileStruct.Microservices {
-			service.SensorOrg = &m.Org
-			service.SensorUrl = &m.Url
-			service.SensorVersion = &m.VersionRange
+		service := api.Service{Name: &emptyStr} // we reuse this too
+		if len(inputFileStruct.Services) > 0 {
+			fmt.Println("Setting service variables...")
+		}
+		for _, m := range inputFileStruct.Services {
+			service.Org = &m.Org
+			service.Url = &m.Url
+			service.VersionRange = &m.VersionRange
 			attr.Mappings = &m.Variables
 			attrSlice := []api.Attribute{*attr}
 			service.Attributes = &attrSlice
-			cliutils.HorizonPutPost(http.MethodPost, "microservice/config", []int{201, 200}, service)
+			cliutils.HorizonPutPost(http.MethodPost, "service/config", []int{201, 200}, service)
+		}
+
+		// Set the microservice variables
+		attr = api.NewAttribute("UserInputAttributes", []string{}, "microservice", false, false, map[string]interface{}{}) // we reuse this for each microservice
+		microservice := api.MicroService{SensorName: &emptyStr} // we reuse this too
+		if len(inputFileStruct.Microservices) > 0 {
+			fmt.Println("Setting microservice variables...")
+		}
+		for _, m := range inputFileStruct.Microservices {
+			microservice.SensorOrg = &m.Org
+			microservice.SensorUrl = &m.Url
+			microservice.SensorVersion = &m.VersionRange
+			attr.Mappings = &m.Variables
+			attrSlice := []api.Attribute{*attr}
+			microservice.Attributes = &attrSlice
+			cliutils.HorizonPutPost(http.MethodPost, "microservice/config", []int{201, 200}, microservice)
 		}
 
 		// Set the workload variables
-		fmt.Println("Setting workload variables...")
 		attr = api.NewAttribute("UserInputAttributes", []string{}, "workload", false, false, map[string]interface{}{})
+		if len(inputFileStruct.Workloads) > 0 {
+			fmt.Println("Setting workload variables...")
+		}
 		for _, w := range inputFileStruct.Workloads {
 			attr.Mappings = &w.Variables
 			workload := api.WorkloadConfig{Org: w.Org, WorkloadURL: w.Url, Version: w.VersionRange, Attributes: []api.Attribute{*attr}}

--- a/cli/samples/insert-service-into-pattern.json
+++ b/cli/samples/insert-service-into-pattern.json
@@ -1,0 +1,49 @@
+/* Sample json for adding/replacing a service in an existing pattern. */
+    {
+      "serviceUrl": "https://bluehorizon.network/services/netspeed-docker",
+      "serviceOrgid": "IBM",
+      "serviceArch": "amd64",
+      "serviceVersions": [
+        {
+          "version": "2.5",
+          "deployment_overrides": {
+            "services": {
+              "netspeed5": {
+                "environment": [
+                  "USE_NEW_STAGING_URL=false"
+                ]
+              }
+            }
+          },
+          "deployment_overrides_signature": "",
+          "priority": {
+            "priority_value": 50,
+            "retries": 1,
+            "retry_durations": 3600,
+            "verified_durations": 52
+          },
+          "upgradePolicy": {
+            "lifecycle": "immediate",
+            "time": "01:00AM"
+          }
+        }
+      ],
+      "dataVerification": {
+        "enabled": true,
+        "URL": "",
+        "user": "",
+        "password": "",
+        "interval": 480,
+        "check_rate": 15,
+        "metering": {
+          "tokens": 1,
+          "per_time_unit": "min",
+          "notification_interval": 30
+        }
+      },
+      "nodeHealth": {
+        "missing_heartbeat_interval": 600,
+        "check_agreement_status": 120
+      }
+    }
+

--- a/cli/samples/pattern-workloads.json
+++ b/cli/samples/pattern-workloads.json
@@ -1,13 +1,13 @@
 {
   "label": "Cpu2wiotp for amd64 and arm",
-  "description": "Horizon deployment pattern that runs the cpu2wiotp service",
+  "description": "Horizon deployment pattern that runs the cpu2wiotp workload",
   "public": true,
-  "services": [
+  "workloads": [
     {
-      "serviceUrl": "https://internetofthings.ibmcloud.com/services/cpu2wiotp",
-      "serviceOrgid": "IBM",
-      "serviceArch": "amd64",
-      "serviceVersions": [
+      "workloadUrl": "https://internetofthings.ibmcloud.com/workloads/cpu2wiotp",
+      "workloadOrgid": "IBM",
+      "workloadArch": "amd64",
+      "workloadVersions": [
         {
           "version": "1.1.3",
           "deployment_overrides": {},
@@ -22,10 +22,10 @@
       }
     },
     {
-      "serviceUrl": "https://internetofthings.ibmcloud.com/services/cpu2wiotp",
-      "serviceOrgid": "IBM",
-      "serviceArch": "arm",
-      "serviceVersions": [
+      "workloadUrl": "https://internetofthings.ibmcloud.com/workloads/cpu2wiotp",
+      "workloadOrgid": "IBM",
+      "workloadArch": "arm",
+      "workloadVersions": [
         {
           "version": "1.1.3",
           "deployment_overrides": {},

--- a/cli/samples/service.json
+++ b/cli/samples/service.json
@@ -1,0 +1,38 @@
+{
+  "label": "Cpu2wiotp for x86_64",
+  "description": "Sample Horizon service that repeatedly reads the CPU load and sends it to WIoTP",
+  "public": true,
+  "url": "https://internetofthings.ibmcloud.com/services/cpu2wiotp",
+  "version": "1.1.3",
+  "arch": "amd64",
+  "sharable": "single",
+  "requiredServices": [
+    {
+      "url": "https://internetofthings.ibmcloud.com/services/cpu",
+      "org": "IBM",
+      "version": "[0.0.0,INFINITY)",
+      "arch": "amd64"
+    }
+  ],
+  "userInput": [
+    {
+      "name": "WIOTP_DEVICE_AUTH_TOKEN",
+      "label": "The token you gave to the device or gateway you created in the WIoTP UI",
+      "type": "string"
+    }
+  ],
+  "deployment": {
+    "services": {
+      "cpu2wiotp": {
+        "image": "openhorizon/example_wl_x86_cpu2wiotp:1.1.3",
+        "environment": [
+          "WIOTP_DOMAIN=internetofthings.ibmcloud.com"
+        ]
+      }
+    }
+  },
+  "deployment_signature": "",
+  "imageStore": {
+    "storeType": "dockerRegistry"
+  }
+}

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -10,42 +10,36 @@ import (
 	"github.com/open-horizon/anax/policy"
 )
 
-type APIMicroservices struct {
-	Config      []api.APIMicroserviceConfig `json:"config"`      // the microservice configurations
-	Instances   map[string][]interface{}    `json:"instances"`   // the microservice instances that are running
-	Definitions map[string][]interface{}    `json:"definitions"` // the definitions of microservices from the exchange
-}
-
-// Not using policy.APISpecification, because it includes a field ExclusiveAccess that is filled in in various parts of the code that we can't easily duplicate
-type APISpecification struct {
-	SpecRef string `json:"specRef"`      // A URL pointing to the definition of the API spec
-	Org     string `json:"organization"` // The organization where the microservice is defined
-	Version string `json:"version"`      // The version of the API spec in OSGI version format
-	Arch    string `json:"arch"`         // The hardware architecture of the API spec impl. Added in version 2.
+type APIServices struct {
+	Config []api.APIMicroserviceConfig `json:"config"` // the microservice configurations
+	//Instances   map[string][]interface{}    `json:"instances"`   // the microservice instances that are running
+	//Definitions map[string][]interface{}    `json:"definitions"` // the definitions of microservices from the exchange
 }
 
 type OurService struct {
-	APISpecs  []APISpecification     `json:"apiSpec"` // removed omitempty
+	Url       string                 `json:"url"`     // A URL pointing to the definition of the service
+	Org       string                 `json:"org"`     // The organization where the service is defined
+	Version   string                 `json:"version"` // The version of the service in OSGI version format
+	Arch      string                 `json:"arch"`    // The hardware architecture of the service impl
 	Variables map[string]interface{} `json:"variables"`
 }
 
 func List() {
 	// Get the services
-	var apiOutput APIMicroservices
+	var apiOutput APIServices
 	// Note: intentionally querying /microservice, instead of just /microservice/config, because in the future we will probably want to mix in some key runtime info
-	httpCode := cliutils.HorizonGet("microservice", []int{200, cliutils.ANAX_NOT_CONFIGURED_YET}, &apiOutput)
+	httpCode := cliutils.HorizonGet("service/config", []int{200, cliutils.ANAX_NOT_CONFIGURED_YET}, &apiOutput)
 	//todo: i think config can be queried even before the node is registered?
 	if httpCode == cliutils.ANAX_NOT_CONFIGURED_YET {
 		cliutils.Fatal(cliutils.HTTP_ERROR, cliutils.MUST_REGISTER_FIRST)
 	}
-	apiServices := apiOutput.Config
 
 	// Go thru the services and pull out interesting fields
 	services := make([]OurService, 0)
-	for _, s := range apiServices {
-		serv := OurService{Variables: make(map[string]interface{})}
-
+	for _, s := range apiOutput.Config {
 		arch := cutil.ArchString()
+		serv := OurService{Url: s.SensorUrl, Org: s.SensorOrg, Version: s.SensorVersion, Arch: arch, Variables: make(map[string]interface{})}
+
 		for _, attr := range s.Attributes {
 			if b_attr, err := json.Marshal(attr); err != nil {
 				cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal '/microservice/config' output attribute %v. %v", attr, err)
@@ -57,7 +51,7 @@ func List() {
 				switch a.(type) {
 				case persistence.ArchitectureAttributes:
 					// get arch
-					arch = a.(persistence.ArchitectureAttributes).Architecture
+					serv.Arch = a.(persistence.ArchitectureAttributes).Architecture
 				case persistence.UserInputAttributes:
 					// get user input
 					serv.Variables = a.GetGenericMappings()
@@ -65,7 +59,6 @@ func List() {
 			}
 		}
 
-		serv.APISpecs = append(serv.APISpecs, APISpecification{SpecRef: s.SensorUrl, Org: s.SensorOrg, Version: s.SensorVersion, Arch: arch})
 		services = append(services, serv)
 	}
 

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -80,7 +80,7 @@ func List() {
 func Registered() {
 	// The registered microservices are listed as policies
 	apiOutput := make(map[string]policy.Policy)
-	httpCode := cliutils.HorizonGet("microservice/policy", []int{200, cliutils.ANAX_NOT_CONFIGURED_YET}, &apiOutput)
+	httpCode := cliutils.HorizonGet("service/policy", []int{200, cliutils.ANAX_NOT_CONFIGURED_YET}, &apiOutput)
 	if httpCode == cliutils.ANAX_NOT_CONFIGURED_YET {
 		cliutils.Fatal(cliutils.HTTP_ERROR, cliutils.MUST_REGISTER_FIRST)
 	}


### PR DESCRIPTION
Fixed:
- `hzn exchange service publish` and could not find /usr/horizon/samples/service.json file.
- `hzn exchange pattern publish` does not work for service based. And the sample file does not show the how to put services in the pattern.
- `hzn exchange pattern list` does not work for service based patterns.
- `hzn exchange pattern verify` does not work for service based patterns.
- `hzn register` does not work for service based if there is input file.
- `hzn service list` and `hzn service registered` do not show anything