### PR TITLE
Issue 444 - Support sharable=single services

### DIFF
--- a/api/container.go
+++ b/api/container.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Get docker container metadata from the docker API for workload containers
-func GetWorkloadContainers(dockerEndpoint string) ([]dockerclient.APIContainers, error) {
+func GetWorkloadContainers(dockerEndpoint string, agreementId string) ([]dockerclient.APIContainers, error) {
 	if client, err := dockerclient.NewClient(dockerEndpoint); err != nil {
 		return nil, errors.New(fmt.Sprintf("unable to create docker client from %v, error %v", dockerEndpoint, err))
 	} else {
@@ -24,6 +24,10 @@ func GetWorkloadContainers(dockerEndpoint string) ([]dockerclient.APIContainers,
 			for _, c := range containers {
 				if _, exists := c.Labels["network.bluehorizon.colonus.service_name"]; exists {
 					if _, exists := c.Labels["network.bluehorizon.colonus.infrastructure"]; !exists {
+						// If we are filtering by agreement id, then check the agreement id label
+						if agreementId != "" && (c.Labels["network.bluehorizon.colonus.agreement_id"] != agreementId) {
+							continue
+						}
 						ret = append(ret, c)
 					}
 				}

--- a/api/output.go
+++ b/api/output.go
@@ -63,6 +63,7 @@ func NewMicroserviceInstanceOutput(mi persistence.MicroserviceInstance, containe
 }
 
 func NewAgreementServiceInstanceOutput(ag *persistence.EstablishedAgreement, containers *[]dockerclient.APIContainers) *MicroserviceInstanceOutput {
+	sipe := persistence.NewServiceInstancePathElement(ag.RunningWorkload.URL, ag.RunningWorkload.Version)
 	mi := persistence.MicroserviceInstance{
 		SpecRef:              ag.RunningWorkload.URL,
 		Version:              ag.RunningWorkload.Version,
@@ -76,6 +77,7 @@ func NewAgreementServiceInstanceOutput(ag *persistence.EstablishedAgreement, con
 		CleanupStartTime:     ag.AgreementTerminatedTime,
 		AssociatedAgreements: []string{ag.CurrentAgreementId},
 		MicroserviceDefId:    "",
+		ParentPath:           [][]persistence.ServiceInstancePathElement{[]persistence.ServiceInstancePathElement{*sipe}},
 	}
 
 	return &MicroserviceInstanceOutput{

--- a/api/path_service.go
+++ b/api/path_service.go
@@ -66,7 +66,7 @@ func FindServicesForOutput(pm *policy.PolicyManager,
 		if agInst.Archived {
 			wrap.Instances[archivedKey] = append(wrap.Instances[archivedKey], *NewAgreementServiceInstanceOutput(&agInst, nil))
 		} else {
-			containers, err := GetMicroserviceContainer(config.Edge.DockerEndpoint, agInst.RunningWorkload.URL)
+			containers, err := GetWorkloadContainers(config.Edge.DockerEndpoint, agInst.CurrentAgreementId)
 			if err != nil {
 				return nil, errors.New(fmt.Sprintf("unable to get docker container info, error %v", err))
 			}

--- a/api/path_workload.go
+++ b/api/path_workload.go
@@ -18,7 +18,7 @@ func FindWorkloadForOutput(db *bolt.DB, config *config.HorizonConfig) (*AllWorkl
 
 	work.Config = cfgs["config"]
 
-	containers, err := GetWorkloadContainers(config.Edge.DockerEndpoint)
+	containers, err := GetWorkloadContainers(config.Edge.DockerEndpoint, "")
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("unable to get running workload containers, error %v", err))
 	}

--- a/ethblockchain/blockchainworker.go
+++ b/ethblockchain/blockchainworker.go
@@ -511,7 +511,7 @@ func (w *EthBlockchainWorker) fireStartEvent(details *exchange.ChainDetails, nam
 		cc := events.NewContainerConfig(*url, details.DeploymentDesc.Torrent.Signature, details.DeploymentDesc.Deployment, details.DeploymentDesc.DeploymentSignature, details.DeploymentDesc.DeploymentUserInfo, "")
 		envAdds := w.computeEnvVarsForContainer(details)
 		w.SetColonusDir(name, envAdds["COLONUS_DIR"])
-		lc := events.NewContainerLaunchContext(cc, &envAdds, events.BlockchainConfig{Type: CHAIN_TYPE, Name: name}, name, "", []events.MicroserviceSpec{})
+		lc := events.NewContainerLaunchContext(cc, &envAdds, events.BlockchainConfig{Type: CHAIN_TYPE, Name: name}, name, "", []events.MicroserviceSpec{}, nil)
 		w.BaseWorker.Manager.Messages <- events.NewLoadContainerMessage(events.LOAD_CONTAINER, lc)
 
 		return nil

--- a/events/events.go
+++ b/events/events.go
@@ -159,11 +159,12 @@ type ContainerLaunchContext struct {
 	Blockchain           BlockchainConfig
 	Name                 string // used as the docker network name and part of container name. For microservice it is the ms instance key
 	AgreementId          string
-	Microservices        []MicroserviceSpec // Service dependencies go here. Microservices (in the workload/microservice model) never have dependencies.
+	Microservices        []MicroserviceSpec                     // Service dependencies go here. Microservices (in the workload/microservice model) never have dependencies.
+	ServicePathElement   persistence.ServiceInstancePathElement // The service that we're trying to start.
 }
 
 func (c ContainerLaunchContext) String() string {
-	return fmt.Sprintf("ContainerConfig: %v, EnvironmentAdditions: %v, Blockchain: %v, Name: %v, AgreementId: %v, ServiceDependencies: %v", c.Configure, c.EnvironmentAdditions, c.Blockchain, c.Name, c.AgreementId, c.Microservices)
+	return fmt.Sprintf("ContainerConfig: %v, EnvironmentAdditions: %v, Blockchain: %v, Name: %v, AgreementId: %v, ServiceDependencies: %v, ThisService: %v", c.Configure, c.EnvironmentAdditions, c.Blockchain, c.Name, c.AgreementId, c.Microservices, c.ServicePathElement)
 }
 
 func (c ContainerLaunchContext) ShortString() string {
@@ -182,7 +183,11 @@ func (c ContainerLaunchContext) GetMicroservices() []MicroserviceSpec {
 	return c.Microservices
 }
 
-func NewContainerLaunchContext(config *ContainerConfig, envAdds *map[string]string, bc BlockchainConfig, name string, agId string, mss []MicroserviceSpec) *ContainerLaunchContext {
+func (c ContainerLaunchContext) GetServicePathElement() *persistence.ServiceInstancePathElement {
+	return &c.ServicePathElement
+}
+
+func NewContainerLaunchContext(config *ContainerConfig, envAdds *map[string]string, bc BlockchainConfig, name string, agId string, mss []MicroserviceSpec, spe *persistence.ServiceInstancePathElement) *ContainerLaunchContext {
 	return &ContainerLaunchContext{
 		Configure:            *config,
 		EnvironmentAdditions: envAdds,
@@ -190,6 +195,7 @@ func NewContainerLaunchContext(config *ContainerConfig, envAdds *map[string]stri
 		Name:                 name,
 		AgreementId:          agId,
 		Microservices:        mss,
+		ServicePathElement:   *spe,
 	}
 }
 

--- a/microservice/microservice.go
+++ b/microservice/microservice.go
@@ -189,6 +189,15 @@ func ConvertServiceToPersistent(es *exchange.ServiceDefinition, org string) (*pe
 	return pms, nil
 }
 
+func ConvertRequiredServicesToExchange(m *persistence.MicroserviceDefinition) *[]exchange.ServiceDependency {
+	reqServs := make([]exchange.ServiceDependency, 0)
+	for _, rs := range m.RequiredServices {
+		sd := exchange.ServiceDependency{URL: rs.URL, Org: rs.Org, Version: rs.Version, Arch: rs.Arch}
+		reqServs = append(reqServs, sd)
+	}
+	return &reqServs
+}
+
 // check if the given msdef is eligible for a upgrade
 func MicroserviceReadyForUpgrade(msdef *persistence.MicroserviceDefinition, db *bolt.DB) bool {
 	glog.V(5).Infof("Check if microservice is available for a upgrade: %v.", msdef.SpecRef)

--- a/microservice/microservice_test.go
+++ b/microservice/microservice_test.go
@@ -62,7 +62,7 @@ func TestMicroserviceReadyForUpgrade(t *testing.T) {
 	pms.UpgradeStartTime = uint64(0)
 
 	pms.Id = "1"
-	msi, err := persistence.NewMicroserviceInstance(db, pms.SpecRef, pms.Version, pms.Id)
+	msi, err := persistence.NewMicroserviceInstance(db, pms.SpecRef, pms.Version, pms.Id, []persistence.ServiceInstancePathElement{})
 	assert.Nil(t, err, fmt.Sprintf("should not return error, but got this: %v", err))
 
 	pms.AutoUpgrade = true

--- a/persistence/microservices_test.go
+++ b/persistence/microservices_test.go
@@ -1,0 +1,208 @@
+// +build unit
+
+package persistence
+
+import (
+	"github.com/boltdb/bolt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+)
+
+// Parent and child, simple case.
+func Test_ServiceInstancePath_HasDirectParent_simple(t *testing.T) {
+
+	// Setup the DB for the UT environment
+	dir, db, err := utsetup()
+	if err != nil {
+		t.Errorf("Error setting up UT DB: %v", err)
+	}
+
+	defer cleanTestDir(dir)
+
+	// Setup initial variable values
+	parentURL := "url1"
+	parentVersion := "1.0.0"
+	childURL := "url2"
+	childVersion := "2.0.0"
+
+	// Establish the dependency path objects
+	parent := NewServiceInstancePathElement(parentURL, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childVersion)
+
+	depPath := []ServiceInstancePathElement{*parent, *child}
+	// Create the test microservice instance to represent the child
+	if msi, err := NewMicroserviceInstance(db, childURL, childVersion, "1234", depPath); err != nil {
+		t.Errorf("Error creating instance: %v", err)
+	} else if !msi.HasDirectParent(parent) {
+		t.Errorf("Child %v has direct parent: %v", child, depPath)
+	}
+}
+
+// Parent is not in child's dependency path
+func Test_ServiceInstancePath_HasDirectParent_fail1(t *testing.T) {
+
+	// Setup the DB for the UT environment
+	dir, db, err := utsetup()
+	if err != nil {
+		t.Errorf("Error setting up UT DB: %v", err)
+	}
+
+	defer cleanTestDir(dir)
+
+	// Setup initial variable values
+	parentURL := "url1"
+	parentVersion := "1.0.0"
+	childURL := "url2"
+	childVersion := "2.0.0"
+
+	// Establish the dependency path objects
+	parent := NewServiceInstancePathElement(parentURL, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childVersion)
+
+	notParent := NewServiceInstancePathElement("other", parentVersion)
+
+	depPath := []ServiceInstancePathElement{*parent, *child}
+	// Create the test microservice instance to represent the child
+	if msi, err := NewMicroserviceInstance(db, childURL, childVersion, "1234", depPath); err != nil {
+		t.Errorf("Error creating instance: %v", err)
+	} else if msi.HasDirectParent(notParent) {
+		t.Errorf("Child %v does not have direct parent: %v", child, depPath)
+	}
+}
+
+// Parent is in child dependency path, but not directly the child's parent.
+func Test_ServiceInstancePath_HasDirectParent_fail2(t *testing.T) {
+
+	// Setup the DB for the UT environment
+	dir, db, err := utsetup()
+	if err != nil {
+		t.Errorf("Error setting up UT DB: %v", err)
+	}
+
+	defer cleanTestDir(dir)
+
+	// Setup initial variable values
+	parentURL := "url1"
+	parentVersion := "1.0.0"
+	childURL := "url2"
+	childVersion := "2.0.0"
+	child2URL := "url3"
+	child2Version := "3.0.0"
+
+	// Establish the dependency path objects
+	parent := NewServiceInstancePathElement(parentURL, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Version)
+
+	depPath := []ServiceInstancePathElement{*parent, *child, *child2}
+	// Create the test microservice instance to represent the child
+	if msi, err := NewMicroserviceInstance(db, child2URL, child2Version, "1234", depPath); err != nil {
+		t.Errorf("Error creating instance: %v", err)
+	} else if msi.HasDirectParent(parent) {
+		t.Errorf("Child %v does not have direct parent: %v", child2, depPath)
+	}
+}
+
+// Parent is not in either of child's dependency paths.
+func Test_ServiceInstancePath_HasDirectParent_fail3(t *testing.T) {
+
+	// Setup the DB for the UT environment
+	dir, db, err := utsetup()
+	if err != nil {
+		t.Errorf("Error setting up UT DB: %v", err)
+	}
+
+	defer cleanTestDir(dir)
+
+	// Setup initial variable values
+	parentURL := "url1"
+	parentVersion := "1.0.0"
+	childURL := "url2"
+	childVersion := "2.0.0"
+	child2URL := "url3"
+	child2Version := "3.0.0"
+
+	// Establish the dependency path objects
+	parent := NewServiceInstancePathElement(parentURL, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Version)
+
+	notParent := NewServiceInstancePathElement("other", parentVersion)
+
+	depPath := []ServiceInstancePathElement{*parent, *child, *child2}
+	dp2 := []ServiceInstancePathElement{*parent, *child2}
+
+	// Create the test microservice instance to represent the child
+	if msi, err := NewMicroserviceInstance(db, child2URL, child2Version, "1234", depPath); err != nil {
+		t.Errorf("Error creating instance: %v", err)
+	} else if _, err := UpdateMSInstanceAddDependencyPath(db, msi.GetKey(), &dp2); err != nil {
+		t.Errorf("Error updating instance: %v", err)
+	} else if msi.HasDirectParent(notParent) {
+		t.Errorf("Child %v does not have direct parent: %v %v", child2, depPath, dp2)
+	}
+}
+
+// Parent is in second of child's dependency paths.
+func Test_ServiceInstancePath_HasDirectParent_second(t *testing.T) {
+
+	// Setup the DB for the UT environment
+	dir, db, err := utsetup()
+	if err != nil {
+		t.Errorf("Error setting up UT DB: %v", err)
+	}
+
+	defer cleanTestDir(dir)
+
+	// Setup initial variable values
+	parentURL := "url1"
+	parentVersion := "1.0.0"
+	childURL := "url2"
+	childVersion := "2.0.0"
+	child2URL := "url3"
+	child2Version := "3.0.0"
+
+	// Establish the dependency path objects
+	parent := NewServiceInstancePathElement(parentURL, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Version)
+
+	depPath := []ServiceInstancePathElement{*parent, *child, *child2}
+	dp2 := []ServiceInstancePathElement{*parent, *child2}
+
+	// Create the test microservice instance to represent the child
+	if msi, err := NewMicroserviceInstance(db, child2URL, child2Version, "1234", depPath); err != nil {
+		t.Errorf("Error creating instance: %v", err)
+	} else if newmsi, err := UpdateMSInstanceAddDependencyPath(db, msi.GetKey(), &dp2); err != nil {
+		t.Errorf("Error updating instance: %v", err)
+	} else if !newmsi.HasDirectParent(parent) {
+		t.Errorf("Child %v does have direct parent: %v", child2, dp2)
+	}
+}
+
+// Utility functions needed by tests
+func utsetup() (string, *bolt.DB, error) {
+	dir, err := ioutil.TempDir("", "utdb-")
+	if err != nil {
+		return "", nil, err
+	}
+
+	db, err := bolt.Open(path.Join(dir, "anax-ut.db"), 0600, &bolt.Options{Timeout: 10 * time.Second})
+	if err != nil {
+		return dir, nil, err
+	}
+
+	return dir, db, nil
+}
+
+// Make a deferred call to this function after calling setup(), passing the output dirpath of the setup() function.
+func cleanTestDir(dirPath string) error {
+	if _, err := os.Stat(dirPath); !os.IsNotExist(err) {
+		if err := os.RemoveAll(dirPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Supports sharable=multiple for dependency trees where the service is referred to more than once.

Also fixes the GET /service output in the instances section to properly display containers for agreement services.