### PR TITLE
improvements to anax container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ CLI_MAN_DIR := cli/man1
 CLI_COMPLETION_DIR := cli/bash_completion
 DEFAULT_UI = api/static/index.html
 ANAX_CONTAINER_DIR := anax-in-container
-DOCKER_IMAGE_VERSION ?= 0.5.1
+DOCKER_IMAGE_VERSION ?= 2.17.5
 DOCKER_IMAGE = openhorizon/$(arch)_anax:$(DOCKER_IMAGE_VERSION)
+DOCKER_IMAGE_LATEST = openhorizon/$(arch)_anax:latest
 # To not use cache, so it picks up the latest horizon deb pkgs: DOCKER_MAYBE_CACHE='--no-cache' make docker-image
 DOCKER_MAYBE_CACHE ?=
 
@@ -73,11 +74,15 @@ $(CLI_EXECUTABLE): $(shell find . -name '*.go' -not -path './vendor/*') gopathli
 
 docker-image:
 	@echo "Producing anax docker image $(DOCKER_IMAGE)"
-	if [[ $(arch) == "amd64" ]]; then cd $(ANAX_CONTAINER_DIR) && docker build $(DOCKER_MAYBE_CACHE) -t $(DOCKER_IMAGE) -f ./Dockerfile.$(arch) .; else echo "Building the anax docker image is not supported on $(arch)"; fi
+	if [[ $(arch) == "amd64" ]]; then \
+	  cd $(ANAX_CONTAINER_DIR) && docker build $(DOCKER_MAYBE_CACHE) -t $(DOCKER_IMAGE) -f ./Dockerfile.$(arch) . && \
+	  docker tag $(DOCKER_IMAGE) $(DOCKER_IMAGE_LATEST); \
+	else echo "Building the anax docker image is not supported on $(arch)"; fi
 
 docker-push: docker-image
 	@echo "Pushing anax docker image $(DOCKER_IMAGE)"
 	docker push $(DOCKER_IMAGE)
+	docker push $(DOCKER_IMAGE_LATEST)
 
 clean: mostlyclean
 	@echo "Clean"

--- a/anax-in-container/README.md
+++ b/anax-in-container/README.md
@@ -28,11 +28,10 @@ make docker-push
 **Note: we haven't actually tested this case yet.**
 
 ```
-export ANAX_CONTAINER_VERSION=0.5.1    # or what is the latest
 sudo bash -c 'mkdir -p /etc/wiotp-edge /var/wiotp-edge && chmod 777 /etc/wiotp-edge /var/wiotp-edge'
 mkdir -p /var/tmp/horizon/service_storage    # anax will check for this, because this will be mounted into service containers
-docker pull openhorizon/amd64_anax:$ANAX_CONTAINER_VERSION
-docker run -d -t --name amd64_anax --privileged -p 127.0.0.1:8081:80 -v /var/run/docker.sock:/var/run/docker.sock -v /etc/wiotp-edge:/etc/wiotp-edge -v /var/wiotp-edge:/var/wiotp-edge openhorizon/amd64_anax:$ANAX_CONTAINER_VERSION
+docker pull openhorizon/amd64_anax
+docker run -d -t --name amd64_anax --privileged -p 127.0.0.1:8081:80 -v /var/run/docker.sock:/var/run/docker.sock -v /var/tmp/horizon:/var/tmp/horizon -v /etc/wiotp-edge:/etc/wiotp-edge -v /var/wiotp-edge:/var/wiotp-edge openhorizon/amd64_anax /root/wiotp-env.sh
 export HORIZON_URL='http://localhost:8081'    # to point the hzn cmd to the container
 docker exec amd64_anax bash   # enter the container
 wiotp_agent_setup --org $HZN_ORG_ID --deviceType $WIOTP_GW_TYPE --deviceId $WIOTP_GW_ID --deviceToken "$WIOTP_GW_TOKEN" -cn 'edge-connector'
@@ -43,14 +42,12 @@ hzn agreement list
 ## Using the Anax Container for the Bluehorizon/WIoTP Hyrbrid Environment
 
 ```
-export ANAX_CONTAINER_VERSION=0.5.1    # or what is the latest
 sudo bash -c 'mkdir -p /etc/wiotp-edge /var/wiotp-edge && chmod 777 /etc/wiotp-edge /var/wiotp-edge'
 mkdir -p /var/tmp/horizon/service_storage    # anax will check for this, because this will be mounted into service containers
-docker pull openhorizon/amd64_anax:$ANAX_CONTAINER_VERSION
-docker run -d -t --name amd64_anax --privileged -p 127.0.0.1:8081:80 -v /var/run/docker.sock:/var/run/docker.sock -v /etc/wiotp-edge:/etc/wiotp-edge -v /var/wiotp-edge:/var/wiotp-edge -v `pwd`:/outside openhorizon/amd64_anax:$ANAX_CONTAINER_VERSION /root/bluehorizon-env.sh
+docker pull openhorizon/amd64_anax
+docker run -d -t --name amd64_anax --privileged -p 127.0.0.1:8081:80 -v /var/run/docker.sock:/var/run/docker.sock -v /var/tmp/horizon:/var/tmp/horizon -v /etc/wiotp-edge:/etc/wiotp-edge -v /var/wiotp-edge:/var/wiotp-edge -v `pwd`:/outside openhorizon/amd64_anax /root/bluehorizon-env.sh "$WIOTP_GW_TOKEN"
 export HORIZON_URL='http://localhost:8081'    # to point the hzn cmd to the container
 hzn node list   # ensure you talking to the container, and the bluehorizon-env.sh config script ran
-docker exec amd64_anax wiotp_create_certificate -p $WIOTP_GW_TOKEN
 hzn register -n $EXCHANGE_NODEAUTH -f ~/examples/edge/wiotp/location2wiotp/horizon/userinput-service.json $HZN_ORG_ID $WIOTP_GW_TYPE
 hzn agreement list
 ```
@@ -60,10 +57,10 @@ hzn agreement list
 **Note: you currently can't have both instances of anax running the core-iot service, because the core-iot containers collide on ports, /etc/wiotp-edge, and /var/wiotp-edge.**
 
 ```
-export ANAX_CONTAINER_VERSION=0.5.1    # or what is the latest
-docker pull openhorizon/amd64_anax:$ANAX_CONTAINER_VERSION
+# TODO: set Edge.MultipleAnaxInstances
+docker pull openhorizon/amd64_anax
 # Note the slightly different container name and port number in the next 2 cmds
-docker run -d -t --name amd64_anax2 --privileged -p 127.0.0.1:8082:80 -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:/outside openhorizon/amd64_anax:$ANAX_CONTAINER_VERSION /root/bluehorizon-env.sh
+docker run -d -t --name amd64_anax2 --privileged -p 127.0.0.1:8082:80 -v /var/run/docker.sock:/var/run/docker.sock -v /var/tmp/horizon:/var/tmp/horizon -v `pwd`:/outside openhorizon/amd64_anax /root/bluehorizon-env.sh
 export HORIZON_URL='http://localhost:8082'    # to point the hzn cmd to the container
 hzn node list   # ensure you talking to the right container, and the bluehorizon-env.sh config script ran
 hzn register -n $EXCHANGE_NODEAUTH $HZN_ORG_ID $WIOTP_GW_TYPE -f ~/examples/edge/wiotp/location2wiotp/horizon/without-core-iot/userinput.json
@@ -72,19 +69,23 @@ hzn agreement list
 
 ## Experimental: Using the Anax Container on Mac for the Bluehorizon/WIoTP Hyrbrid Environment
 
-**Note: this doesn't quite work yet, because docker can't configure the unix syslog driver. See: https://github.com/open-horizon/anax/issues/628**
-
 ```
-export ANAX_CONTAINER_VERSION=0.5.1    # or what is the latest
 export MAC_HOST=192.168.1.12   # whatever your mac IP address is
 socat TCP-LISTEN:2375,reuseaddr,fork UNIX-CONNECT:/var/run/docker.sock &   # have docker api listen on a port, in addition to a unix socket
-sudo bash -c 'mkdir -p /private/etc/wiotp-edge /private/var/wiotp-edge && chmod 777 /private/etc/wiotp-edge /private/var/wiotp-edge'
+# Note: we let docker create /etc/wiotp-edge and /var/wiotp-edge automatically, in its VM tmpfs
 mkdir -p /private/var/tmp/horizon/service_storage    # anax will check for this, because this will be mounted into service containers
-docker pull openhorizon/amd64_anax:$ANAX_CONTAINER_VERSION
-docker run -d -t --name amd64_anax --privileged -p 127.0.0.1:8081:80 -e MAC_HOST=$MAC_HOST -v /private/var/tmp/horizon:/private/var/tmp/horizon -v /private/etc/wiotp-edge:/etc/wiotp-edge -v /private/var/wiotp-edge:/var/wiotp-edge -v `pwd`:/outside openhorizon/amd64_anax:$ANAX_CONTAINER_VERSION /root/bluehorizon-env.sh
+docker pull openhorizon/amd64_anax
+docker run -d -t --name amd64_anax --privileged -p 127.0.0.1:8081:80 -e MAC_HOST=$MAC_HOST -v /private/var/tmp/horizon:/private/var/tmp/horizon -v /etc/wiotp-edge:/etc/wiotp-edge -v /var/wiotp-edge:/var/wiotp-edge -v `pwd`:/outside openhorizon/amd64_anax /root/bluehorizon-env.sh "$WIOTP_GW_TOKEN"
 export HORIZON_URL='http://localhost:8081'    # to point the hzn cmd to the container
 hzn node list   # ensure you talking to the container, and the bluehorizon-env.sh config script ran
-docker exec amd64_anax wiotp_create_certificate -p $WIOTP_GW_TOKEN
 hzn register -n $EXCHANGE_NODEAUTH -f ~/input/services/core-iot-input.json $HZN_ORG_ID $WIOTP_GW_TYPE
 hzn agreement list
+```
+
+## Experimental: Support for 'hzn dev' on Mac
+
+If you install go and docker on your mac, clone https://github.com/open-horizon/anax and 'make cli/hzn', you can use `hzn dev` on your mac. If you are developing services that use the WIoTP core-iot service, you can get the `/etc/wiotp-edge` and `/var/wiotp-edge` directories populated using:
+```
+docker pull openhorizon/amd64_anax
+docker run -t --rm --name amd64_anax --privileged -v /etc/wiotp-edge:/etc/wiotp-edge -v /var/wiotp-edge:/var/wiotp-edge openhorizon/amd64_anax only_certificate "$WIOTP_GW_TOKEN"
 ```

--- a/anax-in-container/service/anax.service
+++ b/anax-in-container/service/anax.service
@@ -2,12 +2,19 @@
 
 # Script to start, restart, and stop anax inside a docker container
 
+# Note: this won't run while we are blocking on a foreground cmd. Have to run anax in background and use wait.
+trap 'echo "Unregistering..."; /usr/bin/hzn unregister -f; echo "Done. Exiting..."; exit 0' SIGTERM
+
 ANAX_LOG_LEVEL=${ANAX_LOG_LEVEL:-3}
 
 usage() {
-	echo "Usage: $0 {start|restart|status} [env-script-to-run]"
+	echo "Usage: $0 {start|restart|status|block} [env-script-to-run] [gw-token]"
 	exit 1
 }
+
+cmd="$1"
+envScript="$2"
+token="$3"
 
 # Check the exit status of the previously run command and exit if nonzero
 checkrc() {
@@ -22,41 +29,23 @@ checkrc() {
   fi
 }
 
-start() {
-	while true; do
-		cmd="/usr/horizon/bin/anax -v $ANAX_LOG_LEVEL -logtostderr -config /etc/horizon/anax.json"
-		echo "$cmd"
-		$cmd    # purposely running this in the foreground
-		echo "Anax ended with exit code $?.  Respawning..." >&2
-		sleep 1		# in case the cmd above is failing, this loop won't consume 100% cpu
-	done
-}
-
-# Note: the way to stop anax w/o it restarting is to stop the container
-#stopanax() {
-#	killall /usr/horizon/bin/anax
-#}
-
-restart() {
-	killall /usr/horizon/bin/anax 		# the start function will automatically restart it
-	#stopanax
-	#start
-}
-
-psg() {
-	ps aux|head -1
-	ps aux|grep -i $*|grep -v '0:00 /bin/grep -'
-}
-
-status() {
-	psg /usr/horizon/bin/anax
+createCertificate() {
+	token="$1"
+	echo "Creating the WIoTP certificate with token '$token'..."
+	wiotp_create_certificate -p "$token"
 }
 
 defaultEnv() {
+	token="$1"
+
 	# Now the the host dirs /etc/wiotp-edge and /var/wiotp-edge have been mounted over ours, copy are backup back into them
 	# I don't think we have to check if we have already done this, because i think it is only run on the 1st start of the container
 	cp -a /tmp/etc/wiotp-edge/* /etc/wiotp-edge
 	cp -a /tmp/var/wiotp-edge/* /var/wiotp-edge
+
+	if [[ -n "$token" ]]; then
+		createCertificate "$token"   # create the wiotp certificate
+	fi
 
 	# Update several fields in anax.json
 	anaxJsonFile='/etc/horizon/anax.json'
@@ -90,31 +79,85 @@ defaultEnv() {
 	checkrc $? "write anax.json"
 }
 
-# Main....
-if [[ -z "$1" ]]; then usage; fi
-
-if [[ -n "$2" && "$2" == "DO_NOT_RUN" ]]; then
+block() {
+	echo "Sleeping forever..."
 	while :; do sleep 2073600; done    # block forever w/o starting anax so the container stays up, and you can exec in, start anax manually, and debug
-fi
+}
 
-# Do the config that is specific to running anax in a container, but needed for all environments
-defaultEnv
+start() {
+	envScript="$1"
+	token="$2"
 
-# This argument is an optional script to run to configure anax for a specific development environment before starting it
-if [[ -n "$2" ]]; then
-	# Run the environment config script, then fall thru to start anax
-	envScript="$2"
-	if [[ ! -x "$envScript" ]]; then
-		echo "Error: the environment script to run ($envScript) does not exist, or is not executable."
-		exit 2
+	if [[ -n "$envScript" ]]; then
+		# Handle special case environments
+		if [[ "$envScript" == "block" ]]; then
+			block   # a special case to just sleep forever so we can get into the container and examine it
+		elif [[ "$envScript" == "only_certificate" ]]; then
+			if [[ -z "$token" ]]; then
+				echo "Error: a token must be specified $envScript."
+				exit 2
+			fi
+			createCertificate "$token"   # create the wiotp certificate
+			exit 0
+		fi
 	fi
-	$envScript
-	checkrc $? "running $envScript"
-fi
 
-case "$1" in
+	# Do the config that is specific to running anax in a container, but needed for all environments
+	defaultEnv "$token"    # the optional gw token to create the wiotp certificate with
+
+	# This argument is an optional script to run to configure anax for a specific development environment before starting it
+	if [[ -n "$envScript" ]]; then
+		# Run the environment config script, then fall thru to start anax
+		if [[ ! -x "$envScript" ]]; then
+			echo "Error: the environment script to run ($envScript) does not exist, or is not executable."
+			exit 2
+		fi
+		$envScript
+		checkrc $? "running $envScript"
+	fi
+
+	# Now repeatedly run anax...
+	while true; do
+		anaxCmd="/usr/horizon/bin/anax -v $ANAX_LOG_LEVEL -logtostderr -config /etc/horizon/anax.json"
+		echo "$anaxCmd"
+		# We run this in the background and wait on it using wait, because that's the only way for traps to get control immediately
+		$anaxCmd &
+		pid=$!
+		wait $pid
+		if [[ $? -gt 128 ]]; then
+			# This means a signal interrupted wait. If it was sigterm, then our trap will run immediately, clean up, and exit.
+			# Else, we should go back to waiting on anax
+			wait $pid
+		fi
+		echo "Anax ended with exit code $?.  Respawning..." >&2
+		sleep 1		# in case the cmd above is failing, this loop won't consume 100% cpu
+	done
+}
+
+# Note: the way to stop anax w/o it restarting is to stop the container
+#stopanax() {
+#	killall /usr/horizon/bin/anax
+#}
+
+restart() {
+	killall /usr/horizon/bin/anax 		# the start function will automatically restart it
+	#stopanax
+	#start
+}
+
+psg() {
+	ps aux|head -1
+	ps aux|grep -i $*|grep -v '0:00 /bin/grep -'
+}
+
+status() {
+	psg /usr/horizon/bin/anax
+}
+
+# Main....
+case "$cmd" in
 	start)
-		start
+		start "$envScript" "$token"
 		;;
 	# stop)
 		# stopanax

--- a/anax-in-container/service/bluehorizon-env.sh
+++ b/anax-in-container/service/bluehorizon-env.sh
@@ -30,14 +30,14 @@ anaxJson=$(jq ".Edge.ExchangeURL = \"https://exchange.staging.bluehorizon.networ
 checkrc $? "change ExchangeURL"
 
 # Currently the horizon-wiotp deb pkg either doesn't have these config params at all, or have them set to false because those features are in prod yet.
-anaxJson=$(jq ".Edge.TrustCertUpdatesFromOrg = true" <<< $anaxJson)
-checkrc $? "change TrustCertUpdatesFromOrg"
+#anaxJson=$(jq ".Edge.TrustCertUpdatesFromOrg = true" <<< $anaxJson)
+#checkrc $? "change TrustCertUpdatesFromOrg"
 
 anaxJson=$(jq ".Edge.TrustDockerAuthFromOrg = true" <<< $anaxJson)
 checkrc $? "change TrustDockerAuthFromOrg"
 
-anaxJson=$(jq ".Edge.ServiceUpgradeCheckIntervalS = 300" <<< $anaxJson)
-checkrc $? "change ServiceUpgradeCheckIntervalS"
+#anaxJson=$(jq ".Edge.ServiceUpgradeCheckIntervalS = 300" <<< $anaxJson)
+#checkrc $? "change ServiceUpgradeCheckIntervalS"
 
 # Write the new json back to the file
 echo "$anaxJson" > $anaxJsonFile

--- a/cli/dev/dependency.go
+++ b/cli/dev/dependency.go
@@ -271,9 +271,9 @@ func DependenciesExists(directory string, okToCreate bool) (bool, error) {
 
 // Validate that the dependencies are complete and coherent with the rest of the definitions in the project.
 // Any errors will be returned to the caller.
-func ValidateDependencies(directory string, userInputs *register.InputFile, userInputsFilePath string) error {
+func ValidateDependencies(directory string, userInputs *register.InputFile, userInputsFilePath string, projectType string) error {
 
-	if IsWorkloadProject(directory) {
+	if projectType != SERVICE_COMMAND && (projectType == WORKLOAD_COMMAND || IsWorkloadProject(directory) ) {
 
 		// Get the current project's definition file.
 		d, err := GetWorkloadDefinition(directory)
@@ -311,7 +311,7 @@ func ValidateDependencies(directory string, userInputs *register.InputFile, user
 			}
 		}
 
-	} else if IsServiceProject(directory) {
+	} else if projectType != WORKLOAD_COMMAND && (projectType == SERVICE_COMMAND ||  IsServiceProject(directory) ) {
 
 		d, err := GetServiceDefinition(directory, SERVICE_DEFINITION_FILE)
 		if err != nil {

--- a/cli/dev/utils.go
+++ b/cli/dev/utils.go
@@ -198,7 +198,7 @@ func CommonProjectValidation(dir string, userInputFile string, projectType strin
 	}
 
 	// Validate Dependencies
-	if derr := ValidateDependencies(dir, userInputs, userInputsFilePath); derr != nil {
+	if derr := ValidateDependencies(dir, userInputs, userInputsFilePath, SERVICE_COMMAND); derr != nil {
 		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "'%v %v' project does not validate. %v", projectType, cmd, derr)
 	}
 }


### PR DESCRIPTION
- fixed 1 case in which `hzn dev service start` was looking at `workload.definition.json`
- anax-in-container improvements:
    - added sigterm catching to unregister before the container goes down
    - improved how `/etc/wiotp-edge` and `/var/wiotp-edge` are handled on mac. This enabled `hzn dev` to run services that use core-iot on mac.
    - the anax container now creates the wiotp certificate if it is passed the token on `docker run`
    - added a mode in which the anax container can be run to only create the wiotp certificate, and then will exit. This is in support of `hzn dev`
    - the make target now uses a version that is intended to match horizon's version. And it will also be tagged as `latest`, so users can more easily use it.