### PR TITLE
Issue 747 - Support services that have the same URL/name but come fro…

### DIFF
--- a/agreement/agreement.go
+++ b/agreement/agreement.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/abstractprotocol"
 	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/eventlog"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/exchange"
@@ -240,22 +241,22 @@ func (w *AgreementWorker) CommandHandler(command worker.Command) bool {
 			protocols := strings.Join(a_protocols, ",")
 
 			eventlog.LogAgreementEvent2(w.db, persistence.SEVERITY_INFO,
-				fmt.Sprintf("Start policy advertising with the exchange for service %v.", newPolicy.APISpecs[0].SpecRef),
+				fmt.Sprintf("Start policy advertising with the exchange for service %v/%v.", newPolicy.APISpecs[0].Org, newPolicy.APISpecs[0].SpecRef),
 				persistence.EC_START_POLICY_ADVERTISING,
-				"", persistence.WorkloadInfo{}, []string{newPolicy.APISpecs[0].SpecRef}, "", protocols)
+				"", persistence.WorkloadInfo{}, newPolicy.APISpecs.AsStringArray(), "", protocols)
 			// Publish what we have for the world to see
 			if err := w.advertiseAllPolicies(w.BaseWorker.Manager.Config.Edge.PolicyPath); err != nil {
 				eventlog.LogAgreementEvent2(w.db, persistence.SEVERITY_ERROR,
-					fmt.Sprintf("Unable to advertise policies with exchange for service %v, error: %v", newPolicy.APISpecs[0].SpecRef, err),
+					fmt.Sprintf("Unable to advertise policies with exchange for service %v/%v, error: %v", newPolicy.APISpecs[0].Org, newPolicy.APISpecs[0].SpecRef, err),
 					persistence.EC_ERROR_POLICY_ADVERTISING,
-					"", persistence.WorkloadInfo{}, []string{newPolicy.APISpecs[0].SpecRef}, "", protocols)
+					"", persistence.WorkloadInfo{}, newPolicy.APISpecs.AsStringArray(), "", protocols)
 
 				glog.Warningf(logString(fmt.Sprintf("unable to advertise policies with exchange, error: %v", err)))
 			} else {
 				eventlog.LogAgreementEvent2(w.db, persistence.SEVERITY_INFO,
-					fmt.Sprintf("Complete policy advertising with the exchange for service %v.", newPolicy.APISpecs[0].SpecRef),
+					fmt.Sprintf("Complete policy advertising with the exchange for service %v/%v.", newPolicy.APISpecs[0].Org, newPolicy.APISpecs[0].SpecRef),
 					persistence.EC_COMPLETE_POLICY_ADVERTISING,
-					"", persistence.WorkloadInfo{}, []string{newPolicy.APISpecs[0].SpecRef}, "", protocols)
+					"", persistence.WorkloadInfo{}, newPolicy.APISpecs.AsStringArray(), "", protocols)
 			}
 		}
 
@@ -708,7 +709,7 @@ func (w *AgreementWorker) advertiseAllPolicies(location string) error {
 		ms := make([]exchange.Microservice, 0, 10)
 		for _, p := range policies {
 			newMS := new(exchange.Microservice)
-			newMS.Url = p.APISpecs[0].SpecRef
+			newMS.Url = cutil.FormOrgSpecUrl(p.APISpecs[0].SpecRef, p.APISpecs[0].Org)
 
 			// The version property needs special handling
 			newProp := &exchange.MSProp{

--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-horizon/anax/abstractprotocol"
 	"github.com/open-horizon/anax/agreementbot/persistence"
 	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/exchange"
 	"github.com/open-horizon/anax/policy"
@@ -870,7 +871,7 @@ func (w *AgreementBotWorker) searchExchange(pol *policy.Policy, polOrg string) (
 					if newMS, err := w.makeNewMSSearchElement(rs.SpecRef, rs.Org, "", arch, pol); err != nil {
 						return nil, err
 					} else {
-						msMap[rs.SpecRef] = newMS
+						msMap[cutil.FormOrgSpecUrl(rs.SpecRef, rs.Org)] = newMS
 					}
 				}
 			}
@@ -914,7 +915,7 @@ func (w *AgreementBotWorker) searchExchange(pol *policy.Policy, polOrg string) (
 
 func (w *AgreementBotWorker) makeNewMSSearchElement(specRef string, org string, version string, arch string, pol *policy.Policy) (*exchange.Microservice, error) {
 	newMS := new(exchange.Microservice)
-	newMS.Url = specRef
+	newMS.Url = cutil.FormOrgSpecUrl(specRef, org)
 	newMS.NumAgreements = 1
 
 	if props, err := RetrieveAllProperties(version, arch, pol); err != nil {

--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -240,7 +240,7 @@ func (b *BaseAgreementWorker) InitiateNewAgreement(cph ConsumerProtocolHandler, 
 					// Run through all the services on the node that are required by this workload and merge those policies.
 					for _, devMS := range services {
 						// Find the device's service definition based on the services needed by the workload.
-						if devMS.Url == apiSpec.SpecRef {
+						if devMS.Url == cutil.FormOrgSpecUrl(apiSpec.SpecRef, apiSpec.Org) {
 							if pol, err := policy.DemarshalPolicy(devMS.Policy); err != nil {
 								glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("error demarshalling device %v policy, error: %v", wi.Device.Id, err)))
 								return

--- a/api/container.go
+++ b/api/container.go
@@ -39,7 +39,7 @@ func GetWorkloadContainers(dockerEndpoint string, agreementId string) ([]dockerc
 }
 
 // Get docker container metadata from the docker API for microservice containers
-func GetMicroserviceContainer(dockerEndpoint string, mURL string, mVersion string, mInstanceId string) ([]dockerclient.APIContainers, error) {
+func GetMicroserviceContainer(dockerEndpoint string, mURL string, mOrg string, mVersion string, mInstanceId string) ([]dockerclient.APIContainers, error) {
 	if client, err := dockerclient.NewClient(dockerEndpoint); err != nil {
 		return nil, errors.New(fmt.Sprintf("unable to create docker client from %v, error %v", dockerEndpoint, err))
 	} else {
@@ -57,7 +57,7 @@ func GetMicroserviceContainer(dockerEndpoint string, mURL string, mVersion strin
 			for _, c := range containers {
 				if _, exists := c.Labels[container.LABEL_PREFIX+".infrastructure"]; exists {
 					if agid, exists := c.Labels[container.LABEL_PREFIX+".agreement_id"]; exists {
-						name := cutil.MakeMSInstanceKey(mURL, mVersion, mInstanceId)
+						name := cutil.MakeMSInstanceKey(mURL, mOrg, mVersion, mInstanceId)
 						if agid == name {
 							ret = append(ret, c)
 						}

--- a/api/output.go
+++ b/api/output.go
@@ -62,9 +62,10 @@ func NewMicroserviceInstanceOutput(mi persistence.MicroserviceInstance, containe
 }
 
 func NewAgreementServiceInstanceOutput(ag *persistence.EstablishedAgreement, containers *[]dockerclient.APIContainers) *MicroserviceInstanceOutput {
-	sipe := persistence.NewServiceInstancePathElement(ag.RunningWorkload.URL, ag.RunningWorkload.Version)
+	sipe := persistence.NewServiceInstancePathElement(ag.RunningWorkload.URL, ag.RunningWorkload.Org, ag.RunningWorkload.Version)
 	mi := persistence.MicroserviceInstance{
 		SpecRef:              ag.RunningWorkload.URL,
+		Org:                  ag.RunningWorkload.Org,
 		Version:              ag.RunningWorkload.Version,
 		Arch:                 ag.RunningWorkload.Arch,
 		InstanceId:           ag.CurrentAgreementId,

--- a/api/path_attributes.go
+++ b/api/path_attributes.go
@@ -419,6 +419,7 @@ func parseAgreementProtocol(errorhandler ErrorHandler, permitEmpty bool, given *
 // AttributeVerifier returns true if there is a handled inputError (one that caused a write to the http responsewriter) and error if there is a system processing problem
 type AttributeVerifier func(attr persistence.Attribute) (bool, error)
 
+// the sensorURL is in the form of "org/url"
 func toPersistedAttributesAttachedToService(errorhandler ErrorHandler, persistedDevice *persistence.ExchangeDevice, defaultRAM int64, attrs []Attribute, sensorURL string, additionalVerifiers []AttributeVerifier) ([]persistence.Attribute, bool, error) {
 
 	additionalVerifiers = append(additionalVerifiers, func(attr persistence.Attribute) (bool, error) {
@@ -607,6 +608,7 @@ func toOutModel(persisted persistence.Attribute) *Attribute {
 	}
 }
 
+//  the sensorUrl is in the form of "org/url"
 func FinalizeAttributesSpecifiedInService(defaultRAM int64, sensorURL string, attributes []persistence.Attribute) []persistence.Attribute {
 
 	// check for required
@@ -719,7 +721,7 @@ func payloadToAttributes(errorhandler ErrorHandler, body io.Reader, permitPartia
 // HTTP response.
 func FindAndWrapAttributesForOutput(db *bolt.DB, id string) (map[string][]Attribute, error) {
 
-	attributes, err := persistence.FindApplicableAttributes(db, "")
+	attributes, err := persistence.FindApplicableAttributes(db, "", "")
 	if err != nil {
 		return nil, fmt.Errorf("Failed fetching existing service attributes. Error: %v", err)
 	}

--- a/api/path_service.go
+++ b/api/path_service.go
@@ -53,7 +53,7 @@ func FindServicesForOutput(pm *policy.PolicyManager,
 		if msinst.Archived {
 			wrap.Instances[archivedKey] = append(wrap.Instances[archivedKey], *NewMicroserviceInstanceOutput(msinst, nil))
 		} else {
-			containers, err := GetMicroserviceContainer(config.Edge.DockerEndpoint, msinst.SpecRef, msinst.Version, msinst.InstanceId)
+			containers, err := GetMicroserviceContainer(config.Edge.DockerEndpoint, msinst.SpecRef, msinst.Org, msinst.Version, msinst.InstanceId)
 			if err != nil {
 				return nil, errors.New(fmt.Sprintf("unable to get docker container info, error %v", err))
 			}

--- a/cli/dev/utils.go
+++ b/cli/dev/utils.go
@@ -300,7 +300,7 @@ func createEnvVarMap(agreementId string,
 	}
 
 	// Third, add in default system attributes if not already present.
-	attrs = api.FinalizeAttributesSpecifiedInService(1024, msURL, attrs)
+	attrs = api.FinalizeAttributesSpecifiedInService(1024, cutil.FormOrgSpecUrl(msURL, org), attrs)
 
 	cliutils.Verbose("Final Attributes: %v", attrs)
 
@@ -493,7 +493,7 @@ func startDependent(dir string,
 			return nil, errors.New(fmt.Sprintf("unable to generate instance ID: %v", err))
 		}
 
-		sId := cutil.MakeMSInstanceKey(serviceDef.URL, serviceDef.Version, id.String())
+		sId := cutil.MakeMSInstanceKey(serviceDef.URL, serviceDef.Org, serviceDef.Version, id.String())
 
 		return StartContainers(deployment, serviceDef.URL, serviceDef.Version, globals, serviceDef.UserInputs, configUserInputs, serviceDef.Org, depConfig, cw, msNetworks, true, false, sId)
 	}

--- a/container/container.go
+++ b/container/container.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/config"
 	"github.com/open-horizon/anax/containermessage"
+	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/eventlog"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/persistence"
@@ -1166,7 +1167,7 @@ func (b *ContainerWorker) CommandHandler(command worker.Command) bool {
 			glog.Infof("Receved configure command for agreement %v. Ignoring it because this agreement has been terminated.", agreementId)
 		} else if ags[0].AgreementExecutionStartTime != 0 {
 			glog.Infof("Receved configure command for agreement %v. Ignoring it because the containers for this agreement has been configured.", agreementId)
-		} else if ms_containers, err := b.findMsContainersAndUpdateMsInstance(persistence.NewServiceInstancePathElement(ags[0].RunningWorkload.URL, ags[0].RunningWorkload.Version), agreementId, cmd.AgreementLaunchContext.Microservices); err != nil {
+		} else if ms_containers, err := b.findMsContainersAndUpdateMsInstance(persistence.NewServiceInstancePathElement(ags[0].RunningWorkload.URL, ags[0].RunningWorkload.Org, ags[0].RunningWorkload.Version), agreementId, cmd.AgreementLaunchContext.Microservices); err != nil {
 			glog.Errorf("Error checking service containers: %v", err)
 
 			// requeue the command
@@ -1431,7 +1432,7 @@ func (b *ContainerWorker) CommandHandler(command worker.Command) bool {
 			glog.Errorf("Error retrieving service instance from database for %v, error: %v", cmd.MsInstKey, err)
 		} else if msinst == nil {
 			glog.Errorf("Cannot find service instance record from database for %v.", cmd.MsInstKey)
-		} else if serviceNames, err := b.findMicroserviceDefContainerNames(msinst.SpecRef, msinst.Version, msinst.MicroserviceDefId); err != nil {
+		} else if serviceNames, err := b.findMicroserviceDefContainerNames(msinst.SpecRef, msinst.Org, msinst.Version, msinst.MicroserviceDefId); err != nil {
 			glog.Errorf("Error retrieving service contianers for %v, error: %v", cmd.MsInstKey, err)
 		} else if serviceNames != nil && len(serviceNames) > 0 {
 
@@ -1460,7 +1461,7 @@ func (b *ContainerWorker) CommandHandler(command worker.Command) bool {
 				// ask governer to record it into the db
 				u, _ := url.Parse("")
 				cc := events.NewContainerConfig(*u, "", "", "", "", "", nil)
-				ll := events.NewContainerLaunchContext(cc, nil, events.BlockchainConfig{}, cmd.MsInstKey, "", []events.MicroserviceSpec{}, persistence.NewServiceInstancePathElement("", ""))
+				ll := events.NewContainerLaunchContext(cc, nil, events.BlockchainConfig{}, cmd.MsInstKey, "", []events.MicroserviceSpec{}, persistence.NewServiceInstancePathElement("", "", ""))
 				b.Messages() <- events.NewContainerMessage(events.EXECUTION_FAILED, *ll, "", "")
 			}
 		}
@@ -1841,25 +1842,25 @@ func (b *ContainerWorker) ContainersMatchingAgreement(agreements []string, inclu
 }
 
 // find the microservice definition from the db
-func (b *ContainerWorker) findMicroserviceDefContainerNames(api_spec string, version string, msdef_key string) ([]string, error) {
+func (b *ContainerWorker) findMicroserviceDefContainerNames(api_spec string, org string, version string, msdef_key string) ([]string, error) {
 
 	container_names := make([]string, 0)
 	// find the ms from the local db, it is okay if the ms def is not found. this is old behavious befor the ms split.
 	if msdef, err := persistence.FindMicroserviceDefWithKey(b.db, msdef_key); err != nil {
-		return nil, fmt.Errorf("Error finding service definition from the local db for %v version %v key %v. %v", api_spec, version, msdef_key, err)
+		return nil, fmt.Errorf("Error finding service definition from the local db for %v version %v key %v. %v", cutil.FormOrgSpecUrl(api_spec, org), version, msdef_key, err)
 	} else if msdef != nil && msdef.HasDeployment() {
 		// get the service name from the ms def
 		deployment, _, _ := msdef.GetDeployment()
 		deploymentDesc := new(containermessage.DeploymentDescription)
 		if err := json.Unmarshal([]byte(deployment), &deploymentDesc); err != nil {
-			return nil, fmt.Errorf("Error Unmarshalling deployment string %v for service %v version %v. %v", deployment, api_spec, version, err)
+			return nil, fmt.Errorf("Error Unmarshalling deployment string %v for service %v version %v. %v", deployment, cutil.FormOrgSpecUrl(api_spec, org), version, err)
 		} else {
 			for serviceName, _ := range deploymentDesc.Services {
 				container_names = append(container_names, serviceName)
 			}
 		}
 	}
-	glog.V(5).Infof("The container names for service %v version %v are: %v", api_spec, version, container_names)
+	glog.V(5).Infof("The container names for service %v/%v version %v are: %v", org, api_spec, version, container_names)
 	return container_names, nil
 }
 
@@ -1872,10 +1873,10 @@ func (b *ContainerWorker) findMsContainersAndUpdateMsInstance(parent *persistenc
 	} else {
 		for _, api_spec := range microservices {
 			// find the ms from the local db,
-			if msc_names, err := b.findMicroserviceDefContainerNames(api_spec.SpecRef, api_spec.Version, api_spec.MsdefId); err != nil {
+			if msc_names, err := b.findMicroserviceDefContainerNames(api_spec.SpecRef, api_spec.Org, api_spec.Version, api_spec.MsdefId); err != nil {
 				return nil, fmt.Errorf("Error finding service definition from the local db for %v. %v", api_spec, err)
-			} else if msinsts, err := persistence.FindMicroserviceInstances(b.db, []persistence.MIFilter{persistence.AllInstancesMIFilter(api_spec.SpecRef, api_spec.Version), persistence.UnarchivedMIFilter()}); err != nil {
-				return nil, fmt.Errorf("Error retrieving service instances for %v version %v from database, error: %v", api_spec.SpecRef, api_spec.Version, err)
+			} else if msinsts, err := persistence.FindMicroserviceInstances(b.db, []persistence.MIFilter{persistence.AllInstancesMIFilter(api_spec.SpecRef, api_spec.Org, api_spec.Version), persistence.UnarchivedMIFilter()}); err != nil {
+				return nil, fmt.Errorf("Error retrieving service instances for %v/%v version %v from database, error: %v", api_spec.Org, api_spec.SpecRef, api_spec.Version, err)
 			} else if msinsts == nil || len(msinsts) == 0 {
 				return nil, fmt.Errorf("No service instance for service %v yet.", api_spec)
 			} else {
@@ -1916,7 +1917,7 @@ func (b *ContainerWorker) findMsContainersAndUpdateMsInstance(parent *persistenc
 
 				// get the service name from the ms def
 				for _, serviceName := range msc_names {
-					// compare with the container name. assume the container name = <msname>_<version>-<service name>
+					// compare with the container name. assume the container name = <msinstkey>-<service name>
 					for _, container := range containers {
 						if _, ok := container.Labels[LABEL_PREFIX+".infrastructure"]; ok {
 							cname := container.Names[0]

--- a/cutil/cutil.go
+++ b/cutil/cutil.go
@@ -229,14 +229,18 @@ func SetSystemEnvvars(envAdds map[string]string, prefix string, lat string, lon 
 
 }
 
-func MakeMSInstanceKey(specRef string, v string, id string) string {
+func MakeMSInstanceKey(specRef string, org string, v string, id string) string {
 	s := specRef
 	if strings.Contains(specRef, "://") {
 		s = strings.Split(specRef, "://")[1]
 	}
 	new_s := strings.Replace(s, "/", "-", -1)
 
-	return fmt.Sprintf("%v_%v_%v", new_s, v, id)
+	if org == "" {
+		return fmt.Sprintf("%v_%v_%v", new_s, v, id)
+	} else {
+		return fmt.Sprintf("%v_%v_%v_%v", org, new_s, v, id)
+	}
 }
 
 // This function parsed the given image name to disfferent parts. The image name has the following format:
@@ -384,4 +388,13 @@ func GetAllHostIPv4Addresses(interfaceFilters []NetFilter) ([]string, error) {
 	}
 
 	return ips, nil
+}
+
+// it returns the org/url form for an api spec
+func FormOrgSpecUrl(url string, org string) string {
+	if org == "" {
+		return url
+	} else {
+		return fmt.Sprintf("%v/%v", org, url)
+	}
 }

--- a/eventlog/eventlog_manager_test.go
+++ b/eventlog/eventlog_manager_test.go
@@ -37,7 +37,7 @@ func Test_LogEvent(t *testing.T) {
 	src1 := persistence.NewAgreementEventSourceFromAg(*ag1)
 
 	// service source type
-	svc1, err1 := persistence.NewMicroserviceInstance(db, "http://sensor1.org", "1.2.0", "1", []persistence.ServiceInstancePathElement{})
+	svc1, err1 := persistence.NewMicroserviceInstance(db, "http://sensor1.org", "myorg", "1.2.0", "1", []persistence.ServiceInstancePathElement{})
 	if err1 != nil {
 		t.Errorf("error writing agreement1: %v", err1)
 	}
@@ -256,11 +256,11 @@ func Test_LogServiceEvent(t *testing.T) {
 	}
 	defer cleanTestDir(dir)
 
-	src1, err1 := persistence.NewMicroserviceInstance(db, "http://sensor1.org", "1.2.0", "1", []persistence.ServiceInstancePathElement{})
+	src1, err1 := persistence.NewMicroserviceInstance(db, "http://sensor1.org", "myorg", "1.2.0", "1", []persistence.ServiceInstancePathElement{})
 	if err1 != nil {
 		t.Errorf("error writing agreement1: %v", err1)
 	}
-	src2, err2 := persistence.NewMicroserviceInstance(db, "http://sensor2.org", "1.0.0", "2", []persistence.ServiceInstancePathElement{})
+	src2, err2 := persistence.NewMicroserviceInstance(db, "http://sensor2.org", "myorg", "1.0.0", "2", []persistence.ServiceInstancePathElement{})
 	if err2 != nil {
 		t.Errorf("error writing agreement2: %v", err2)
 	}

--- a/events/events.go
+++ b/events/events.go
@@ -102,6 +102,7 @@ type LaunchContext interface {
 
 type MicroserviceSpec struct {
 	SpecRef string
+	Org     string
 	Version string
 	MsdefId string
 }
@@ -211,7 +212,7 @@ func NewContainerLaunchContext(config *ContainerConfig, envAdds *map[string]stri
 
 	spe_temp := spe
 	if spe_temp == nil {
-		spe_temp = persistence.NewServiceInstancePathElement("", "")
+		spe_temp = persistence.NewServiceInstancePathElement("", "", "")
 	}
 
 	return &ContainerLaunchContext{
@@ -591,7 +592,7 @@ func NewGovernanceWorkloadCancelationMessage(id EventId, cause EndContractCause,
 
 	return &GovernanceWorkloadCancelationMessage{
 		GovernanceMaintenanceMessage: *govMaint,
-		Cause:                        cause,
+		Cause: cause,
 	}
 }
 

--- a/exchange/rpc.go
+++ b/exchange/rpc.go
@@ -780,7 +780,7 @@ func GetPatterns(httpClientFactory *config.HTTPClientFactory, org string, patter
 	if pattern == "" {
 		glog.V(3).Infof(rpclogString(fmt.Sprintf("getting pattern definitions for %v", org)))
 	} else {
-		glog.V(3).Infof(rpclogString(fmt.Sprintf("getting pattern definitions for %v and %v", org, pattern)))
+		glog.V(3).Infof(rpclogString(fmt.Sprintf("getting pattern definitions for %v/%v", org, pattern)))
 	}
 
 	var resp interface{}

--- a/governance/microservice.go
+++ b/governance/microservice.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/api"
 	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/eventlog"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/exchange"
@@ -73,9 +74,9 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 		return nil, fmt.Errorf(logString(fmt.Sprintf("No service definition available for key %v.", ms_key)))
 	} else {
 		if !msdef.HasDeployment() {
-			glog.Infof(logString(fmt.Sprintf("No workload needed for service %v.", msdef.SpecRef)))
-			if mi, err := persistence.NewMicroserviceInstance(w.db, msdef.SpecRef, msdef.Version, ms_key, dependencyPath); err != nil {
-				return nil, fmt.Errorf(logString(fmt.Sprintf("Error persisting service instance for %v %v %v.", msdef.SpecRef, msdef.Version, ms_key)))
+			glog.Infof(logString(fmt.Sprintf("No workload needed for service %v/%v.", msdef.Org, msdef.SpecRef)))
+			if mi, err := persistence.NewMicroserviceInstance(w.db, msdef.SpecRef, msdef.Org, msdef.Version, ms_key, dependencyPath); err != nil {
+				return nil, fmt.Errorf(logString(fmt.Sprintf("Error persisting service instance for %v/%v %v %v.", msdef.Org, msdef.SpecRef, msdef.Version, ms_key)))
 				// if the new microservice does not have containers, just mark it done.
 			} else if mi, err := persistence.UpdateMSInstanceExecutionState(w.db, mi.GetKey(), true, 0, ""); err != nil {
 				return nil, fmt.Errorf(logString(fmt.Sprintf("Failed to update the ExecutionStartTime for service instance %v. %v", mi.GetKey(), err)))
@@ -92,7 +93,7 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 		// convert to torrent structure only if the torrent string exists on the exchange
 		if torr != "" {
 			if err := json.Unmarshal([]byte(torr), &torrent); err != nil {
-				return nil, fmt.Errorf(logString(fmt.Sprintf("The torrent definition for service %v has error: %v", msdef.SpecRef, err)))
+				return nil, fmt.Errorf(logString(fmt.Sprintf("The torrent definition for service %v/%v has error: %v", msdef.Org, msdef.SpecRef, err)))
 			}
 		} else {
 			// this is the service case where the image server is defined
@@ -119,7 +120,7 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 			if w.Config.Edge.TrustCertUpdatesFromOrg {
 				key_map, err := exchange.GetHTTPObjectSigningKeysHandler(w)(exchange.SERVICE, msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch)
 				if err != nil {
-					return nil, fmt.Errorf(logString(fmt.Sprintf("received error getting signing keys from the exchange: %v %v %v %v. %v", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, err)))
+					return nil, fmt.Errorf(logString(fmt.Sprintf("received error getting signing keys from the exchange: %v/%v %v %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Arch, err)))
 				}
 
 				if key_map != nil {
@@ -155,24 +156,24 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 			// be greater than the dependency version.
 			ms_specs := []events.MicroserviceSpec{}
 			for _, rs := range msdef.RequiredServices {
-				if msdefs, err := persistence.FindUnarchivedMicroserviceDefs(w.db, rs.URL); err != nil {
-					return nil, fmt.Errorf(logString(fmt.Sprintf("received error reading service definition for %v: %v", rs.URL, err)))
+				if msdefs, err := persistence.FindUnarchivedMicroserviceDefs(w.db, rs.URL, rs.Org); err != nil {
+					return nil, fmt.Errorf(logString(fmt.Sprintf("received error reading service definition for %v/%v: %v", rs.Org, rs.URL, err)))
 				} else {
 					// Assume the first msdef is the one we want.
-					msspec := events.MicroserviceSpec{SpecRef: rs.URL, Version: msdefs[0].Version, MsdefId: msdefs[0].Id}
+					msspec := events.MicroserviceSpec{SpecRef: rs.URL, Org: rs.Org, Version: msdefs[0].Version, MsdefId: msdefs[0].Id}
 					ms_specs = append(ms_specs, msspec)
 				}
 			}
 
 			// save the instance
-			if ms_instance, err := persistence.NewMicroserviceInstance(w.db, msdef.SpecRef, msdef.Version, ms_key, dependencyPath); err != nil {
-				return nil, fmt.Errorf(logString(fmt.Sprintf("Error persisting service instance for %v %v %v.", msdef.SpecRef, msdef.Version, ms_key)))
+			if ms_instance, err := persistence.NewMicroserviceInstance(w.db, msdef.SpecRef, msdef.Org, msdef.Version, ms_key, dependencyPath); err != nil {
+				return nil, fmt.Errorf(logString(fmt.Sprintf("Error persisting service instance for %v/%v %v %v.", msdef.Org, msdef.SpecRef, msdef.Version, ms_key)))
 			} else {
 				// get the image auth for service (we have to try even for microservice because we do not know if this is ms or svc.)
 				img_auths := make([]events.ImageDockerAuth, 0)
 				if w.Config.Edge.TrustDockerAuthFromOrg {
 					if ias, err := exchange.GetHTTPServiceDockerAuthsHandler(w)(msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch); err != nil {
-						glog.V(5).Infof(logString(fmt.Sprintf("received error querying exchange for service image auths: %v version %v, error %v", msdef.SpecRef, msdef.Version, err)))
+						glog.V(5).Infof(logString(fmt.Sprintf("received error querying exchange for service image auths: %v/%v version %v, error %v", msdef.Org, msdef.SpecRef, msdef.Version, err)))
 					} else {
 						if ias != nil {
 							for _, iau_temp := range ias {
@@ -190,10 +191,10 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 				cc := events.NewContainerConfig(*url, ms_workload.Torrent.Signature, ms_workload.Deployment, ms_workload.DeploymentSignature, ms_workload.DeploymentUserInfo, "", img_auths)
 
 				// convert the user input from the service attributes to env variables
-				if attrs, err := persistence.FindApplicableAttributes(w.db, msdef.SpecRef); err != nil {
-					return nil, fmt.Errorf(logString(fmt.Sprintf("Unable to fetch service preferences for %v. Err: %v", msdef.SpecRef, err)))
+				if attrs, err := persistence.FindApplicableAttributes(w.db, msdef.SpecRef, msdef.Org); err != nil {
+					return nil, fmt.Errorf(logString(fmt.Sprintf("Unable to fetch service preferences for %v/%v. Err: %v", msdef.Org, msdef.SpecRef, err)))
 				} else if envAdds, err := persistence.AttributesToEnvvarMap(attrs, make(map[string]string), config.ENVVAR_PREFIX, w.Config.Edge.DefaultServiceRegistrationRAM); err != nil {
-					return nil, fmt.Errorf(logString(fmt.Sprintf("Failed to convert service preferences to environmental variables for %v. Err: %v", msdef.SpecRef, err)))
+					return nil, fmt.Errorf(logString(fmt.Sprintf("Failed to convert service preferences to environmental variables for %v/%v. Err: %v", msdef.Org, msdef.SpecRef, err)))
 				} else {
 					envAdds[config.ENVVAR_PREFIX+"DEVICE_ID"] = exchange.GetId(w.GetExchangeId())
 					envAdds[config.ENVVAR_PREFIX+"ORGANIZATION"] = exchange.GetOrg(w.GetExchangeId())
@@ -207,7 +208,7 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 							}
 						}
 					}
-					lc := events.NewContainerLaunchContext(cc, &envAdds, events.BlockchainConfig{}, ms_instance.GetKey(), agreementId, ms_specs, persistence.NewServiceInstancePathElement(msdef.SpecRef, msdef.Version))
+					lc := events.NewContainerLaunchContext(cc, &envAdds, events.BlockchainConfig{}, ms_instance.GetKey(), agreementId, ms_specs, persistence.NewServiceInstancePathElement(msdef.SpecRef, msdef.Org, msdef.Version))
 					w.Messages() <- events.NewLoadContainerMessage(events.LOAD_CONTAINER, lc)
 				}
 
@@ -284,7 +285,7 @@ func (w *GovernanceWorker) CleanupMicroservice(spec_ref string, version string, 
 // It changes the current running microservice from the old to new, assuming the given microservice is ready for a change.
 // One can check it by calling microservice.MicroserviceReadyForUpgrade to find out.
 func (w *GovernanceWorker) UpgradeMicroservice(msdef *persistence.MicroserviceDefinition, new_msdef *persistence.MicroserviceDefinition, upgrade bool) error {
-	glog.V(3).Infof(logString(fmt.Sprintf("Start changing service %v from version %v to version %v", msdef.SpecRef, msdef.Version, new_msdef.Version)))
+	glog.V(3).Infof(logString(fmt.Sprintf("Start changing service %v/%v from version %v to version %v", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version)))
 
 	// archive the old ms def and save the new one to db
 	if _, err := persistence.MsDefArchived(w.db, msdef.Id); err != nil {
@@ -292,17 +293,17 @@ func (w *GovernanceWorker) UpgradeMicroservice(msdef *persistence.MicroserviceDe
 	} else if err := persistence.SaveOrUpdateMicroserviceDef(w.db, new_msdef); err != nil {
 		return fmt.Errorf(logString(fmt.Sprintf("Failed to save service definition to db. %v. %v", new_msdef, err)))
 	} else if _, err := persistence.MSDefUpgradeNewMsId(w.db, msdef.Id, new_msdef.Id); err != nil {
-		return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeNewMsId to %v for service def %v version %v id %v. %v", new_msdef.Id, msdef.SpecRef, msdef.Version, msdef.Id, err)))
+		return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeNewMsId to %v for service def %v/%v version %v id %v. %v", new_msdef.Id, new_msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 	} else if _, err := persistence.MSDefUpgradeStarted(w.db, new_msdef.Id); err != nil {
-		return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeStartTime for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+		return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeStartTime for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 	}
 
 	// clean up old microservice
 	var eClearError error
 	var ms_insts []persistence.MicroserviceInstance
 	eClearError = nil
-	if ms_insts, eClearError = persistence.FindMicroserviceInstances(w.db, []persistence.MIFilter{persistence.AllInstancesMIFilter(msdef.SpecRef, msdef.Version), persistence.UnarchivedMIFilter()}); eClearError != nil {
-		glog.Errorf(logString(fmt.Sprintf("Error retrieving all the service instances from db for %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, eClearError)))
+	if ms_insts, eClearError = persistence.FindMicroserviceInstances(w.db, []persistence.MIFilter{persistence.AllInstancesMIFilter(msdef.SpecRef, msdef.Org, msdef.Version), persistence.UnarchivedMIFilter()}); eClearError != nil {
+		glog.Errorf(logString(fmt.Sprintf("Error retrieving all the service instances from db for %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, eClearError)))
 	} else if ms_insts != nil && len(ms_insts) > 0 {
 		for _, msi := range ms_insts {
 			if msi.MicroserviceDefId == msdef.Id {
@@ -319,11 +320,11 @@ func (w *GovernanceWorker) UpgradeMicroservice(msdef *persistence.MicroserviceDe
 	// update msdef UpgradeAgreementsClearedTime
 	if eClearError != nil {
 		if _, err := persistence.MSDefUpgradeFailed(w.db, new_msdef.Id, microservice.MS_CLEAR_OLD_AGS_FAILED, microservice.DecodeReasonCode(microservice.MS_CLEAR_OLD_AGS_FAILED)); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeAgreementsClearedTime for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeAgreementsClearedTime for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	} else {
 		if _, err := persistence.MsDefUpgradeAgreementsCleared(w.db, new_msdef.Id); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeAgreementsClearedTime for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeAgreementsClearedTime for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	}
 
@@ -332,35 +333,35 @@ func (w *GovernanceWorker) UpgradeMicroservice(msdef *persistence.MicroserviceDe
 	unregError = nil
 	unregError = microservice.RemoveMicroservicePolicy(msdef.SpecRef, msdef.Org, msdef.Version, msdef.Id, w.Config.Edge.PolicyPath, w.pm)
 	if unregError != nil {
-		glog.Errorf(logString(fmt.Sprintf("Failed to remove service policy for service def %v version %v. %v", msdef.SpecRef, msdef.Version, unregError)))
-	} else if unregError = microservice.UnregisterMicroserviceExchange(exchange.GetHTTPDeviceHandler(w), exchange.GetHTTPPutDeviceHandler(w), msdef.SpecRef, w.GetExchangeId(), w.GetExchangeToken(), w.db); unregError != nil {
-		glog.Errorf(logString(fmt.Sprintf("Failed to unregister service from the exchange for service def %v. %v", msdef.SpecRef, unregError)))
+		glog.Errorf(logString(fmt.Sprintf("Failed to remove service policy for service def %v/%v version %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, unregError)))
+	} else if unregError = microservice.UnregisterMicroserviceExchange(exchange.GetHTTPDeviceHandler(w), exchange.GetHTTPPutDeviceHandler(w), msdef.SpecRef, msdef.Org, w.GetExchangeId(), w.GetExchangeToken(), w.db); unregError != nil {
+		glog.Errorf(logString(fmt.Sprintf("Failed to unregister service from the exchange for service def %v/%v. %v", msdef.Org, msdef.SpecRef, unregError)))
 	}
 
 	// update msdef UpgradeMsUnregisteredTime
 	if unregError != nil {
 		if _, err := persistence.MSDefUpgradeFailed(w.db, new_msdef.Id, microservice.MS_UNREG_EXCH_FAILED, microservice.DecodeReasonCode(microservice.MS_UNREG_EXCH_FAILED)); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update service upgrading failure reason for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update service upgrading failure reason for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	} else {
 		if _, err := persistence.MSDefUpgradeMsUnregistered(w.db, new_msdef.Id); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeMsUnregisteredTime for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeMsUnregisteredTime for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	}
 
 	// create a new policy file and register the new microservice in exchange
 	if err := microservice.GenMicroservicePolicy(new_msdef, w.Config.Edge.PolicyPath, w.db, w.Messages(), exchange.GetOrg(w.GetExchangeId())); err != nil {
 		if _, err := persistence.MSDefUpgradeFailed(w.db, new_msdef.Id, microservice.MS_REREG_EXCH_FAILED, microservice.DecodeReasonCode(microservice.MS_REREG_EXCH_FAILED)); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update service upgrading failure reason for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update service upgrading failure reason for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	} else {
 		if _, err := persistence.MSDefUpgradeMsReregistered(w.db, new_msdef.Id); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeMsReregisteredTime for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeMsReregisteredTime for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	}
 
 	// done for the microservices without containers.
-	glog.V(3).Infof(logString(fmt.Sprintf("End changing service %v version %v key %v", msdef.SpecRef, msdef.Version, msdef.Id)))
+	glog.V(3).Infof(logString(fmt.Sprintf("End changing service %v/%v version %v key %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id)))
 
 	return nil
 }
@@ -371,27 +372,27 @@ func (w *GovernanceWorker) RollbackMicroservice(msdef *persistence.MicroserviceD
 		// get next lower version
 		if new_msdef, err := microservice.GetRollbackMicroserviceDef(exchange.GetHTTPServiceResolverHandler(w), msdef, w.db); err != nil {
 			eventlog.LogDatabaseEvent(w.db, persistence.SEVERITY_ERROR,
-				fmt.Sprintf("Error finding the new service definition to downgrade to for %v %v version key %v. error: %v", msdef.SpecRef, msdef.Version, msdef.Id, err),
+				fmt.Sprintf("Error finding the new service definition to downgrade to for %v/%v version %v key %v. error: %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err),
 				persistence.EC_DATABASE_ERROR)
-			return fmt.Errorf(logString(fmt.Sprintf("Error finding the new service definition to downgrade to for %v %v version key %v. error: %v", msdef.SpecRef, msdef.Version, msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Error finding the new service definition to downgrade to for %v/%v version %v key %v. error: %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 		} else if new_msdef == nil { //no more to try, exit out
 			eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-				fmt.Sprintf("Could not find lower version to downgrade for %v version %v.", msdef.SpecRef, msdef.Version),
+				fmt.Sprintf("Could not find lower version to downgrade for %v/%v version %v.", msdef.Org, msdef.SpecRef, msdef.Version),
 				persistence.EC_NO_VERSION_TO_DOWNGRADE,
 				"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
-			glog.Warningf(logString(fmt.Sprintf("Unable to find the service definition to downgrade to for %v %v version key %v.", msdef.SpecRef, msdef.Version, msdef.Id)))
-			return fmt.Errorf(logString(fmt.Sprintf("Unable to find the service definition to downgrade to for %v %v version key %v.", msdef.SpecRef, msdef.Version, msdef.Id)))
+			glog.Warningf(logString(fmt.Sprintf("Unable to find the service definition to downgrade to for %v/%v version %v key %v.", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id)))
+			return fmt.Errorf(logString(fmt.Sprintf("Unable to find the service definition to downgrade to for %v/%v version %v key %v.", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id)))
 		} else {
 			if err := w.UpgradeMicroservice(msdef, new_msdef, false); err != nil {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-					fmt.Sprintf("Error downgrading service %v frpm version %v to version %v. Eror: %v", msdef.SpecRef, msdef.Version, new_msdef.Version, err),
+					fmt.Sprintf("Error downgrading service %v/%v frpm version %v to version %v. Eror: %v", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version, err),
 					persistence.EC_ERROR_DOWNGRADE_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
-				glog.Errorf(logString(fmt.Sprintf("Failed to downgrade %v from version %v key %v to version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, new_msdef.Version, new_msdef.Id, err)))
+				glog.Errorf(logString(fmt.Sprintf("Failed to downgrade %v/%v from version %v key %v to version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, new_msdef.Version, new_msdef.Id, err)))
 				msdef = new_msdef
 			} else {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-					fmt.Sprintf("Complete downgrading service %v from version %v to version %v.", msdef.SpecRef, msdef.Version, new_msdef.Version),
+					fmt.Sprintf("Complete downgrading service %v/%v from version %v to version %v.", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version),
 					persistence.EC_COMPLETE_DOWNGRADE_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
 				return nil
@@ -415,11 +416,11 @@ func (w *GovernanceWorker) startMicroserviceInstForAgreement(msdef *persistence.
 		// For other sharing modes, start a new instance only if there is no existing one.
 		// The "exclusive" sharing mode is handled by maxAgreements=1 in the node side policy file. This ensures that agbots and nodes will
 		// only support one agreement at any time.
-	} else if ms_insts, err := persistence.FindMicroserviceInstances(w.db, []persistence.MIFilter{persistence.AllInstancesMIFilter(msdef.SpecRef, msdef.Version), persistence.UnarchivedMIFilter()}); err != nil {
+	} else if ms_insts, err := persistence.FindMicroserviceInstances(w.db, []persistence.MIFilter{persistence.AllInstancesMIFilter(msdef.SpecRef, msdef.Org, msdef.Version), persistence.UnarchivedMIFilter()}); err != nil {
 		eventlog.LogDatabaseEvent(w.db, persistence.SEVERITY_ERROR,
-			fmt.Sprintf("Error retrieving all the service instances from db for %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, err),
+			fmt.Sprintf("Error retrieving all the service instances from db for %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err),
 			persistence.EC_DATABASE_ERROR)
-		return fmt.Errorf(logString(fmt.Sprintf("Error retrieving all the service instances from db for %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, err)))
+		return fmt.Errorf(logString(fmt.Sprintf("Error retrieving all the service instances from db for %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 	} else if ms_insts == nil || len(ms_insts) == 0 {
 		needs_new_ms = true
 	} else {
@@ -431,33 +432,33 @@ func (w *GovernanceWorker) startMicroserviceInstForAgreement(msdef *persistence.
 		if msi, inst_err = w.StartMicroservice(msdef.Id, agreementId, dependencyPath); inst_err != nil {
 
 			eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-				fmt.Sprintf("Service starting failed for %v version %v, error: %v", msdef.SpecRef, msdef.Version, inst_err),
+				fmt.Sprintf("Service starting failed for %v/%v version %v, error: %v", msdef.Org, msdef.SpecRef, msdef.Version, inst_err),
 				persistence.EC_ERROR_START_SERVICE,
 				"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{agreementId})
 
 			// Try to downgrade the service/microservice to a lower version.
-			glog.V(3).Infof(logString(fmt.Sprintf("Ending the agreement: %v because service %v failed to start", agreementId, msdef.SpecRef)))
+			glog.V(3).Infof(logString(fmt.Sprintf("Ending the agreement: %v because service %v/%v failed to start", agreementId, msdef.Org, msdef.SpecRef)))
 			ag_reason_code := w.producerPH[protocol].GetTerminationCode(producer.TERM_REASON_MS_DOWNGRADE_REQUIRED)
 			ag_reason_text := w.producerPH[protocol].GetTerminationReason(ag_reason_code)
 			if agreementId != "" {
 				w.cancelAgreement(agreementId, protocol, ag_reason_code, ag_reason_text)
 			}
 
-			glog.V(3).Infof(logString(fmt.Sprintf("Downgrading service %v because version %v key %v failed to start. Error: %v", msdef.SpecRef, msdef.Version, msdef.Id, inst_err)))
+			glog.V(3).Infof(logString(fmt.Sprintf("Downgrading service %v/%v because version %v key %v failed to start. Error: %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, inst_err)))
 			eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-				fmt.Sprintf("Start downgrading service %v version %v because service for aagreement failed to start.", msdef.SpecRef, msdef.Version),
+				fmt.Sprintf("Start downgrading service %v/%v version %v because service for aagreement failed to start.", msdef.Org, msdef.SpecRef, msdef.Version),
 				persistence.EC_START_DOWNGRADE_SERVICE,
 				"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{agreementId})
 
 			if err := w.RollbackMicroservice(msdef); err != nil {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-					fmt.Sprintf("Error downgrading service %v version %v. %v", msdef.SpecRef, msdef.Version, err),
+					fmt.Sprintf("Error downgrading service %v/%v version %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, err),
 					persistence.EC_ERROR_DOWNGRADE_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{agreementId})
-				glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, err)))
+				glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 			}
 
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to start service instance for %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, inst_err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to start service instance for %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, inst_err)))
 		}
 	} else if _, err := persistence.UpdateMSInstanceAddDependencyPath(w.db, msi.GetKey(), &dependencyPath); err != nil {
 		return fmt.Errorf(logString(fmt.Sprintf("error adding dependency path %v to the service %v: %v", dependencyPath, msi.GetKey(), err)))
@@ -494,11 +495,11 @@ func (w *GovernanceWorker) handleMicroserviceInstForAgEnded(agreementId string, 
 					if id == agreementId {
 						msd, err := persistence.FindMicroserviceDefWithKey(w.db, msi.MicroserviceDefId)
 						if err != nil {
-							glog.Errorf(logString(fmt.Sprintf("Error retrieving service definition %v version %v key %v from database, error: %v", msi.SpecRef, msi.Version, msi.MicroserviceDefId, err)))
+							glog.Errorf(logString(fmt.Sprintf("Error retrieving service definition %v version %v key %v from database, error: %v", cutil.FormOrgSpecUrl(msi.SpecRef, msi.Org), msi.Version, msi.MicroserviceDefId, err)))
 							// delete the microservice instance if the sharing mode is "multiple"
 						} else {
 							eventlog.LogServiceEvent(w.db, persistence.SEVERITY_INFO,
-								fmt.Sprintf("Start cleaning up service %v because agreement %v ended.", msi.SpecRef, agreementId),
+								fmt.Sprintf("Start cleaning up service %v because agreement %v ended.", cutil.FormOrgSpecUrl(msi.SpecRef, msi.Org), agreementId),
 								persistence.EC_START_CLEANUP_SERVICE,
 								msi)
 
@@ -543,17 +544,17 @@ func (w *GovernanceWorker) handleMicroserviceExecFailure(msdef *persistence.Micr
 
 	// rollback the microservice to lower version
 	eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-		fmt.Sprintf("Start downgrading service %v version %v because service failed to start.", msdef.SpecRef, msdef.Version),
+		fmt.Sprintf("Start downgrading service %v/%v version %v because service failed to start.", msdef.Org, msdef.SpecRef, msdef.Version),
 		persistence.EC_START_DOWNGRADE_SERVICE,
 		msinst_key, msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
 
 	if err := w.RollbackMicroservice(msdef); err != nil {
 		eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-			fmt.Sprintf("Failed to downgrade service %v version %v, error: %v", msdef.SpecRef, msdef.Version, err),
+			fmt.Sprintf("Failed to downgrade service %v/%v version %v, error: %v", msdef.Org, msdef.SpecRef, msdef.Version, err),
 			persistence.EC_ERROR_DOWNGRADE_SERVICE,
 			msinst_key, msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
 
-		glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, err)))
+		glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 
 		// this service just could not be started. we have to cancel all the associated agreements
 		cleanup_reason := microservice.MS_EXEC_FAILED
@@ -574,37 +575,37 @@ func (w *GovernanceWorker) handleMicroserviceUpgrade(msdef_id string) {
 	} else if microservice.MicroserviceReadyForUpgrade(msdef, w.db) {
 		// find the new ms def to upgrade to
 		if new_msdef, err := microservice.GetUpgradeMicroserviceDef(exchange.GetHTTPServiceResolverHandler(w), msdef, w.db); err != nil {
-			glog.Errorf(logString(fmt.Sprintf("Error finding the new service definition to upgrade to for %v version %v. %v", msdef.SpecRef, msdef.Version, err)))
+			glog.Errorf(logString(fmt.Sprintf("Error finding the new service definition to upgrade to for %v/%v version %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, err)))
 		} else if new_msdef == nil {
-			glog.V(5).Infof(logString(fmt.Sprintf("No changes for service definition %v, no need to upgrade.", msdef.SpecRef)))
+			glog.V(5).Infof(logString(fmt.Sprintf("No changes for service definition %v/%v, no need to upgrade.", msdef.Org, msdef.SpecRef)))
 		} else {
 			eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-				fmt.Sprintf("Start upgrading service %v from version %v to version %v.", msdef.SpecRef, msdef.Version, new_msdef.Version),
+				fmt.Sprintf("Start upgrading service %v/%v from version %v to version %v.", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version),
 				persistence.EC_START_UPGRADE_SERVICE,
 				"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
 
 			if err := w.UpgradeMicroservice(msdef, new_msdef, true); err != nil {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-					fmt.Sprintf("Failed to upgrade service %v from version %v to version %v, error: %v", msdef.SpecRef, msdef.Version, new_msdef.Version, err),
+					fmt.Sprintf("Failed to upgrade service %v/%v from version %v to version %v, error: %v", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version, err),
 					persistence.EC_ERROR_UPGRADE_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
-				glog.Errorf(logString(fmt.Sprintf("Error upgrading service %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, err)))
+				glog.Errorf(logString(fmt.Sprintf("Error upgrading service %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 
 				// rollback the microservice to lower version
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-					fmt.Sprintf("Start downgrading service %v version %v because upgrade failed.", new_msdef.SpecRef, new_msdef.Version),
+					fmt.Sprintf("Start downgrading service %v/%v version %v because upgrade failed.", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version),
 					persistence.EC_START_DOWNGRADE_SERVICE,
 					"", new_msdef.SpecRef, new_msdef.Org, new_msdef.Version, new_msdef.Arch, []string{})
 				if err := w.RollbackMicroservice(new_msdef); err != nil {
 					eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-						fmt.Sprintf("Failed to downgrade service %v version %v, error: %v", new_msdef.SpecRef, new_msdef.Version, err),
+						fmt.Sprintf("Failed to downgrade service %v/%v version %v, error: %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, err),
 						persistence.EC_ERROR_DOWNGRADE_SERVICE,
 						"", new_msdef.SpecRef, new_msdef.Org, new_msdef.Version, new_msdef.Arch, []string{})
-					glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v version %v key %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+					glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v/%v version %v key %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 				}
 			} else {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-					fmt.Sprintf("Complete upgrading service %v from version %v to version %v.", msdef.SpecRef, msdef.Version, new_msdef.Version),
+					fmt.Sprintf("Complete upgrading service %v/%v from version %v to version %v.", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version),
 					persistence.EC_COMPLETE_UPGRADE_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
 			}

--- a/governance/shutdown.go
+++ b/governance/shutdown.go
@@ -273,7 +273,7 @@ func (w *GovernanceWorker) patchNodeKey() error {
 // Remove all attributes from the DB.
 func (w *GovernanceWorker) deleteAttributes() error {
 	// Retrieve all attributes in the DB.
-	attrs, err := persistence.FindApplicableAttributes(w.db, "")
+	attrs, err := persistence.FindApplicableAttributes(w.db, "", "")
 	if err != nil {
 		return errors.New(fmt.Sprintf("unable to retrieve attribute objects from database, error: %v", err))
 	} else if attrs == nil || len(attrs) == 0 {

--- a/microservice/microservice.go
+++ b/microservice/microservice.go
@@ -135,7 +135,7 @@ func ConvertRequiredServicesToExchange(m *persistence.MicroserviceDefinition) *[
 
 // check if the given msdef is eligible for a upgrade
 func MicroserviceReadyForUpgrade(msdef *persistence.MicroserviceDefinition, db *bolt.DB) bool {
-	glog.V(5).Infof("Check if service is available for a upgrade: %v.", msdef.SpecRef)
+	glog.V(5).Infof("Check if service %v/%v is available for a upgrade.", msdef.Org, msdef.SpecRef)
 
 	if msdef.Archived {
 		return false
@@ -162,8 +162,8 @@ func MicroserviceReadyForUpgrade(msdef *persistence.MicroserviceDefinition, db *
 	// will never be found by this function and will therefore never be upgraded (which is the behavior we want).
 
 	// Use a filter that only returns unarchived, non-terminating instances that match the input service definition.
-	if ms_insts, err := persistence.FindMicroserviceInstances(db, []persistence.MIFilter{persistence.AllInstancesMIFilter(msdef.SpecRef, msdef.Version), persistence.UnarchivedMIFilter(), persistence.NotCleanedUpMIFilter()}); err != nil {
-		glog.Errorf("Error retrieving all the service instances from db for %v version %v. %v", msdef.SpecRef, msdef.Version, err)
+	if ms_insts, err := persistence.FindMicroserviceInstances(db, []persistence.MIFilter{persistence.AllInstancesMIFilter(msdef.SpecRef, msdef.Org, msdef.Version), persistence.UnarchivedMIFilter(), persistence.NotCleanedUpMIFilter()}); err != nil {
+		glog.Errorf("Error retrieving all the service instances from db for %v/%v version %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, err)
 		return false
 	} else if ms_insts != nil && len(ms_insts) > 0 {
 		for _, msi := range ms_insts {
@@ -188,17 +188,17 @@ func MicroserviceReadyForUpgrade(msdef *persistence.MicroserviceDefinition, db *
 // compare the version and content with the current msdef and decide if it needs to upgrade.
 // It returns the new msdef if the old one needs to be upgraded, otherwide return nil.
 func GetUpgradeMicroserviceDef(getService exchange.ServiceResolverHandler, msdef *persistence.MicroserviceDefinition, db *bolt.DB) (*persistence.MicroserviceDefinition, error) {
-	glog.V(3).Infof("Get new service def for upgrading service %v version %v key %v", msdef.SpecRef, msdef.Version, msdef.Id)
+	glog.V(3).Infof("Get new service def for upgrading service %v/%v version %v key %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id)
 
 	// convert the sensor version to a version expression
 	if vExp, err := policy.Version_Expression_Factory(msdef.UpgradeVersionRange); err != nil {
 		return nil, fmt.Errorf("Unable to convert %v to a version expression, error %v", msdef.UpgradeVersionRange, err)
 	} else if _, e_sdef, err := getService(msdef.SpecRef, msdef.Org, vExp.Get_expression(), msdef.Arch); err != nil {
-		return nil, fmt.Errorf("Failed to find a highest version for service %v version range %v: %v", msdef.SpecRef, msdef.UpgradeVersionRange, err)
+		return nil, fmt.Errorf("Failed to find a highest version for service %v/%v version range %v: %v", msdef.Org, msdef.SpecRef, msdef.UpgradeVersionRange, err)
 	} else if e_sdef == nil {
-		return nil, fmt.Errorf("Could not find any services for %v within the version range %v.", msdef.SpecRef, msdef.UpgradeVersionRange)
+		return nil, fmt.Errorf("Could not find any services for %v/%v within the version range %v.", msdef.Org, msdef.SpecRef, msdef.UpgradeVersionRange)
 	} else if new_msdef, err := ConvertServiceToPersistent(e_sdef, msdef.Org); err != nil {
-		return nil, fmt.Errorf("Failed to convert service metadata to persistent.MicroserviceDefinition for %v. %v", msdef.SpecRef, err)
+		return nil, fmt.Errorf("Failed to convert service metadata to persistent.MicroserviceDefinition for %v/%v. %v", msdef.Org, msdef.SpecRef, err)
 	} else {
 		// if the newer version is smaller than the old one, do nothing
 		if c, err := policy.CompareVersions(e_sdef.GetVersion(), msdef.Version); err != nil {
@@ -209,7 +209,7 @@ func GetUpgradeMicroserviceDef(getService exchange.ServiceResolverHandler, msdef
 			return nil, nil // no change, do nothing
 		} else {
 			if msdefs, err := persistence.FindMicroserviceDefs(db, []persistence.MSFilter{persistence.UrlVersionMSFilter(new_msdef.SpecRef, new_msdef.Version), persistence.ArchivedMSFilter()}); err != nil {
-				return nil, fmt.Errorf("Failed to get archived service definition for %v version %v. %v", msdef.SpecRef, msdef.Version, err)
+				return nil, fmt.Errorf("Failed to get archived service definition for %v/%v version %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, err)
 			} else if msdefs != nil && len(msdefs) > 0 {
 				for _, ms := range msdefs {
 					if ms.UpgradeNewMsId != "" && bytes.Equal(ms.MetadataHash, new_msdef.MetadataHash) {
@@ -233,7 +233,7 @@ func GetUpgradeMicroserviceDef(getService exchange.ServiceResolverHandler, msdef
 
 // Get a msdef with a lower version compared to the given msdef version and return the new microservice def.
 func GetRollbackMicroserviceDef(getService exchange.ServiceResolverHandler, msdef *persistence.MicroserviceDefinition, db *bolt.DB) (*persistence.MicroserviceDefinition, error) {
-	glog.V(3).Infof("Get next highest service def for rolling back service %v version %v key %v", msdef.SpecRef, msdef.Version, msdef.Id)
+	glog.V(3).Infof("Get next highest service def for rolling back service %v/%v version %v key %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id)
 
 	// convert the sensor version to a version expression
 	if vExp, err := policy.Version_Expression_Factory(msdef.UpgradeVersionRange); err != nil {
@@ -241,11 +241,11 @@ func GetRollbackMicroserviceDef(getService exchange.ServiceResolverHandler, msde
 	} else if err := vExp.ChangeCeiling(msdef.Version, false); err != nil { //modify the version range in order to searh for new ms
 		return nil, nil
 	} else if _, e_sdef, err := getService(msdef.SpecRef, msdef.Org, vExp.Get_expression(), msdef.Arch); err != nil {
-		return nil, fmt.Errorf("Failed to find a highest version for service %v version range %v: %v", msdef.SpecRef, vExp.Get_expression(), err)
+		return nil, fmt.Errorf("Failed to find a highest version for service %v/%v version range %v: %v", msdef.Org, msdef.SpecRef, vExp.Get_expression(), err)
 	} else if e_sdef == nil {
 		return nil, nil
 	} else if new_msdef, err := ConvertServiceToPersistent(e_sdef, msdef.Org); err != nil {
-		return nil, fmt.Errorf("Failed to convert service metadata to persistent.MicroserviceDefinition for %v. %v", msdef.SpecRef, err)
+		return nil, fmt.Errorf("Failed to convert service metadata to persistent.MicroserviceDefinition for %v/%v. %v", msdef.Org, msdef.SpecRef, err)
 	} else {
 
 		// copy some attributes from the old over to the new
@@ -289,7 +289,7 @@ func RemoveMicroservicePolicy(spec_ref string, org string, version string, msdef
 
 // Generate a new policy file for given ms and the register the microservice on the exchange.
 func GenMicroservicePolicy(msdef *persistence.MicroserviceDefinition, policyPath string, db *bolt.DB, e chan events.Message, deviceOrg string) error {
-	glog.V(3).Infof("Generate policy for the given service %v version %v key %v", msdef.SpecRef, msdef.Version, msdef.Id)
+	glog.V(3).Infof("Generate policy for the given service %v/%v version %v key %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id)
 
 	var haPartner []string
 	var meterPolicy policy.Meter
@@ -343,8 +343,8 @@ func GenMicroservicePolicy(msdef *persistence.MicroserviceDefinition, policyPath
 	}
 
 	// get the attributes for the microservice from the service_attribute table
-	if orig_attributes, err := persistence.FindApplicableAttributes(db, msdef.SpecRef); err != nil {
-		return fmt.Errorf("Failed to get the service attributes for %v from db. %v", msdef.SpecRef, err)
+	if orig_attributes, err := persistence.FindApplicableAttributes(db, msdef.SpecRef, msdef.Org); err != nil {
+		return fmt.Errorf("Failed to get the service attributes for %v/%v from db. %v", msdef.Org, msdef.SpecRef, err)
 	} else {
 		// device the attributes into 2 groups, common and specific
 		common_attribs := make([]persistence.Attribute, 0)
@@ -371,11 +371,11 @@ func GenMicroservicePolicy(msdef *persistence.MicroserviceDefinition, policyPath
 		//Generate a policy based on all the attributes and the service definition
 		maxAgreements := 1
 		if msdef.Sharable == exchange.MS_SHARING_MODE_SINGLETON || msdef.Sharable == exchange.MS_SHARING_MODE_MULTIPLE || msdef.Sharable == exchange.MS_SHARING_MODE_SINGLE {
-			maxAgreements = 2 // hard coded 2 for now, will change to 0 later
+			maxAgreements = 5 // hard coded 2 for now, will change to 0 later
 		}
 
 		if msg, err := policy.GeneratePolicy(msdef.SpecRef, msdef.Org, msdef.Name, msdef.Version, msdef.RequestedArch, &props, haPartner, meterPolicy, counterPartyProperties, *list, maxAgreements, policyPath, deviceOrg); err != nil {
-			return fmt.Errorf("Failed to generate policy for %v version %v. Error: %v", msdef.SpecRef, msdef.Version, err)
+			return fmt.Errorf("Failed to generate policy for %v/%v version %v. Error: %v", msdef.Org, msdef.SpecRef, msdef.Version, err)
 		} else {
 			e <- msg
 		}
@@ -387,10 +387,10 @@ func GenMicroservicePolicy(msdef *persistence.MicroserviceDefinition, policyPath
 // Unregisters the given microservice from the exchange
 func UnregisterMicroserviceExchange(getExchangeDevice exchange.DeviceHandler,
 	putExchangeDevice exchange.PutDeviceHandler,
-	spec_ref string,
+	spec_ref string, org string,
 	device_id string, device_token string, db *bolt.DB) error {
 
-	glog.V(3).Infof("Unregister service %v from exchange for %v.", spec_ref, device_id)
+	glog.V(3).Infof("Unregister service %v/%v from exchange for %v.", org, spec_ref, device_id)
 
 	var deviceName string
 
@@ -412,7 +412,7 @@ func UnregisterMicroserviceExchange(getExchangeDevice exchange.DeviceHandler,
 		// remove the service with the given spec_ref
 		ms_put := make([]exchange.Microservice, 0, 10)
 		for _, ms := range services {
-			if ms.Url != spec_ref {
+			if ms.Url != cutil.FormOrgSpecUrl(spec_ref, org) {
 				ms_put = append(ms_put, ms)
 			}
 		}
@@ -421,12 +421,12 @@ func UnregisterMicroserviceExchange(getExchangeDevice exchange.DeviceHandler,
 		pdr := exchange.CreateDevicePut(device_token, deviceName)
 		pdr.RegisteredServices = ms_put
 
-		glog.V(3).Infof("Unregistering service: %v", spec_ref)
+		glog.V(3).Infof("Unregistering service: %v/%v", org, spec_ref)
 
 		if resp, err := putExchangeDevice(device_id, device_token, pdr); err != nil {
-			return fmt.Errorf("Received error unregistering service %v from the exchange: %v", spec_ref, err)
+			return fmt.Errorf("Received error unregistering service %v/%v from the exchange: %v", org, spec_ref, err)
 		} else {
-			glog.V(3).Infof("Unregistered service %v in exchange: %v", spec_ref, resp)
+			glog.V(3).Infof("Unregistered service %v/%v in exchange: %v", org, spec_ref, resp)
 		}
 	}
 	return nil

--- a/microservice/microservice_test.go
+++ b/microservice/microservice_test.go
@@ -63,7 +63,7 @@ func TestMicroserviceReadyForUpgrade(t *testing.T) {
 	pms.UpgradeStartTime = uint64(0)
 
 	pms.Id = "1"
-	msi, err := persistence.NewMicroserviceInstance(db, pms.SpecRef, pms.Version, pms.Id, []persistence.ServiceInstancePathElement{})
+	msi, err := persistence.NewMicroserviceInstance(db, pms.SpecRef, pms.Org, pms.Version, pms.Id, []persistence.ServiceInstancePathElement{})
 	assert.Nil(t, err, fmt.Sprintf("should not return error, but got this: %v", err))
 
 	pms.AutoUpgrade = true
@@ -166,19 +166,19 @@ func TestUnregisterServiceExchange(t *testing.T) {
 	assert.Nil(t, err, fmt.Sprintf("should not return error, but got this: %v", err))
 
 	m1 := exchange.Microservice{
-		Url:           "gps",
+		Url:           "myorg/gps",
 		Properties:    nil,
 		NumAgreements: 0,
 		Policy:        "blahblah",
 	}
 	m2 := exchange.Microservice{
-		Url:           "network",
+		Url:           "myorg/network",
 		Properties:    nil,
 		NumAgreements: 0,
 		Policy:        "blahblah",
 	}
 	m3 := exchange.Microservice{
-		Url:           "pwsms",
+		Url:           "myorg/pwsms",
 		Properties:    nil,
 		NumAgreements: 0,
 		Policy:        "blahblah",
@@ -193,7 +193,7 @@ func TestUnregisterServiceExchange(t *testing.T) {
 
 	err = UnregisterMicroserviceExchange(getVariableDeviceHandler(nil, mss),
 		checkPutDeviceHandler(t, mss, url),
-		url, device_id, device_token, db)
+		url, org, device_id, device_token, db)
 	assert.NotNil(t, err, "Device not created in the db yet.")
 
 	// save device in db
@@ -202,12 +202,12 @@ func TestUnregisterServiceExchange(t *testing.T) {
 
 	err = UnregisterMicroserviceExchange(getVariableDeviceHandler(nil, nil),
 		checkPutDeviceHandler(t, nil, url),
-		url, device_id, device_token, db)
+		url, org, device_id, device_token, db)
 	assert.Nil(t, err, "no registered ms, nothing to do")
 
 	err = UnregisterMicroserviceExchange(getVariableDeviceHandler(nil, mss),
 		checkPutDeviceHandler(t, mss, url),
-		url, device_id, device_token, db)
+		url, org, device_id, device_token, db)
 	assert.Nil(t, err, "eveything should have worked")
 
 	err = cleanupDB(dir)

--- a/persistence/attribute_types.go
+++ b/persistence/attribute_types.go
@@ -19,8 +19,8 @@ func (a LocationAttributes) GetMeta() *AttributeMeta {
 
 func (a LocationAttributes) GetGenericMappings() map[string]interface{} {
 	return map[string]interface{}{
-		"lat":                  a.Lat,
-		"lon":                  a.Lon,
+		"lat": a.Lat,
+		"lon": a.Lon,
 		"location_accuracy_km": a.LocationAccuracyKM,
 		"use_gps":              a.UseGps,
 	}

--- a/persistence/microservices_test.go
+++ b/persistence/microservices_test.go
@@ -25,16 +25,18 @@ func Test_ServiceInstancePath_HasDirectParent_simple(t *testing.T) {
 	// Setup initial variable values
 	parentURL := "url1"
 	parentVersion := "1.0.0"
+	parentOrg := "myorg"
 	childURL := "url2"
+	childOrg := "childorg"
 	childVersion := "2.0.0"
 
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement(parentURL, parentVersion)
-	child := NewServiceInstancePathElement(childURL, childVersion)
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
 
 	depPath := []ServiceInstancePathElement{*parent, *child}
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, childURL, childVersion, "1234", depPath); err != nil {
+	if msi, err := NewMicroserviceInstance(db, childURL, childOrg, childVersion, "1234", depPath); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if !msi.HasDirectParent(parent) {
 		t.Errorf("Child %v has direct parent: %v", child, depPath)
@@ -54,19 +56,21 @@ func Test_ServiceInstancePath_HasDirectParent_fail1(t *testing.T) {
 
 	// Setup initial variable values
 	parentURL := "url1"
+	parentOrg := "myorg"
 	parentVersion := "1.0.0"
 	childURL := "url2"
+	childOrg := "childorg"
 	childVersion := "2.0.0"
 
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement(parentURL, parentVersion)
-	child := NewServiceInstancePathElement(childURL, childVersion)
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
 
-	notParent := NewServiceInstancePathElement("other", parentVersion)
+	notParent := NewServiceInstancePathElement("other", parentOrg, parentVersion)
 
 	depPath := []ServiceInstancePathElement{*parent, *child}
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, childURL, childVersion, "1234", depPath); err != nil {
+	if msi, err := NewMicroserviceInstance(db, childURL, childOrg, childVersion, "1234", depPath); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if msi.HasDirectParent(notParent) {
 		t.Errorf("Child %v does not have direct parent: %v", child, depPath)
@@ -86,20 +90,23 @@ func Test_ServiceInstancePath_HasDirectParent_fail2(t *testing.T) {
 
 	// Setup initial variable values
 	parentURL := "url1"
+	parentOrg := "myorg"
 	parentVersion := "1.0.0"
 	childURL := "url2"
+	childOrg := "childorg"
 	childVersion := "2.0.0"
 	child2URL := "url3"
+	child2Org := "child2org"
 	child2Version := "3.0.0"
 
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement(parentURL, parentVersion)
-	child := NewServiceInstancePathElement(childURL, childVersion)
-	child2 := NewServiceInstancePathElement(child2URL, child2Version)
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Org, child2Version)
 
 	depPath := []ServiceInstancePathElement{*parent, *child, *child2}
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, child2URL, child2Version, "1234", depPath); err != nil {
+	if msi, err := NewMicroserviceInstance(db, child2URL, child2Org, child2Version, "1234", depPath); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if msi.HasDirectParent(parent) {
 		t.Errorf("Child %v does not have direct parent: %v", child2, depPath)
@@ -119,24 +126,27 @@ func Test_ServiceInstancePath_HasDirectParent_fail3(t *testing.T) {
 
 	// Setup initial variable values
 	parentURL := "url1"
+	parentOrg := "myorg"
 	parentVersion := "1.0.0"
 	childURL := "url2"
+	childOrg := "childorg2"
 	childVersion := "2.0.0"
 	child2URL := "url3"
+	child2Org := "child2Org"
 	child2Version := "3.0.0"
 
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement(parentURL, parentVersion)
-	child := NewServiceInstancePathElement(childURL, childVersion)
-	child2 := NewServiceInstancePathElement(child2URL, child2Version)
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Org, child2Version)
 
-	notParent := NewServiceInstancePathElement("other", parentVersion)
+	notParent := NewServiceInstancePathElement("other", parentOrg, parentVersion)
 
 	depPath := []ServiceInstancePathElement{*parent, *child, *child2}
 	dp2 := []ServiceInstancePathElement{*parent, *child2}
 
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, child2URL, child2Version, "1234", depPath); err != nil {
+	if msi, err := NewMicroserviceInstance(db, child2URL, child2Org, child2Version, "1234", depPath); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if _, err := UpdateMSInstanceAddDependencyPath(db, msi.GetKey(), &dp2); err != nil {
 		t.Errorf("Error updating instance: %v", err)
@@ -158,22 +168,25 @@ func Test_ServiceInstancePath_HasDirectParent_second(t *testing.T) {
 
 	// Setup initial variable values
 	parentURL := "url1"
+	parentOrg := "myorg"
 	parentVersion := "1.0.0"
 	childURL := "url2"
+	childOrg := "childorg"
 	childVersion := "2.0.0"
 	child2URL := "url3"
+	child2Org := "childorg3"
 	child2Version := "3.0.0"
 
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement(parentURL, parentVersion)
-	child := NewServiceInstancePathElement(childURL, childVersion)
-	child2 := NewServiceInstancePathElement(child2URL, child2Version)
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Org, child2Version)
 
 	depPath := []ServiceInstancePathElement{*parent, *child, *child2}
 	dp2 := []ServiceInstancePathElement{*parent, *child2}
 
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, child2URL, child2Version, "1234", depPath); err != nil {
+	if msi, err := NewMicroserviceInstance(db, child2URL, child2Org, child2Version, "1234", depPath); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if newmsi, err := UpdateMSInstanceAddDependencyPath(db, msi.GetKey(), &dp2); err != nil {
 		t.Errorf("Error updating instance: %v", err)

--- a/persistence/persistence_int_test.go
+++ b/persistence/persistence_int_test.go
@@ -62,7 +62,8 @@ func Test_SaveArchitectureAttributes(t *testing.T) {
 		panic(err)
 	}
 
-	matches, err := FindApplicableAttributes(testDb, "zoo")
+	// check for backword compatibility
+	matches, err := FindApplicableAttributes(testDb, "zoo", "mycomp")
 	if err != nil {
 		panic(err)
 	}
@@ -98,8 +99,8 @@ func Test_DiscriminateSavedAttributes(t *testing.T) {
 		}
 	}
 
-	illZ := "http://illuminated.z/v/2"
-	illK := "http://illuminated.k/v/2"
+	illZ := "mycomp/http://illuminated.z/v/2"
+	illK := "mycomp/http://illuminated.k/v/2"
 
 	arch := &ArchitectureAttributes{
 		Meta: &AttributeMeta{
@@ -189,7 +190,7 @@ func Test_DiscriminateSavedAttributes(t *testing.T) {
 
 	pub(creds, illK)
 
-	services, err := FindApplicableAttributes(testDb, illK)
+	services, err := FindApplicableAttributes(testDb, "http://illuminated.k/v/2", "mycomp")
 	if err != nil {
 		panic(err)
 	}

--- a/policy/api_spec_list.go
+++ b/policy/api_spec_list.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"errors"
 	"fmt"
+	"github.com/open-horizon/anax/cutil"
 )
 
 // The purpose of this file is to provide APIs for working with the API spec list in a Policy.
@@ -70,7 +71,7 @@ func (self *APISpecList) Concatenate(new_list *APISpecList) {
 // This function adds an API spec to the list. Return an error if there are duplicates.
 func (self *APISpecList) Add_API_Spec(new_ele *APISpecification) error {
 	for _, ele := range *self {
-		if ele.SpecRef == new_ele.SpecRef {
+		if ele.SpecRef == new_ele.SpecRef && ele.Org == new_ele.Org {
 			return errors.New(fmt.Sprintf("APISpecList %v already has the element being added: %v", *self, *new_ele))
 		}
 	}
@@ -164,7 +165,7 @@ func (self *APISpecList) MergeWith(other *APISpecList) APISpecList {
 func (self *APISpecList) AsStringArray() []string {
 	res := make([]string, 0, 10)
 	for _, apiSpec := range *self {
-		res = append(res, apiSpec.SpecRef)
+		res = append(res, cutil.FormOrgSpecUrl(apiSpec.SpecRef, apiSpec.Org))
 	}
 	return res
 }
@@ -187,9 +188,9 @@ func (self *APISpecList) GetCommonVersionRanges() (*APISpecList, error) {
 
 				// get the intersection of the two version ranges
 				if v, err := Version_Expression_Factory(apiSpec.Version); err != nil {
-					return nil, fmt.Errorf("Error creating version range for %v, %v", apiSpec.SpecRef, apiSpec.Version)
+					return nil, fmt.Errorf("Error creating version range for %v/%v, %v", apiSpec.Org, apiSpec.SpecRef, apiSpec.Version)
 				} else if v_new, err := Version_Expression_Factory(newApiSpec.Version); err != nil {
-					return nil, fmt.Errorf("Error creating version range for %v, %v", newApiSpec.SpecRef, newApiSpec.Version)
+					return nil, fmt.Errorf("Error creating version range for %v/%v, %v", newApiSpec.Org, newApiSpec.SpecRef, newApiSpec.Version)
 				} else if err := v.IntersectsWith(v_new); err != nil {
 					// no intersection found, remove the microservice from the list.
 					(*new_list)[i].Version = NO_INTERSECTION

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"fmt"
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/events"
 	"strings"
@@ -15,11 +16,11 @@ import (
 
 func GeneratePolicy(sensorUrl string, sensorOrg string, sensorName string, sensorVersion string, arch string, props *map[string]interface{}, haPartners []string, meterPolicy Meter, counterPartyProperties RequiredProperty, agps []AgreementProtocol, maxAgreements int, filePath string, deviceOrg string) (*events.PolicyCreatedMessage, error) {
 
-	glog.V(5).Infof("Generating policy for %v", sensorUrl)
+	glog.V(5).Infof("Generating policy for %v/%v", sensorOrg, sensorUrl)
 
 	// Generate a policy file name
 	a_tmp := strings.Split(sensorUrl, "/")
-	fileName := a_tmp[len(a_tmp)-1]
+	fileName := fmt.Sprintf("%v_%v", sensorOrg, a_tmp[len(a_tmp)-1])
 
 	p := Policy_Factory("Policy for " + fileName)
 	p.Add_API_Spec(APISpecification_Factory(sensorUrl, sensorOrg, sensorVersion, arch))

--- a/policy/policy_manager.go
+++ b/policy/policy_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/cutil"
 	"reflect"
 	"sync"
 )
@@ -123,7 +124,7 @@ func (self *PolicyManager) addPolicy(org string, newPolicy *Policy) error {
 
 		keyName := newPolicy.Header.Name
 		if self.APISpecCounts {
-			keyName = newPolicy.APISpecs[0].SpecRef
+			keyName = cutil.FormOrgSpecUrl(newPolicy.APISpecs[0].SpecRef, newPolicy.APISpecs[0].Org)
 		}
 
 		self.AgreementCounts[org][keyName] = cce
@@ -330,7 +331,7 @@ func (self *PolicyManager) AttemptingAgreement(policies []Policy, agreement stri
 		for _, pol := range policies {
 			keyName := pol.Header.Name
 			if self.APISpecCounts && len(pol.APISpecs) > 0 {
-				keyName = pol.APISpecs[0].SpecRef
+				keyName = cutil.FormOrgSpecUrl(pol.APISpecs[0].SpecRef, pol.APISpecs[0].Org)
 			}
 
 			if cce, there := orgMap[keyName]; !there {
@@ -370,7 +371,7 @@ func (self *PolicyManager) FinalAgreement(policies []Policy, agreement string, o
 
 			keyName := pol.Header.Name
 			if self.APISpecCounts && len(pol.APISpecs) > 0 {
-				keyName = pol.APISpecs[0].SpecRef
+				keyName = cutil.FormOrgSpecUrl(pol.APISpecs[0].SpecRef, pol.APISpecs[0].Org)
 			}
 
 			if cce, there := orgMap[keyName]; !there {
@@ -411,7 +412,7 @@ func (self *PolicyManager) CancelAgreement(policies []Policy, agreement string, 
 
 			keyName := pol.Header.Name
 			if self.APISpecCounts && len(pol.APISpecs) > 0 {
-				keyName = pol.APISpecs[0].SpecRef
+				keyName = cutil.FormOrgSpecUrl(pol.APISpecs[0].SpecRef, pol.APISpecs[0].Org)
 			}
 
 			if cce, there := orgMap[keyName]; !there {
@@ -449,7 +450,7 @@ func (self *PolicyManager) ReachedMaxAgreements(policies []Policy, org string) (
 
 			keyName := pol.Header.Name
 			if self.APISpecCounts {
-				keyName = pol.APISpecs[0].SpecRef
+				keyName = cutil.FormOrgSpecUrl(pol.APISpecs[0].SpecRef, pol.APISpecs[0].Org)
 			}
 
 			if cce, there := orgMap[keyName]; !there {
@@ -641,7 +642,7 @@ func (self *PolicyManager) GetAllAvailablePolicies(org string) []Policy {
 
 		keyName := pol.Header.Name
 		if self.APISpecCounts {
-			keyName = pol.APISpecs[0].SpecRef
+			keyName = cutil.FormOrgSpecUrl(pol.APISpecs[0].SpecRef, pol.APISpecs[0].Org)
 		}
 
 		if self.AgreementTracking && self.unlockedReachedMaxAgreements(pol, self.AgreementCounts[org][keyName].Count) {

--- a/producer/producer_protocol_handler.go
+++ b/producer/producer_protocol_handler.go
@@ -175,7 +175,7 @@ func (w *BaseProducerProtocolHandler) HandleProposal(ph abstractprotocol.Protoco
 		eventlog.LogAgreementEvent2(
 			w.db,
 			persistence.SEVERITY_INFO,
-			fmt.Sprintf("Node received Proposal message for service %v from the agbot %v.", wls, proposal.ConsumerId()),
+			fmt.Sprintf("Node received Proposal message for service %v/%v from the agbot %v.", worg, wls, proposal.ConsumerId()),
 			persistence.EC_RECEIVED_PROPOSAL,
 			proposal.AgreementId(),
 			persistence.WorkloadInfo{URL: wls, Org: worg, Version: wversion, Arch: warch},
@@ -226,7 +226,7 @@ func (w *BaseProducerProtocolHandler) HandleProposal(ph abstractprotocol.Protoco
 					eventlog.LogAgreementEvent2(
 						w.db,
 						persistence.SEVERITY_INFO,
-						fmt.Sprintf("Node rejected the proposal for service %v.", wls),
+						fmt.Sprintf("Node rejected the proposal for service %v/%v.", worg, wls),
 						persistence.EC_REJECT_PROPOSAL,
 						proposal.AgreementId(),
 						persistence.WorkloadInfo{URL: wls, Org: worg, Version: wversion, Arch: warch},
@@ -242,7 +242,7 @@ func (w *BaseProducerProtocolHandler) HandleProposal(ph abstractprotocol.Protoco
 			eventlog.LogAgreementEvent2(
 				w.db,
 				persistence.SEVERITY_ERROR,
-				fmt.Sprintf("Error handling proposal for service %v. Error: %v", wls, err_log_event),
+				fmt.Sprintf("Error handling proposal for service %v/%v. Error: %v", worg, wls, err_log_event),
 				persistence.EC_ERROR_PROCESSING_PROPOSAL,
 				proposal.AgreementId(),
 				persistence.WorkloadInfo{URL: wls, Org: worg, Version: wversion, Arch: warch},

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,7 @@ HORIZON_PKG_VER ?= $(shell curl -s $(PKGS_URL) | grep -A 2 'Package: horizon' | 
 #    MSGHUB_API_KEY
 #
 
-TEST_VARS ?= NOLOOP=1 TEST_DIFF_ORG=0 TEST_PATTERNS=sall
+TEST_VARS ?= NOLOOP=1 TEST_DIFF_ORG=0 TEST_PATTERNS="sall"
 APPSTORE = $(shell echo $(TEST_VARS) | awk -F "APPSTORE=" '{print $$2}' | cut -c1)
 
 # msghub

--- a/test/README.md
+++ b/test/README.md
@@ -52,11 +52,11 @@ Here is a full description of all the variables you can use to setup the test th
 - NOLOOP=1 - turns off the loop that cancels agreements on the device and agbot (alternating), every 10 mins. Usually you want to specify NOLOOP=1 when actively iterating code.
 - NOCANCEL=1 - when set with NOLOOP=1, skips the single round of cancellation tests for less log clutter and time when just interested in agreement formation.
 - UNCONFIG=1 - turns on the unconfig/reconfig loop tests.
-- PATTERN=name - specify the name of a configured pattern that you want the device to use. Builtin patterns are pws, spws, ns, sns, loc, sloc, gps, sgps, ns-keytest, all, sall, cpu2msghub etc. If you specify PATTERN, but turn off one of the microservices that the workload needs, the system will not work correctly. If you dont specify a PATTERN, the manually managed policy files will be used to run the workloads (unless you turn them off).
-- NONS=1 - dont register the netspeed microservice.
-- NOGPS=1 - dont register the gpstest microservice.
-- NOLOC=1 - dont register the location microservice.
-- NOPWS=1 - dont register the weather microservice. This is a good workload to run when iterating code because it is simple and reliable, it wont get in your way.
+- PATTERN=name - specify the name of a configured pattern that you want the device to use. Builtin patterns are spws, sns, sloc, sgps, sall, cpu2msghub etc. If you specify PATTERN, but turn off one of the dependent services that the top service needs, the system will not work correctly. If you dont specify a PATTERN, the manually managed policy files will be used to run the workloads (unless you turn them off).
+- NONS=1 - dont register the netspeed service.
+- NOGPS=1 - dont register the gpstest service.
+- NOLOC=1 - dont register the location service.
+- NOPWS=1 - dont register the weather service. This is a good workload to run when iterating code because it is simple and reliable, it wont get in your way.
 - NOANAX=1 - anax is started for API tests but is then stopped and is NOT restarted to run workloads.
 - NOAGBOT=1 - the agbot is never started.
 - HA=1 - register 2 devices (and the workload services) as an HA pair. You will get 2 anax device processes in the container.

--- a/test/docker/fs/etc/agbot/policy.d/e2edev/netspeed2.policy
+++ b/test/docker/fs/etc/agbot/policy.d/e2edev/netspeed2.policy
@@ -1,0 +1,63 @@
+{
+    "header": {
+        "name": "CS e2edev netspeed policy",
+        "version": "2.0"
+    },
+    "useServices": true,
+    "agreementProtocols": [
+      {
+        "name": "Basic"
+      }
+    ],
+    "workloads": [
+    {
+      "workloadUrl":"https://bluehorizon.network/services/netspeed",
+      "organization":"e2edev",
+      "version":"2.3.0",
+      "arch":"amd64",
+      "deployment_overrides":"{\"services\":{\"netspeed5\":{\"environment\":[\"E2EDEV_OVERRIDE=1\"]}}}",
+      "deployment_overrides_signature":"CoQb1Tw204vbMP0H1Faw7Sp9lHHSiIzvhlX9SEejx2kRY+x6uj7PB4fvJUBoYlWJJOkecQKDD9zdLm6hD32b+f9zMWaBdRF5Ab4pHU5gcDPpuPGnYup1ZreSe4eqPnThkGgfYIW5zcQd/vbxO9tx31EM8lJ5NrhcJ5rwhwbIPDh7Hstxi84IetNAygE1gPaTGQaJzzqATFYINwWkxjJXjihdEVuo5IvINJusHtIs7C6BIVy9+CExUXXxem1I/bzvwzY1wpKuubHxq1CddIKr+BaHAsErHIHvJQVc3JoDPgXPjVE8ew1QKjLCkC86wRbANN6rhCB2Q6+HhyaRfv8oJDz8XoLBcYw6bKerGMCxEBTuyUu0n9mTSCzEZZaaLdmxTzaLN47Svm8Gj18tT5CjvYkeSgDpISwRR0aME8YSHO6OtRKhLFGvZDzR4hu6kzyfp7aiYHRzVDrfcKhch/c0AuAEb6qEQ8nCHnSFJwEXP/3L3qKy8y8OT+42vumXTYOp7IadZ+UnFxLNJip9qnEsXFS8+WlT3PwaNMKFdg+zsJfUz5V+OXaotZKfe9PABn4+656PfngIi+N7q/unnrNSzc/BN8Dgy1FSHqVQ0UfRWST31pStJi2kS46UreIBgG9T6D/WgwnvATN3BaZkveiwDpUXRNv5nGzcWqnIerWWfL8=",
+      "priority":{
+        "priority_value": 3,
+        "retries": 1,
+        "retry_durations": 1800,
+        "verified_durations": 45
+      }
+    },
+    {
+      "workloadUrl":"https://bluehorizon.network/services/netspeed",
+      "organization":"e2edev",
+      "version":"2.3.0",
+      "arch":"amd64",
+      "deployment_overrides":"{\"services\":{\"netspeed5\":{\"environment\":[\"E2EDEV_OVERRIDE=1\"]}}}",
+      "deployment_overrides_signature":"CoQb1Tw204vbMP0H1Faw7Sp9lHHSiIzvhlX9SEejx2kRY+x6uj7PB4fvJUBoYlWJJOkecQKDD9zdLm6hD32b+f9zMWaBdRF5Ab4pHU5gcDPpuPGnYup1ZreSe4eqPnThkGgfYIW5zcQd/vbxO9tx31EM8lJ5NrhcJ5rwhwbIPDh7Hstxi84IetNAygE1gPaTGQaJzzqATFYINwWkxjJXjihdEVuo5IvINJusHtIs7C6BIVy9+CExUXXxem1I/bzvwzY1wpKuubHxq1CddIKr+BaHAsErHIHvJQVc3JoDPgXPjVE8ew1QKjLCkC86wRbANN6rhCB2Q6+HhyaRfv8oJDz8XoLBcYw6bKerGMCxEBTuyUu0n9mTSCzEZZaaLdmxTzaLN47Svm8Gj18tT5CjvYkeSgDpISwRR0aME8YSHO6OtRKhLFGvZDzR4hu6kzyfp7aiYHRzVDrfcKhch/c0AuAEb6qEQ8nCHnSFJwEXP/3L3qKy8y8OT+42vumXTYOp7IadZ+UnFxLNJip9qnEsXFS8+WlT3PwaNMKFdg+zsJfUz5V+OXaotZKfe9PABn4+656PfngIi+N7q/unnrNSzc/BN8Dgy1FSHqVQ0UfRWST31pStJi2kS46UreIBgG9T6D/WgwnvATN3BaZkveiwDpUXRNv5nGzcWqnIerWWfL8=",
+      "priority":{
+        "priority_value": 2,
+        "retries": 1,
+        "retry_durations": 3600
+      }
+    }
+    ],
+    "resourceLimits": {
+        "networkUpload": 1024,
+        "networkDownload": 1024,
+        "memory": 2048,
+        "cpus": 2
+    },
+    "properties": [
+      {
+          "name": "iame2edev",
+          "value": true
+      },
+      {
+          "name": "fred",
+          "value": 11
+      }
+    ],
+    "nodeHealth": {
+        "missing_heartbeat_interval": 240,
+        "check_agreement_status": 60
+    },
+    "dataVerification": {},
+    "maxAgreements": 2
+}

--- a/test/gov/loc2_apireg.sh
+++ b/test/gov/loc2_apireg.sh
@@ -43,11 +43,21 @@ fi
 
 read -d '' slocservice <<EOF
 {
-  "url": "https://bluehorizon.network/service-cpu",
-  "name": "cpu",
-  "organization": "IBM",
-  "versionRange": "1.0.0",
-  "attributes": []
+    "url": "https://bluehorizon.network/service-cpu",
+    "name": "cpu",
+    "organization": "IBM",
+    "versionRange": "1.0.0",
+    "attributes": [
+        {
+            "type": "UserInputAttributes",
+            "label": "User input variables",
+            "publishable": false,
+            "host_only": false,
+            "mappings": {
+                "cpu_var1": "ibmvar1"
+            }
+        }
+    ]
 }
 EOF
 
@@ -57,8 +67,10 @@ echo "Registering service based cpu service"
 
 ERR=$(echo "$slocservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
 if [ "$ERR" != "null" ]; then
-  echo -e "error occured: $ERR"
-  exit 2
+    if [ "${ERR:0:22}" != "Duplicate registration" ]; then 
+        echo -e "error occured: $ERR"
+        exit 2
+    fi
 fi
 
 read -d '' slocservice <<EOF

--- a/test/gov/ns_apireg.sh
+++ b/test/gov/ns_apireg.sh
@@ -5,13 +5,18 @@ echo -e "\nBC setting is $BC"
 if [ "$BC" != "1" ]
 then
 
-echo -e "Pattern is set to $PATTERN"
-if [ "$PATTERN" == "" ]
-then
+    echo -e "Pattern is set to $PATTERN"
+    if [ "$PATTERN" == "" ]
+    then
 
-# Configure the netspeed service variables, at an older version level just to be sure
-# that the runtime will still pick them up for the newer version that is installed in the exchange.
-read -d '' snsconfig <<EOF
+        # Configure the netspeed service variables, at an older version level just to be sure
+        # that the runtime will still pick them up for the newer version that is installed in the exchange.
+        # To test the services from different orgs with same url, we have setup 2 netspeed services.
+        # IBM/netspeed depends on: IBM/nework, IBN/network2, IBM/cpu
+        # e2edev/netspeed depends on: e2edev/network, e2edev/network2, IBM/cpu e2edev/cpu
+
+        ### IBM/netspeed
+        read -d '' snsconfig <<EOF
 {
   "url": "https://bluehorizon.network/services/netspeed",
   "version": "2.2.0",
@@ -33,18 +38,47 @@ read -d '' snsconfig <<EOF
   ]
 }
 EOF
+        echo -e "\n\n[D] IBM/netspeed service config payload: $snsconfig"
+        echo "Registering IBM/netspeed service config on node"
+        ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo -e "\n\n[D] netspeed service config payload: $snsconfig"
+        ### e2edev/netspeed
+        read -d '' snsconfig <<EOF
+{
+  "url": "https://bluehorizon.network/services/netspeed",
+  "version": "2.2.0",
+  "organization": "e2edev",
+  "attributes": [
+    {
+      "type": "UserInputAttributes",
+      "label": "User input variables",
+      "publishable": false,
+      "host_only": false,
+      "mappings": {
+        "var1": "bString",
+        "var2": 10,
+        "var3": 10.22,
+        "var4": ["abcd", "1234"],
+        "var5": "override2"
+      }
+    }
+  ]
+}
+EOF
+        echo -e "\n\n[D] e2edev/netspeed service config payload: $snsconfig"
+        echo "Registering e2edev/netspeed service config on node"
+        ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo "Registering netspeed service config on node"
-
-ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
-if [ "$ERR" != "null" ]; then
-  echo -e "error occured: $ERR"
-  exit 2
-fi
-
-read -d '' networkservice <<EOF
+        ### IBM/network
+        read -d '' networkservice <<EOF
 {
   "url": "https://bluehorizon.network/services/network",
   "version": "1.0.0",
@@ -52,18 +86,34 @@ read -d '' networkservice <<EOF
   "attributes": []
 }
 EOF
+        echo -e "\n\n[D] networkservice payload: $networkservice"
+        echo "Registering IBM/network service"
+        ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo -e "\n\n[D] networkservice payload: $networkservice"
+        ### e2edev/network
+        read -d '' networkservice <<EOF
+{
+  "url": "https://bluehorizon.network/services/network",
+  "version": "1.0.0",
+  "organization": "e2edev",
+  "attributes": []
+}
+EOF
+        echo -e "\n\n[D] networkservice payload: $networkservice"
+        echo "Registering e2edev/network service"
+        ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo "Registering network service"
 
-ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
-if [ "$ERR" != "null" ]; then
-  echo -e "error occured: $ERR"
-  exit 2
-fi
-
-read -d '' networkservice <<EOF
+        ### IBM/network2
+        read -d '' networkservice <<EOF
 {
   "url": "https://bluehorizon.network/services/network2",
   "version": "1.0.0",
@@ -71,25 +121,101 @@ read -d '' networkservice <<EOF
   "attributes": []
 }
 EOF
+        echo -e "\n\n[D] networkservice payload: $networkservice"
+        echo "Registering IBM/network2 service"
+        ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            if [ "${ERR:0:22}" != "Duplicate registration" ]; then
+                echo -e "error occured: $ERR"
+                exit 2
+            fi
+        fi
 
-echo -e "\n\n[D] networkservice payload: $networkservice"
+        ### e2edev/network2
+        read -d '' networkservice <<EOF
+{
+  "url": "https://bluehorizon.network/services/network2",
+  "version": "1.0.0",
+  "organization": "e2edev",
+  "attributes": []
+}
+EOF
+        echo -e "\n\n[D] networkservice payload: $networkservice"
+        echo "Registering e2edev/network2 service"
+        ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            if [ "${ERR:0:22}" != "Duplicate registration" ]; then
+                echo -e "error occured: $ERR"
+                exit 2
+            fi
+        fi
 
-echo "Registering network service"
+         ### IBM/cpu
+        read -d '' slocservice <<EOF
+{
+    "url": "https://bluehorizon.network/service-cpu",
+    "name": "cpu",
+    "organization": "IBM",
+    "versionRange": "1.0.0",
+    "attributes": [
+        {
+            "type": "UserInputAttributes",
+            "label": "User input variables",
+            "publishable": false,
+            "host_only": false,
+            "mappings": {
+                "cpu_var1": "ibmvar1"
+            }
+        }
+    ]
+}
+EOF
+        echo -e "\n\n[D] service based cpu service payload: $slocservice"
+        echo "Registering service based IBM/cpu service"
+        ERR=$(echo "$slocservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            if [ "${ERR:0:22}" != "Duplicate registration" ]; then 
+                echo -e "error occured: $ERR"
+                exit 2
+            fi
+        fi
 
-ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
-if [ "$ERR" != "null" ]; then
-  if [ "${ERR:0:22}" != "Duplicate registration" ]; then
-    echo -e "error occured: $ERR"
-    exit 2
-  fi
-fi
+         ### e2edev/cpu
+        read -d '' slocservice <<EOF
+{
+    "url": "https://bluehorizon.network/service-cpu",
+    "name": "cpu",
+    "organization": "e2edev",
+    "versionRange": "1.0.0",
+    "attributes": [
+        {
+            "type": "UserInputAttributes",
+            "label": "User input variables",
+            "publishable": false,
+            "host_only": false,
+            "mappings": {
+                "cpu_var1": "e2edevvar1"
+             }
+        }
+    ]
+}
+EOF
+        echo -e "\n\n[D] service based cpu service payload: $slocservice"
+        echo "Registering service based e2edev/cpu service"
+        ERR=$(echo "$slocservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-elif [ "$PATTERN" == "sns" ] || [ "$PATTERN" == "sall" ]
-then
+    elif [ "$PATTERN" == "sns" ] || [ "$PATTERN" == "sall" ]
+    then
 
-# Configure the netspeed service variables, at an older version level just to be sure
-# that the runtime will still pick them up for the newer version that is installed in the exchange.
-read -d '' snsconfig <<EOF
+        # Configure the netspeed service variables, at an older version level just to be sure
+        # that the runtime will still pick them up for the newer version that is installed in the exchange.
+
+        ### IBM/netspeed
+        read -d '' snsconfig <<EOF
 {
   "url": "https://bluehorizon.network/services/netspeed",
   "version": "2.2.0",
@@ -111,17 +237,102 @@ read -d '' snsconfig <<EOF
   ]
 }
 EOF
+        echo -e "\n\n[D] IBM/netspeed service config payload: $snsconfig"
+        echo "Registering IBM/netspeed service config on node"
+        ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo -e "\n\n[D] netspeed service config payload: $snsconfig"
+        ### e2edev/netspeed
+        read -d '' snsconfig <<EOF
+{
+  "url": "https://bluehorizon.network/services/netspeed",
+  "version": "2.2.0",
+  "organization": "e2edev",
+  "attributes": [
+    {
+      "type": "UserInputAttributes",
+      "label": "User input variables",
+      "publishable": false,
+      "host_only": false,
+      "mappings": {
+        "var1": "aString",
+        "var2": 5,
+        "var3": 10.2,
+        "var4": ["abc", "123"],
+        "var5": "override"
+      }
+    }
+  ]
+}
+EOF
+        echo -e "\n\n[D] e2edev/netspeed service config payload: $snsconfig"
+        echo "Registering e2edev/netspeed service config on node"
+        ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo "Registering netspeed service config on node"
+         ### IBM/cpu
+        read -d '' slocservice <<EOF
+{
+    "url": "https://bluehorizon.network/service-cpu",
+    "name": "cpu",
+    "organization": "IBM",
+    "versionRange": "1.0.0",
+    "attributes": [
+        {
+            "type": "UserInputAttributes",
+            "label": "User input variables",
+            "publishable": false,
+            "host_only": false,
+            "mappings": {
+                "cpu_var1": "ibmvar1"
+            }
+        }
+    ]
+}
+EOF
+        echo -e "\n\n[D] service based cpu service payload: $slocservice"
+        echo "Registering service based IBM/cpu service"
+        ERR=$(echo "$slocservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            if [ "${ERR:0:22}" != "Duplicate registration" ]; then 
+                echo -e "error occured: $ERR"
+                exit 2
+            fi
+        fi
+        
+         ### e2edev/cpu
+        read -d '' slocservice <<EOF
+{
+    "url": "https://bluehorizon.network/service-cpu",
+    "name": "cpu",
+    "organization": "e2edev",
+    "versionRange": "1.0.0",
+    "attributes": [
+        {
+            "type": "UserInputAttributes",
+            "label": "User input variables",
+            "publishable": false,
+            "host_only": false,
+            "mappings": {
+                "cpu_var1": "e2edevvar1"
+             }
+        }
+    ]
+}
+EOF
+        echo -e "\n\n[D] service based cpu service payload: $slocservice"
+        echo "Registering service based e2edev/cpu service"
+        ERR=$(echo "$slocservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
-if [ "$ERR" != "null" ]; then
-  echo -e "error occured: $ERR"
-  exit 2
-fi
-
-fi
-
+    fi
 fi

--- a/test/gov/service_apireg.sh
+++ b/test/gov/service_apireg.sh
@@ -139,7 +139,13 @@ cat <<EOF >$KEY_TEST_DIR/svc_cpu.json
   "arch":"amd64",
   "sharable":"singleton",
   "matchHardware":{},
-  "userInput":[],
+  "userInput":[
+    {
+      "name":"cpu_var1",
+      "label":"",
+      "type":"string"
+    }
+  ],
   "deployment":{
     "services":{
       "cpu":{
@@ -150,13 +156,52 @@ cat <<EOF >$KEY_TEST_DIR/svc_cpu.json
   "deploymentSignature":""
 }
 EOF
-echo -e "Register cpu service $VERS:"
+echo -e "Register IBM/cpu service $VERS:"
 hzn exchange service publish -I -u $IBM_ADMIN_AUTH -o IBM -f $KEY_TEST_DIR/svc_cpu.json -k $KEY_TEST_DIR/*private.key
 if [ $? -ne 0 ]
 then
-    echo -e "hzn exchange service publish failed for CPU."
+    echo -e "hzn exchange service publish failed for IBM/cpu."
     exit 2
 fi
+
+# cpu service - needed by the e2edev/netspeed
+VERS="1.0"
+cat <<EOF >$KEY_TEST_DIR/svc_cpu.json
+{
+  "label":"CPU service",
+  "description":"CPU service",
+  "public":true,
+  "url":"https://bluehorizon.network/service-cpu",
+  "version":"$VERS",
+  "arch":"amd64",
+  "sharable":"singleton",
+  "matchHardware":{},
+  "userInput":[
+    {
+      "name":"cpu_var1",
+      "label":"",
+      "type":"string"
+    }
+  ],
+  "deployment":{
+    "services":{
+      "cpu":{
+        "image":"openhorizon/amd64_cpu:1.2.2"
+      }
+    }
+  },
+  "deploymentSignature":""
+}
+EOF
+
+echo -e "Register e2edev/cpu service $VERS:"
+hzn exchange service publish -I -u $E2EDEV_ADMIN_AUTH -o e2edev -f $KEY_TEST_DIR/svc_cpu.json -k $KEY_TEST_DIR/*private.key
+if [ $? -ne 0 ]
+then
+    echo -e "hzn exchange service publish failed for e2edev/cpu."
+    exit 2
+fi
+
 
 # A no-op network service used by the netspeed service as a dependency.
 VERS="1.5.0"
@@ -175,9 +220,14 @@ read -d '' sdef <<EOF
   "deploymentSignature":""
 }
 EOF
-echo -e "Register network service $VERS:"
+echo -e "Register IBM/network service $VERS:"
 RES=$(echo "$sdef" | curl -sLX POST --header 'Content-Type: application/json' --header 'Accept: application/json' -H "Authorization:Basic root/root:Horizon-Rul3s" --data @- "${EXCH_URL}/orgs/IBM/services" | jq -r '.')
 results "$RES"
+
+echo -e "Register e2edev/network service $VERS:"
+RES=$(echo "$sdef" | curl -sLX POST --header 'Content-Type: application/json' --header 'Accept: application/json' -H "Authorization:Basic root/root:Horizon-Rul3s" --data @- "${EXCH_URL}/orgs/e2edev/services" | jq -r '.')
+results "$RES"
+
 
 VERS="1.5.0"
 read -d '' sdef <<EOF
@@ -195,8 +245,12 @@ read -d '' sdef <<EOF
   "deploymentSignature":""
 }
 EOF
-echo -e "Register network service $VERS:"
+echo -e "Register IBM/network service $VERS:"
 RES=$(echo "$sdef" | curl -sLX POST --header 'Content-Type: application/json' --header 'Accept: application/json' -H "Authorization:Basic root/root:Horizon-Rul3s" --data @- "${EXCH_URL}/orgs/IBM/services" | jq -r '.')
+results "$RES"
+
+echo -e "Register e2edev/network service $VERS:"
+RES=$(echo "$sdef" | curl -sLX POST --header 'Content-Type: application/json' --header 'Accept: application/json' -H "Authorization:Basic root/root:Horizon-Rul3s" --data @- "${EXCH_URL}/orgs/e2edev/services" | jq -r '.')
 results "$RES"
 
 
@@ -382,7 +436,8 @@ cat <<EOF >$KEY_TEST_DIR/svc_netspeed.json
   "arch":"amd64",
   "requiredServices":[
     {"url":"https://bluehorizon.network/services/network","version":"1.0.0","arch":"amd64","org":"IBM"},
-    {"url":"https://bluehorizon.network/services/network2","version":"1.0.0","arch":"amd64","org":"IBM"}
+    {"url":"https://bluehorizon.network/services/network2","version":"1.0.0","arch":"amd64","org":"IBM"},
+    {"url":"https://bluehorizon.network/service-cpu","version":"1.0.0","arch":"amd64","org":"IBM"}
   ],
   "userInput":[
     {
@@ -429,11 +484,79 @@ cat <<EOF >$KEY_TEST_DIR/svc_netspeed.json
   "deploymentSignature":""
 }
 EOF
-echo -e "Register netspeed service $VERS:"
+echo -e "Register IBM/netspeed service $VERS:"
 hzn exchange service publish -I -u $IBM_ADMIN_AUTH -o IBM -f $KEY_TEST_DIR/svc_netspeed.json -k $KEY_TEST_DIR/*private.key
 if [ $? -ne 0 ]
 then
-    echo -e "hzn exchange service publish failed for Netspeed."
+    echo -e "hzn exchange service publish failed for IBM/netspeed."
+    exit 2
+fi
+
+cat <<EOF >$KEY_TEST_DIR/svc_netspeed.json
+{
+  "label":"Netspeed for x86_64",
+  "description":"Netspeed service",
+  "sharable":"multiple",
+  "public":true,
+  "url":"https://bluehorizon.network/services/netspeed",
+  "version":"$VERS",
+  "arch":"amd64",
+  "requiredServices":[
+    {"url":"https://bluehorizon.network/services/network","version":"1.0.0","arch":"amd64","org":"e2edev"},
+    {"url":"https://bluehorizon.network/services/network2","version":"1.0.0","arch":"amd64","org":"e2edev"},
+    {"url":"https://bluehorizon.network/service-cpu","version":"1.0.0","arch":"amd64","org":"e2edev"},
+    {"url":"https://bluehorizon.network/service-cpu","version":"1.0.0","arch":"amd64","org":"IBM"}
+  ],
+  "userInput":[
+    {
+      "name":"var1",
+      "label":"",
+      "type":"string"
+    },
+    {
+      "name":"var2",
+      "label":"",
+      "type":"int"
+    },
+    {
+      "name":"var3",
+      "label":"",
+      "type":"float"
+    },
+    {
+      "name":"var4",
+      "label":"",
+      "type":"list of strings"
+    },
+    {
+      "name":"var5",
+      "label":"",
+      "type":"string",
+      "defaultValue":"default"
+    },
+    {
+      "name":"var6",
+      "label":"",
+      "type":"string",
+      "defaultValue":"default"
+    }
+  ],
+  "deployment":{
+    "services":{
+      "netspeed5":{
+        "image":"openhorizon/amd64_netspeed:2.5.0",
+        "environment":["USE_NEW_STAGING_URL=false","DEPL_ENV=staging","SKIP_NUM_REPEAT_LOC_READINGS=0"]
+      }
+    }
+  },
+  "deploymentSignature":""
+}
+EOF
+echo -e "Register e2edev/netspeed service $VERS:"
+hzn exchange service publish -I -u $E2EDEV_ADMIN_AUTH -o e2edev -f $KEY_TEST_DIR/svc_netspeed.json -k $KEY_TEST_DIR/*private.key
+if [ $? -ne 0 ]
+then
+    echo -e "hzn exchange service publish failed for e2edev/netspeed."
     exit 2
 fi
 
@@ -949,6 +1072,41 @@ read -d '' msdef <<EOF
     {
       "serviceUrl":"https://bluehorizon.network/services/netspeed",
       "serviceOrgid":"IBM",
+      "serviceArch":"amd64",
+      "serviceVersions":[
+        {
+          "version":"$NSVERS",
+          "deployment_overrides":"{\\\"services\\\":{\\\"netspeed5\\\":{\\\"environment\\\":[\\\"E2EDEV_OVERRIDE=1\\\"]}}}",
+          "deployment_overrides_signature":"CoQb1Tw204vbMP0H1Faw7Sp9lHHSiIzvhlX9SEejx2kRY+x6uj7PB4fvJUBoYlWJJOkecQKDD9zdLm6hD32b+f9zMWaBdRF5Ab4pHU5gcDPpuPGnYup1ZreSe4eqPnThkGgfYIW5zcQd/vbxO9tx31EM8lJ5NrhcJ5rwhwbIPDh7Hstxi84IetNAygE1gPaTGQaJzzqATFYINwWkxjJXjihdEVuo5IvINJusHtIs7C6BIVy9+CExUXXxem1I/bzvwzY1wpKuubHxq1CddIKr+BaHAsErHIHvJQVc3JoDPgXPjVE8ew1QKjLCkC86wRbANN6rhCB2Q6+HhyaRfv8oJDz8XoLBcYw6bKerGMCxEBTuyUu0n9mTSCzEZZaaLdmxTzaLN47Svm8Gj18tT5CjvYkeSgDpISwRR0aME8YSHO6OtRKhLFGvZDzR4hu6kzyfp7aiYHRzVDrfcKhch/c0AuAEb6qEQ8nCHnSFJwEXP/3L3qKy8y8OT+42vumXTYOp7IadZ+UnFxLNJip9qnEsXFS8+WlT3PwaNMKFdg+zsJfUz5V+OXaotZKfe9PABn4+656PfngIi+N7q/unnrNSzc/BN8Dgy1FSHqVQ0UfRWST31pStJi2kS46UreIBgG9T6D/WgwnvATN3BaZkveiwDpUXRNv5nGzcWqnIerWWfL8=",
+          "priority":{
+            "priority_value": 3,
+            "retries": 1,
+            "retry_durations": 1800,
+            "verified_durations": 45
+          },
+          "upgradePolicy": {}
+        },
+        {
+          "version":"$NSVERS",
+          "deployment_overrides":"{\\\"services\\\":{\\\"netspeed5\\\":{\\\"environment\\\":[\\\"E2EDEV_OVERRIDE=1\\\"]}}}",
+          "deployment_overrides_signature":"CoQb1Tw204vbMP0H1Faw7Sp9lHHSiIzvhlX9SEejx2kRY+x6uj7PB4fvJUBoYlWJJOkecQKDD9zdLm6hD32b+f9zMWaBdRF5Ab4pHU5gcDPpuPGnYup1ZreSe4eqPnThkGgfYIW5zcQd/vbxO9tx31EM8lJ5NrhcJ5rwhwbIPDh7Hstxi84IetNAygE1gPaTGQaJzzqATFYINwWkxjJXjihdEVuo5IvINJusHtIs7C6BIVy9+CExUXXxem1I/bzvwzY1wpKuubHxq1CddIKr+BaHAsErHIHvJQVc3JoDPgXPjVE8ew1QKjLCkC86wRbANN6rhCB2Q6+HhyaRfv8oJDz8XoLBcYw6bKerGMCxEBTuyUu0n9mTSCzEZZaaLdmxTzaLN47Svm8Gj18tT5CjvYkeSgDpISwRR0aME8YSHO6OtRKhLFGvZDzR4hu6kzyfp7aiYHRzVDrfcKhch/c0AuAEb6qEQ8nCHnSFJwEXP/3L3qKy8y8OT+42vumXTYOp7IadZ+UnFxLNJip9qnEsXFS8+WlT3PwaNMKFdg+zsJfUz5V+OXaotZKfe9PABn4+656PfngIi+N7q/unnrNSzc/BN8Dgy1FSHqVQ0UfRWST31pStJi2kS46UreIBgG9T6D/WgwnvATN3BaZkveiwDpUXRNv5nGzcWqnIerWWfL8=",
+          "priority":{
+            "priority_value": 2,
+            "retries": 1,
+            "retry_durations": 3600
+          },
+          "upgradePolicy": {}
+        }
+      ],
+      "dataVerification": {},
+      "nodeHealth": {
+        "missing_heartbeat_interval": 120,
+        "check_agreement_status": 30
+      }
+    },
+    {
+      "serviceUrl":"https://bluehorizon.network/services/netspeed",
+      "serviceOrgid":"e2edev",
       "serviceArch":"amd64",
       "serviceVersions":[
         {

--- a/test/gov/service_apitest.sh
+++ b/test/gov/service_apitest.sh
@@ -733,7 +733,7 @@ then
 fi
 
 ERR=$(echo $RES | jq -r ".error")
-if [ "${ERR:0:75}" != "Duplicate registration for https://bluehorizon.network/services/testservice" ]
+if [ "${ERR:0:82}" != "Duplicate registration for e2edev/https://bluehorizon.network/services/testservice" ]
 then
   echo -e "$snsconfig \nresulted in incorrect response: $RES"
   exit 2

--- a/torrent/torrent.go
+++ b/torrent/torrent.go
@@ -145,7 +145,7 @@ func AppendDockerAuth(dockerAuths map[string][]docker.AuthConfiguration, auth do
 func authAttributes(db *bolt.DB, httpAuthAttrs map[string]map[string]string, dockerAuthConfigurations map[string][]docker.AuthConfiguration) error {
 
 	// assemble credentials from attributes
-	attributes, err := persistence.FindApplicableAttributes(db, "")
+	attributes, err := persistence.FindApplicableAttributes(db, "", "")
 	if err != nil {
 		return fmt.Errorf("Error fetching attributes. Error: %v", err)
 	}

--- a/torrent/torrent_int_test.go
+++ b/torrent/torrent_int_test.go
@@ -285,8 +285,8 @@ func Test_Torrent_Event_Suite(suite *testing.T) {
 	images := []string{
 		"summit.hovitos.engineering/amd64/neo4j:3.3.1",               // 189MB
 		"summit.hovitos.engineering/amd64/clojure:boot-2.7.2-alpine", // 147MB
-		"ubuntu:yakkety", // 107MB
-		"registry.ng.bluemix.net/glendarling/x86/cpu:1.2.1", // 9MB
+		"ubuntu:yakkety",                                             // 107MB
+		"registry.ng.bluemix.net/glendarling/x86/cpu:1.2.1",          // 9MB
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
…m different orgs
1) added Org to MicroserviceInstance
2) changed SensorUrl for Attribute so that each is in the form of 'org/url'
3) registeredServices.URL for a node on the exchange is in the form of 'org/url'. 
4) changed policy manager to allow same url from different orgs.
5) changed the eventlog messages so that it uses 'org/url' to refer to a service.
6) Attribute and MicroserviceInstance are backward compatible. 

Problem: We need to discuss how to make item 3) backward compatible. 
