### PR TITLE
Issue 747 - Support services that have the same URL/name but come fro…

### DIFF
--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-horizon/anax/abstractprotocol"
 	"github.com/open-horizon/anax/agreementbot/persistence"
 	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/exchange"
 	"github.com/open-horizon/anax/policy"
@@ -870,7 +871,7 @@ func (w *AgreementBotWorker) searchExchange(pol *policy.Policy, polOrg string) (
 					if newMS, err := w.makeNewMSSearchElement(rs.SpecRef, rs.Org, "", arch, pol); err != nil {
 						return nil, err
 					} else {
-						msMap[rs.SpecRef] = newMS
+						msMap[cutil.FormOrgSpecUrl(rs.SpecRef, rs.Org)] = newMS
 					}
 				}
 			}
@@ -914,7 +915,7 @@ func (w *AgreementBotWorker) searchExchange(pol *policy.Policy, polOrg string) (
 
 func (w *AgreementBotWorker) makeNewMSSearchElement(specRef string, org string, version string, arch string, pol *policy.Policy) (*exchange.Microservice, error) {
 	newMS := new(exchange.Microservice)
-	newMS.Url = specRef
+	newMS.Url = cutil.FormOrgSpecUrl(specRef, org)
 	newMS.NumAgreements = 1
 
 	if props, err := RetrieveAllProperties(version, arch, pol); err != nil {

--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -240,7 +240,7 @@ func (b *BaseAgreementWorker) InitiateNewAgreement(cph ConsumerProtocolHandler, 
 					// Run through all the services on the node that are required by this workload and merge those policies.
 					for _, devMS := range services {
 						// Find the device's service definition based on the services needed by the workload.
-						if devMS.Url == apiSpec.SpecRef {
+						if devMS.Url == cutil.FormOrgSpecUrl(apiSpec.SpecRef, apiSpec.Org) || devMS.Url == apiSpec.SpecRef {
 							if pol, err := policy.DemarshalPolicy(devMS.Policy); err != nil {
 								glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("error demarshalling device %v policy, error: %v", wi.Device.Id, err)))
 								return

--- a/api/api_int_test.go
+++ b/api/api_int_test.go
@@ -142,13 +142,14 @@ func Test_API_attribute_Suite(suite *testing.T) {
 		suite.Error(err)
 	}
 
-	sensorUrl := `https://bluehorizon.network/doc/locsampler`
+	sp := persistence.ServiceSpec{Url: "https://bluehorizon.network/doc/locsampler", Org: "myorg"}
+	sps := new(persistence.ServiceSpecs)
+	sps.AppendServiceSpec(sp)
 
 	bF := false
 	loc, err := persistence.SaveOrUpdateAttribute(db, &persistence.LocationAttributes{
 		Meta: &persistence.AttributeMeta{
 			Id:          "",
-			SensorUrls:  []string{fmt.Sprintf("%v%s", sensorUrl, "-1")},
 			Label:       "My Location",
 			HostOnly:    &bF,
 			Publishable: &bF,
@@ -164,12 +165,12 @@ func Test_API_attribute_Suite(suite *testing.T) {
 	_, err = persistence.SaveOrUpdateAttribute(db, &persistence.UserInputAttributes{
 		Meta: &persistence.AttributeMeta{
 			Id:          "",
-			SensorUrls:  []string{sensorUrl},
 			Label:       "Defs",
 			HostOnly:    &bF,
 			Publishable: &bF,
 			Type:        "UserInputAttributes",
 		},
+		ServiceSpecs: sps,
 		Mappings: map[string]interface{}{
 			"SAMPLE_INTERVAL": "5s",
 		},
@@ -309,8 +310,11 @@ vTLlpah1Y8Dvd1Mg6DorvN7eHb+R9pRYz6m/ll84KeLHyX+ml9Yj9Xem+H7MMYh7
 	pubMapping := []byte(`{
 			"type": "UserInputAttributes",
 			"label": "Application Mappings",
-			"SensorUrls": ["https://foo", "https://goo"],
 			"publishable":	false,
+			"service_specs": [
+			    {"url": "https://foo", "organization": "myorg"},
+			    {"url": "https://goo", "organization": "myorg2"}
+			],
 			"mappings": {
 				"KEY": "VALUE"
 			}}`)
@@ -342,8 +346,10 @@ vTLlpah1Y8Dvd1Mg6DorvN7eHb+R9pRYz6m/ll84KeLHyX+ml9Yj9Xem+H7MMYh7
 			{
             "type": "UserInputAttributes",
             "label": "Application Mappings",
-			"sensor_urls": ["https://zoo"],
-            "publishable":  false,
+           "publishable":  false,
+			"service_specs": [
+			    {"url": "https://zoo", "organization": "myorg"}
+			],
             "mappings": {
                 "KEY": "NEWVALUE"
             }}
@@ -395,7 +401,7 @@ vTLlpah1Y8Dvd1Mg6DorvN7eHb+R9pRYz6m/ll84KeLHyX+ml9Yj9Xem+H7MMYh7
 			}
 		`), true)
 		assert.EqualValues(t, true, (*(*responseAttr).Publishable))
-		assert.Contains(t, (*(*responseAttr).SensorUrls), "https://zoo")
+		assert.Contains(t, (*(*responseAttr).ServiceSpecs), persistence.ServiceSpec{Url: "https://zoo", Org: "myorg"})
 	})
 
 	suite.Run("Update using PATCH to /attribute/{id} is rejected if no type is specified", func(t *testing.T) {

--- a/api/container.go
+++ b/api/container.go
@@ -39,7 +39,7 @@ func GetWorkloadContainers(dockerEndpoint string, agreementId string) ([]dockerc
 }
 
 // Get docker container metadata from the docker API for microservice containers
-func GetMicroserviceContainer(dockerEndpoint string, mURL string, mVersion string, mInstanceId string) ([]dockerclient.APIContainers, error) {
+func GetMicroserviceContainer(dockerEndpoint string, mURL string, mOrg string, mVersion string, mInstanceId string) ([]dockerclient.APIContainers, error) {
 	if client, err := dockerclient.NewClient(dockerEndpoint); err != nil {
 		return nil, errors.New(fmt.Sprintf("unable to create docker client from %v, error %v", dockerEndpoint, err))
 	} else {
@@ -57,7 +57,7 @@ func GetMicroserviceContainer(dockerEndpoint string, mURL string, mVersion strin
 			for _, c := range containers {
 				if _, exists := c.Labels[container.LABEL_PREFIX+".infrastructure"]; exists {
 					if agid, exists := c.Labels[container.LABEL_PREFIX+".agreement_id"]; exists {
-						name := cutil.MakeMSInstanceKey(mURL, mVersion, mInstanceId)
+						name := cutil.MakeMSInstanceKey(mURL, mOrg, mVersion, mInstanceId)
 						if agid == name {
 							ret = append(ret, c)
 						}

--- a/api/input.go
+++ b/api/input.go
@@ -97,13 +97,13 @@ func ConvertFromPersistentHorizonDevice(pDevice *persistence.ExchangeDevice) *Ho
 }
 
 type Attribute struct {
-	Id          *string                 `json:"id"`
-	Type        *string                 `json:"type"`
-	SensorUrls  *[]string               `json:"sensor_urls"`
-	Label       *string                 `json:"label"`
-	Publishable *bool                   `json:"publishable"`
-	HostOnly    *bool                   `json:"host_only"`
-	Mappings    *map[string]interface{} `json:"mappings"`
+	Id           *string                   `json:"id"`
+	Type         *string                   `json:"type"`
+	Label        *string                   `json:"label"`
+	Publishable  *bool                     `json:"publishable"`
+	HostOnly     *bool                     `json:"host_only"`
+	ServiceSpecs *persistence.ServiceSpecs `json:"service_specs,omitempty"`
+	Mappings     *map[string]interface{}   `json:"mappings"`
 }
 
 func (a Attribute) String() string {
@@ -116,14 +116,13 @@ func (a Attribute) String() string {
 		}
 	}
 
-	return fmt.Sprintf("Id: %v, Type: %v, SensorUrls: %v, Label: %v, Publishable: %v, HostOnly: %v, Mappings: %v",
-		getString(a.Id), getString(a.Type), getString(a.SensorUrls), getString(a.Label), getString(a.Publishable), getString(a.HostOnly), getString(a.Mappings))
+	return fmt.Sprintf("Id: %v, Type: %v, Label: %v, Publishable: %v, HostOnly: %v, ServiceSpecs: %v, Mappings: %v",
+		getString(a.Id), getString(a.Type), getString(a.Label), getString(a.Publishable), getString(a.HostOnly), getString(a.ServiceSpecs), getString(a.Mappings))
 }
 
-func NewAttribute(t string, sURLs []string, l string, publishable bool, hostOnly bool, mappings map[string]interface{}) *Attribute {
+func NewAttribute(t string, l string, publishable bool, hostOnly bool, mappings map[string]interface{}) *Attribute {
 	return &Attribute{
 		Type:        &t,
-		SensorUrls:  &sURLs,
 		Label:       &l,
 		Publishable: &publishable,
 		HostOnly:    &hostOnly,

--- a/api/output.go
+++ b/api/output.go
@@ -62,9 +62,10 @@ func NewMicroserviceInstanceOutput(mi persistence.MicroserviceInstance, containe
 }
 
 func NewAgreementServiceInstanceOutput(ag *persistence.EstablishedAgreement, containers *[]dockerclient.APIContainers) *MicroserviceInstanceOutput {
-	sipe := persistence.NewServiceInstancePathElement(ag.RunningWorkload.URL, ag.RunningWorkload.Version)
+	sipe := persistence.NewServiceInstancePathElement(ag.RunningWorkload.URL, ag.RunningWorkload.Org, ag.RunningWorkload.Version)
 	mi := persistence.MicroserviceInstance{
 		SpecRef:              ag.RunningWorkload.URL,
+		Org:                  ag.RunningWorkload.Org,
 		Version:              ag.RunningWorkload.Version,
 		Arch:                 ag.RunningWorkload.Arch,
 		InstanceId:           ag.CurrentAgreementId,

--- a/api/path_agreement_test.go
+++ b/api/path_agreement_test.go
@@ -45,12 +45,15 @@ func Test_FindAgreementsForOutput1(t *testing.T) {
 
 	// Add 3 agreements to the DB, one for each path in the /agreement GET.
 	// Agreement 1 is active, agreement2 is archived, agreement3 is active but terminating.
+	sp := persistence.ServiceSpec{Url: "http://sensor.org", Org: "myorg"}
+	sps := []persistence.ServiceSpec{sp}
+
 	wi, _ := persistence.NewWorkloadInfo("url", "org", "version", "")
-	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement1: %v", err)
-	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement2: %v", err)
-	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement3: %v", err)
 	} else if _, err := persistence.ArchiveEstablishedAgreement(db, "agreementId2", "Basic"); err != nil {
 		t.Errorf("error archiving agreement2: %v", err)
@@ -79,12 +82,15 @@ func Test_DeleteAgreement0(t *testing.T) {
 
 	// Add 3 agreements to the DB, one for each special agreement state.
 	// Agreement 1 is active, agreement2 is archived, agreement3 is active but terminating.
+	sp := persistence.ServiceSpec{Url: "http://sensor.org", Org: "myorg"}
+	sps := []persistence.ServiceSpec{sp}
+
 	wi, _ := persistence.NewWorkloadInfo("url", "org", "version", "")
-	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement1: %v", err)
-	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement2: %v", err)
-	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement3: %v", err)
 	} else if _, err := persistence.ArchiveEstablishedAgreement(db, "agreementId2", "Basic"); err != nil {
 		t.Errorf("error archiving agreement2: %v", err)
@@ -115,12 +121,15 @@ func Test_DeleteAgreement1(t *testing.T) {
 
 	// Add 3 agreements to the DB, one for each special agreement state.
 	// Agreement 1 is active, agreement2 is archived, agreement3 is active but terminating.
+	sp := persistence.ServiceSpec{Url: "http://sensor.org", Org: "myorg"}
+	sps := []persistence.ServiceSpec{sp}
+
 	wi, _ := persistence.NewWorkloadInfo("url", "org", "version", "")
-	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement1: %v", err)
-	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement2: %v", err)
-	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement3: %v", err)
 	} else if _, err := persistence.ArchiveEstablishedAgreement(db, "agreementId2", "Basic"); err != nil {
 		t.Errorf("error archiving agreement2: %v", err)
@@ -149,12 +158,15 @@ func Test_DeleteAgreement2(t *testing.T) {
 
 	// Add 3 agreements to the DB, one for each special agreement state.
 	// Agreement 1 is active, agreement2 is archived, agreement3 is active but terminating.
+	sp := persistence.ServiceSpec{Url: "http://sensor.org", Org: "myorg"}
+	sps := []persistence.ServiceSpec{sp}
+
 	wi, _ := persistence.NewWorkloadInfo("url", "org", "version", "")
-	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement1: %v", err)
-	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement2: %v", err)
-	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement3: %v", err)
 	} else if _, err := persistence.ArchiveEstablishedAgreement(db, "agreementId2", "Basic"); err != nil {
 		t.Errorf("error archiving agreement2: %v", err)
@@ -183,12 +195,15 @@ func Test_DeleteAgreement3(t *testing.T) {
 
 	// Add 3 agreements to the DB, one for each special agreement state.
 	// Agreement 1 is active, agreement2 is archived, agreement3 is active but terminating.
+	sp := persistence.ServiceSpec{Url: "http://sensor.org", Org: "myorg"}
+	sps := []persistence.ServiceSpec{sp}
+
 	wi, _ := persistence.NewWorkloadInfo("url", "org", "version", "")
-	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId1", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement1: %v", err)
-	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId2", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement2: %v", err)
-	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, []string{"http://sensor.org"}, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
+	} else if _, err := persistence.NewEstablishedAgreement(db, "name1", "agreementId3", "consumerId", "{}", "Basic", 1, sps, "signature", "address", "bcType", "bcName", "bcOrg", wi); err != nil {
 		t.Errorf("error writing agreement3: %v", err)
 	} else if _, err := persistence.ArchiveEstablishedAgreement(db, "agreementId2", "Basic"); err != nil {
 		t.Errorf("error archiving agreement2: %v", err)

--- a/api/path_eventlog_test.go
+++ b/api/path_eventlog_test.go
@@ -25,30 +25,34 @@ func Test_FindEventLogsForOutput(t *testing.T) {
 	}
 	defer cleanTestDir(dir)
 
+	sp1 := persistence.ServiceSpec{Url: "http://sensor1.org", Org: "sensor1"}
+	sp2 := persistence.ServiceSpec{Url: "http://mycomp.org", Org: "myorg"}
+	sp3 := persistence.ServiceSpec{Url: "http://sensor3.org", Org: "sensor3"}
+
 	// save event logs
-	if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "proposal received.", persistence.EC_RECEIVED_PROPOSAL, "agreementId1", persistence.WorkloadInfo{"http://top1.com", "myorg", "1.0.0", "amd64"}, []string{"http://sensor1.org"}, "consumerId", "Basic"); err != nil {
+	if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "proposal received.", persistence.EC_RECEIVED_PROPOSAL, "agreementId1", persistence.WorkloadInfo{"http://top1.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp1}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "reply sent.", persistence.EC_RECEIVED_REPLYACK_MESSAGE, "agreementId1", persistence.WorkloadInfo{"http://top1.com", "myorg", "1.0.0", "amd64"}, []string{"http://sensor1.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "reply sent.", persistence.EC_RECEIVED_REPLYACK_MESSAGE, "agreementId1", persistence.WorkloadInfo{"http://top1.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp1}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "proposal received.", persistence.EC_RECEIVED_PROPOSAL, "agreementId2", persistence.WorkloadInfo{"http://top2.com", "myorg", "1.0.0", "amd64"}, []string{"http://mycomp.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "proposal received.", persistence.EC_RECEIVED_PROPOSAL, "agreementId2", persistence.WorkloadInfo{"http://top2.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp2}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "proposal received.", persistence.EC_RECEIVED_PROPOSAL, "agreementId3", persistence.WorkloadInfo{"http://top3.com", "myorg", "1.0.0", "amd64"}, []string{"http://sensor3.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "proposal received.", persistence.EC_RECEIVED_PROPOSAL, "agreementId3", persistence.WorkloadInfo{"http://top3.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp3}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "reply sent.", persistence.EC_RECEIVED_REPLYACK_MESSAGE, "agreementId2", persistence.WorkloadInfo{"http://top2.com", "myorg", "1.0.0", "amd64"}, []string{"http://mycomp.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "reply sent.", persistence.EC_RECEIVED_REPLYACK_MESSAGE, "agreementId2", persistence.WorkloadInfo{"http://top2.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp2}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "agreement finalized.", persistence.EC_AGREEMENT_REACHED, "agreementId1", persistence.WorkloadInfo{"http://top1.com", "myorg", "1.0.0", "amd64"}, []string{"http://sensor1.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "agreement finalized.", persistence.EC_AGREEMENT_REACHED, "agreementId1", persistence.WorkloadInfo{"http://top1.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp1}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "reply sent.", persistence.EC_RECEIVED_REPLYACK_MESSAGE, "agreementId3", persistence.WorkloadInfo{"http://top3.com", "myorg", "1.0.0", "amd64"}, []string{"http://sensor3.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "reply sent.", persistence.EC_RECEIVED_REPLYACK_MESSAGE, "agreementId3", persistence.WorkloadInfo{"http://top3.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp3}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "agreement finalized.", persistence.EC_AGREEMENT_REACHED, "agreementId3", persistence.WorkloadInfo{"http://top3.com", "myorg", "1.0.0", "amd64"}, []string{"http://sensor3.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "agreement finalized.", persistence.EC_AGREEMENT_REACHED, "agreementId3", persistence.WorkloadInfo{"http://top3.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp3}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "agreement finalized.", persistence.EC_AGREEMENT_REACHED, "agreementId2", persistence.WorkloadInfo{"http://top2.com", "myorg", "1.0.0", "amd64"}, []string{"http://mycomp.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_INFO, "agreement finalized.", persistence.EC_AGREEMENT_REACHED, "agreementId2", persistence.WorkloadInfo{"http://top2.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp2}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_ERROR, "something is wrong.", persistence.EC_ERROR_START_CONTAINER, "agreementId1", persistence.WorkloadInfo{"http://top1.com", "myorg", "1.0.0", "amd64"}, []string{"http://sensor1.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_ERROR, "something is wrong.", persistence.EC_ERROR_START_CONTAINER, "agreementId1", persistence.WorkloadInfo{"http://top1.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp1}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_WARN, "something is wrong.", persistence.EC_ERROR_START_CONTAINER, "agreementId2", persistence.WorkloadInfo{"http://top2.com", "myorg", "1.0.0", "amd64"}, []string{"http://mycomp.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_WARN, "something is wrong.", persistence.EC_ERROR_START_CONTAINER, "agreementId2", persistence.WorkloadInfo{"http://top2.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp2}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
-	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_ERROR, "something is really wrong.", persistence.EC_EXCHANGE_ERROR, "agreementId1", persistence.WorkloadInfo{"http://top1.com", "myorg", "1.0.0", "amd64"}, []string{"http://sensor1.org"}, "consumerId", "Basic"); err != nil {
+	} else if err := eventlog.LogAgreementEvent2(db, persistence.SEVERITY_ERROR, "something is really wrong.", persistence.EC_EXCHANGE_ERROR, "agreementId1", persistence.WorkloadInfo{"http://top1.com", "myorg", "1.0.0", "amd64"}, []persistence.ServiceSpec{sp1}, "consumerId", "Basic"); err != nil {
 		t.Errorf("error saving event log: %v", err)
 	}
 
@@ -100,4 +104,11 @@ func Test_FindEventLogsForOutput(t *testing.T) {
 			}
 		}
 	}
+
+	if elogs, err := FindEventLogsForOutput(db, true, map[string][]string{"dependent_services.url": {"http://mycomp.org"}}); err != nil {
+		t.Errorf("error getting event logs: %v", err)
+	} else {
+		assert.Equal(t, 4, len(elogs), "Test FindEventLogsForOutput with selection.")
+	}
+
 }

--- a/api/path_service.go
+++ b/api/path_service.go
@@ -53,7 +53,7 @@ func FindServicesForOutput(pm *policy.PolicyManager,
 		if msinst.Archived {
 			wrap.Instances[archivedKey] = append(wrap.Instances[archivedKey], *NewMicroserviceInstanceOutput(msinst, nil))
 		} else {
-			containers, err := GetMicroserviceContainer(config.Edge.DockerEndpoint, msinst.SpecRef, msinst.Version, msinst.InstanceId)
+			containers, err := GetMicroserviceContainer(config.Edge.DockerEndpoint, msinst.SpecRef, msinst.Org, msinst.Version, msinst.InstanceId)
 			if err != nil {
 				return nil, errors.New(fmt.Sprintf("unable to get docker container info, error %v", err))
 			}

--- a/cli/attribute/attribute.go
+++ b/cli/attribute/attribute.go
@@ -5,16 +5,17 @@ import (
 	"fmt"
 	"github.com/open-horizon/anax/api"
 	"github.com/open-horizon/anax/cli/cliutils"
+	"github.com/open-horizon/anax/persistence"
 )
 
 const HTTPSBasicAuthAttributes = "HTTPSBasicAuthAttributes"
 
 // Our form of the attributes output
 type OurAttributes struct {
-	Type       string                 `json:"type"`
-	Label      string                 `json:"label"`
-	SensorUrls []string               `json:"sensor_urls,omitempty"`
-	Variables  map[string]interface{} `json:"variables"`
+	Type         string                   `json:"type"`
+	Label        string                   `json:"label"`
+	ServiceSpecs persistence.ServiceSpecs `json:"service_specs,omitempty"`
+	Variables    map[string]interface{}   `json:"variables"`
 }
 
 func List() {
@@ -33,10 +34,10 @@ func List() {
 	// Only include interesting fields in our output
 	attrs := []OurAttributes{}
 	for _, a := range apiAttrs {
-		if len(*a.SensorUrls) == 0 {
+		if a.ServiceSpecs == nil {
 			attrs = append(attrs, OurAttributes{Type: *a.Type, Label: *a.Label, Variables: *a.Mappings})
-		} else if *a.Type == HTTPSBasicAuthAttributes {
-			attrs = append(attrs, OurAttributes{Type: *a.Type, Label: *a.Label, SensorUrls: *a.SensorUrls, Variables: *a.Mappings})
+		} else {
+			attrs = append(attrs, OurAttributes{Type: *a.Type, Label: *a.Label, ServiceSpecs: *a.ServiceSpecs, Variables: *a.Mappings})
 		}
 	}
 

--- a/cli/dev/dependency.go
+++ b/cli/dev/dependency.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/anax/persistence"
 	"github.com/open-horizon/anax/policy"
 	"io/ioutil"
 	"net/url"
@@ -462,8 +463,8 @@ func fetchLocalProjectDependency(homeDirectory string, project string, userInput
 		} else {
 			// Copy the global setting so that the dependency continues to work correctly. Also tag the global setting with the
 			// dependencies URL so that the system knows it only applies to this dependency.
-			if len(depGlobal.SensorUrls) == 0 {
-				depGlobal.SensorUrls = append(depGlobal.SensorUrls, sDef.GetURL())
+			if len(depGlobal.ServiceSpecs) == 0 {
+				depGlobal.ServiceSpecs = append(depGlobal.ServiceSpecs, *persistence.NewServiceSpec(sDef.GetURL(), sDef.GetOrg()))
 			}
 			currentUIs.Global = append(currentUIs.Global, depGlobal)
 		}

--- a/cli/dev/userinput.go
+++ b/cli/dev/userinput.go
@@ -130,9 +130,11 @@ func GlobalSetAsAttributes(global []register.GlobalSet) ([]persistence.Attribute
 	// Run through each attribute in the global set of attributes and convert them into an API attributes, as if they are
 	// coming through the anax REST API.
 	for _, gs := range global {
-		attr := api.NewAttribute("", []string{}, "Global variables", false, false, map[string]interface{}{})
+		attr := api.NewAttribute("", "Global variables", false, false, map[string]interface{}{})
 		attr.Type = &gs.Type
-		attr.SensorUrls = &gs.SensorUrls
+		if gs.ServiceSpecs != nil {
+			attr.ServiceSpecs = &gs.ServiceSpecs
+		}
 		attr.Mappings = &gs.Variables
 		cliutils.Verbose("Converted userinput attribute: %v to API attribute: %v", gs, attr)
 

--- a/cli/dev/utils.go
+++ b/cli/dev/utils.go
@@ -288,7 +288,7 @@ func createEnvVarMap(agreementId string,
 	// create a shortened list of global attribute that only apply to this microservice.
 	shortGlobals := make([]register.GlobalSet, 0, 10)
 	for _, inputGlobal := range global {
-		if len(inputGlobal.SensorUrls) == 0 || inputGlobal.SensorUrls[0] == msURL {
+		if len(inputGlobal.ServiceSpecs) == 0 || (inputGlobal.ServiceSpecs[0].Url == msURL && inputGlobal.ServiceSpecs[0].Org == org) {
 			shortGlobals = append(shortGlobals, inputGlobal)
 		}
 	}
@@ -300,7 +300,7 @@ func createEnvVarMap(agreementId string,
 	}
 
 	// Third, add in default system attributes if not already present.
-	attrs = api.FinalizeAttributesSpecifiedInService(1024, msURL, attrs)
+	attrs = api.FinalizeAttributesSpecifiedInService(1024, persistence.NewServiceSpec(msURL, org), attrs)
 
 	cliutils.Verbose("Final Attributes: %v", attrs)
 
@@ -493,7 +493,7 @@ func startDependent(dir string,
 			return nil, errors.New(fmt.Sprintf("unable to generate instance ID: %v", err))
 		}
 
-		sId := cutil.MakeMSInstanceKey(serviceDef.URL, serviceDef.Version, id.String())
+		sId := cutil.MakeMSInstanceKey(serviceDef.URL, serviceDef.Org, serviceDef.Version, id.String())
 
 		return StartContainers(deployment, serviceDef.URL, serviceDef.Version, globals, serviceDef.UserInputs, configUserInputs, serviceDef.Org, depConfig, cw, msNetworks, true, false, sId)
 	}

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -8,6 +8,7 @@ import (
 	cliexchange "github.com/open-horizon/anax/cli/exchange"
 	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/exchange"
+	"github.com/open-horizon/anax/persistence"
 	"github.com/open-horizon/anax/policy"
 	"io/ioutil"
 	"net/http"
@@ -15,13 +16,13 @@ import (
 
 // These structs are used to parse the registration input file. These are also used by the hzn dev code.
 type GlobalSet struct {
-	Type       string                 `json:"type"`
-	SensorUrls []string               `json:"sensor_urls"`
-	Variables  map[string]interface{} `json:"variables"`
+	Type         string                   `json:"type"`
+	ServiceSpecs persistence.ServiceSpecs `json:"service_specs,omitempty"`
+	Variables    map[string]interface{}   `json:"variables"`
 }
 
 func (g GlobalSet) String() string {
-	return fmt.Sprintf("Global Array element, type: %v, sensor_urls: %v, variables: %v", g.Type, g.SensorUrls, g.Variables)
+	return fmt.Sprintf("Global Array element, type: %v, service_specs: %v, variables: %v", g.Type, g.ServiceSpecs, g.Variables)
 }
 
 // Use for services, microservices, and workloads. This is used by other cli sub-cmds too.
@@ -116,13 +117,13 @@ func DoIt(org, pattern, nodeIdTok, userPw, email, inputFile string) {
 	if inputFile != "" {
 		// Set the global variables as attributes with no url (or in the case of HTTPSBasicAuthAttributes, with url equal to image svr)
 		// Technically the AgreementProtocolAttributes can be set, but it has no effect on anax if a pattern is being used.
-		attr := api.NewAttribute("", []string{}, "Global variables", false, false, map[string]interface{}{}) // we reuse this for each GlobalSet
+		attr := api.NewAttribute("", "Global variables", false, false, map[string]interface{}{}) // we reuse this for each GlobalSet
 		if len(inputFileStruct.Global) > 0 {
 			fmt.Println("Setting global variables...")
 		}
 		for _, g := range inputFileStruct.Global {
 			attr.Type = &g.Type
-			attr.SensorUrls = &g.SensorUrls
+			attr.ServiceSpecs = &g.ServiceSpecs
 			attr.Mappings = &g.Variables
 
 			// set HostOnly to true for these 2 types
@@ -135,7 +136,7 @@ func DoIt(org, pattern, nodeIdTok, userPw, email, inputFile string) {
 		}
 
 		// Set the service variables
-		attr = api.NewAttribute("UserInputAttributes", []string{}, "service", false, false, map[string]interface{}{}) // we reuse this for each service
+		attr = api.NewAttribute("UserInputAttributes", "service", false, false, map[string]interface{}{}) // we reuse this for each service
 		emptyStr := ""
 		service := api.Service{Name: &emptyStr} // we reuse this too
 		if len(inputFileStruct.Services) > 0 {

--- a/cutil/cutil.go
+++ b/cutil/cutil.go
@@ -229,14 +229,18 @@ func SetSystemEnvvars(envAdds map[string]string, prefix string, lat string, lon 
 
 }
 
-func MakeMSInstanceKey(specRef string, v string, id string) string {
+func MakeMSInstanceKey(specRef string, org string, v string, id string) string {
 	s := specRef
 	if strings.Contains(specRef, "://") {
 		s = strings.Split(specRef, "://")[1]
 	}
 	new_s := strings.Replace(s, "/", "-", -1)
 
-	return fmt.Sprintf("%v_%v_%v", new_s, v, id)
+	if org == "" {
+		return fmt.Sprintf("%v_%v_%v", new_s, v, id)
+	} else {
+		return fmt.Sprintf("%v_%v_%v_%v", org, new_s, v, id)
+	}
 }
 
 // This function parsed the given image name to disfferent parts. The image name has the following format:
@@ -394,4 +398,13 @@ func SliceContains(a []string, s string) bool {
 		}
 	}
 	return false
+}
+
+// it returns the org/url form for an api spec
+func FormOrgSpecUrl(url string, org string) string {
+	if org == "" {
+		return url
+	} else {
+		return fmt.Sprintf("%v/%v", org, url)
+	}
 }

--- a/eventlog/eventlog_manager.go
+++ b/eventlog/eventlog_manager.go
@@ -19,8 +19,8 @@ func LogAgreementEvent(db *bolt.DB, severity string, message string, event_code 
 }
 
 // Save the agreement eventlog into the db
-func LogAgreementEvent2(db *bolt.DB, severity, message, event_code, agreement_id string, workload persistence.WorkloadInfo, service_url []string, consumer_id, protocol string) error {
-	source := persistence.NewAgreementEventSource(agreement_id, workload, service_url, consumer_id, protocol)
+func LogAgreementEvent2(db *bolt.DB, severity, message, event_code, agreement_id string, workload persistence.WorkloadInfo, dependent_svcs persistence.ServiceSpecs, consumer_id, protocol string) error {
+	source := persistence.NewAgreementEventSource(agreement_id, workload, dependent_svcs, consumer_id, protocol)
 	eventlog := persistence.NewEventLog(severity, message, event_code, persistence.SRC_TYPE_AG, source)
 	return persistence.SaveEventLog(db, eventlog)
 }

--- a/events/events.go
+++ b/events/events.go
@@ -102,6 +102,7 @@ type LaunchContext interface {
 
 type MicroserviceSpec struct {
 	SpecRef string
+	Org     string
 	Version string
 	MsdefId string
 }
@@ -212,7 +213,7 @@ func NewContainerLaunchContext(config *ContainerConfig, envAdds *map[string]stri
 
 	spe_temp := spe
 	if spe_temp == nil {
-		spe_temp = persistence.NewServiceInstancePathElement("", "")
+		spe_temp = persistence.NewServiceInstancePathElement("", "", "")
 	}
 
 	return &ContainerLaunchContext{

--- a/events/events.go
+++ b/events/events.go
@@ -594,7 +594,7 @@ func NewGovernanceWorkloadCancelationMessage(id EventId, cause EndContractCause,
 
 	return &GovernanceWorkloadCancelationMessage{
 		GovernanceMaintenanceMessage: *govMaint,
-		Cause: cause,
+		Cause:                        cause,
 	}
 }
 

--- a/exchange/rpc.go
+++ b/exchange/rpc.go
@@ -780,7 +780,7 @@ func GetPatterns(httpClientFactory *config.HTTPClientFactory, org string, patter
 	if pattern == "" {
 		glog.V(3).Infof(rpclogString(fmt.Sprintf("getting pattern definitions for %v", org)))
 	} else {
-		glog.V(3).Infof(rpclogString(fmt.Sprintf("getting pattern definitions for %v and %v", org, pattern)))
+		glog.V(3).Infof(rpclogString(fmt.Sprintf("getting pattern definitions for %v/%v", org, pattern)))
 	}
 
 	var resp interface{}

--- a/governance/governance.go
+++ b/governance/governance.go
@@ -156,14 +156,14 @@ func (w *GovernanceWorker) NewEvent(incoming events.Message) {
 					eventlog.LogAgreementEvent(
 						w.db,
 						persistence.SEVERITY_INFO,
-						fmt.Sprintf("Image loaded for %v.", ags[0].RunningWorkload.URL),
+						fmt.Sprintf("Image loaded for %v/%v.", ags[0].RunningWorkload.Org, ags[0].RunningWorkload.URL),
 						persistence.EC_IMAGE_LOADED,
 						ags[0])
 				} else {
 					eventlog.LogAgreementEvent(
 						w.db,
 						persistence.SEVERITY_ERROR,
-						fmt.Sprintf("Error loading image for %v.", ags[0].RunningWorkload.URL),
+						fmt.Sprintf("Error loading image for %v/%v.", ags[0].RunningWorkload.Org, ags[0].RunningWorkload.URL),
 						persistence.EC_ERROR_IMAGE_LOADE,
 						ags[0])
 					cmd := w.NewCleanupExecutionCommand(lc.AgreementProtocol, lc.AgreementId, reason, nil)
@@ -177,14 +177,14 @@ func (w *GovernanceWorker) NewEvent(incoming events.Message) {
 				eventlog.LogServiceEvent2(
 					w.db,
 					persistence.SEVERITY_INFO,
-					fmt.Sprintf("Image loaded for service %v.", lc.ServicePathElement.URL),
+					fmt.Sprintf("Image loaded for service %v/%v.", lc.ServicePathElement.Org, lc.ServicePathElement.URL),
 					persistence.EC_IMAGE_LOADED,
 					"", lc.ServicePathElement.URL, "", lc.ServicePathElement.Version, "", lc.AgreementIds)
 			} else {
 				eventlog.LogServiceEvent2(
 					w.db,
 					persistence.SEVERITY_ERROR,
-					fmt.Sprintf("Error loading image for service %v.", lc.ServicePathElement.URL),
+					fmt.Sprintf("Error loading image for service %v/%v.", lc.ServicePathElement.Org, lc.ServicePathElement.URL),
 					persistence.EC_ERROR_IMAGE_LOADE,
 					"", lc.ServicePathElement.URL, "", lc.ServicePathElement.Version, "", lc.AgreementIds)
 				cmd := w.NewUpdateMicroserviceCommand(lc.Name, false, microservice.MS_IMAGE_FETCH_FAILED, microservice.DecodeReasonCode(microservice.MS_IMAGE_FETCH_FAILED))
@@ -627,7 +627,7 @@ func (w *GovernanceWorker) CommandHandler(command worker.Command) bool {
 			eventlog.LogAgreementEvent(
 				w.db,
 				persistence.SEVERITY_INFO,
-				fmt.Sprintf("Workload service containers for %v are up and running.", ag.RunningWorkload.URL),
+				fmt.Sprintf("Workload service containers for %v/%v are up and running.", ag.RunningWorkload.Org, ag.RunningWorkload.URL),
 				persistence.EC_CONTAINER_RUNNING,
 				*ag)
 		}
@@ -745,7 +745,7 @@ func (w *GovernanceWorker) CommandHandler(command worker.Command) bool {
 							fmt.Sprintf("Error handling ReplyAck message for %v. %v", ags[0].RunningWorkload.URL, err_log_msg),
 							persistence.EC_ERROR_PROCESSING_REPLYACT_MESSAGE, ags[0])
 					} else {
-						eventlog.LogAgreementEvent2(w.db, persistence.SEVERITY_ERROR, err_log_msg, persistence.EC_ERROR_PROCESSING_REPLYACT_MESSAGE, replyAck.AgreementId(), persistence.WorkloadInfo{}, []string{}, "", replyAck.Protocol())
+						eventlog.LogAgreementEvent2(w.db, persistence.SEVERITY_ERROR, err_log_msg, persistence.EC_ERROR_PROCESSING_REPLYACT_MESSAGE, replyAck.AgreementId(), persistence.WorkloadInfo{}, []persistence.ServiceSpec{}, "", replyAck.Protocol())
 					}
 				}
 			}
@@ -786,7 +786,7 @@ func (w *GovernanceWorker) CommandHandler(command worker.Command) bool {
 							fmt.Sprintf("Error handling DataReceived message for %v. %v", ags[0].RunningWorkload.URL, err_log_msg),
 							persistence.EC_ERROR_PROCESSING_DATARECEIVED_MESSAGE, ags[0])
 					} else {
-						eventlog.LogAgreementEvent2(w.db, persistence.SEVERITY_ERROR, err_log_msg, persistence.EC_ERROR_PROCESSING_DATARECEIVED_MESSAGE, dataReceived.AgreementId(), persistence.WorkloadInfo{}, []string{}, "", dataReceived.Protocol())
+						eventlog.LogAgreementEvent2(w.db, persistence.SEVERITY_ERROR, err_log_msg, persistence.EC_ERROR_PROCESSING_DATARECEIVED_MESSAGE, dataReceived.AgreementId(), persistence.WorkloadInfo{}, []persistence.ServiceSpec{}, "", dataReceived.Protocol())
 					}
 				}
 			}
@@ -832,7 +832,7 @@ func (w *GovernanceWorker) CommandHandler(command worker.Command) bool {
 					} else {
 						eventlog.LogAgreementEvent2(w.db, persistence.SEVERITY_ERROR, err_log_msg,
 							persistence.EC_ERROR_PROCESSING_METERING_NOTIFY_MESSAGE,
-							mnReceived.AgreementId(), persistence.WorkloadInfo{}, []string{}, "", mnReceived.Protocol())
+							mnReceived.AgreementId(), persistence.WorkloadInfo{}, []persistence.ServiceSpec{}, "", mnReceived.Protocol())
 					}
 				}
 			}
@@ -858,7 +858,7 @@ func (w *GovernanceWorker) CommandHandler(command worker.Command) bool {
 					eventlog.LogAgreementEvent(
 						w.db,
 						persistence.SEVERITY_INFO,
-						fmt.Sprintf("Node received Cancel message for %v from agbot %v.", ags[0].RunningWorkload.URL, exchangeMsg.AgbotId),
+						fmt.Sprintf("Node received Cancel message for %v/%v from agbot %v.", ags[0].RunningWorkload.Org, ags[0].RunningWorkload.URL, exchangeMsg.AgbotId),
 						persistence.EC_RECEIVED_CANCEL_AGREEMENT_MESSAGE, ags[0])
 
 					if exchangeMsg.AgbotId != ags[0].ConsumerId {
@@ -887,7 +887,7 @@ func (w *GovernanceWorker) CommandHandler(command worker.Command) bool {
 					} else {
 						eventlog.LogAgreementEvent2(w.db, persistence.SEVERITY_ERROR, err_log_msg,
 							persistence.EC_ERROR_PROCESSING_CANCEL_AGREEMENT_MESSAGE,
-							canReceived.AgreementId(), persistence.WorkloadInfo{}, []string{}, "", canReceived.Protocol())
+							canReceived.AgreementId(), persistence.WorkloadInfo{}, []persistence.ServiceSpec{}, "", canReceived.Protocol())
 					}
 				}
 			}
@@ -1107,13 +1107,13 @@ func (w *GovernanceWorker) CommandHandler(command worker.Command) bool {
 				glog.Errorf(logString(fmt.Sprintf("Error updating service execution status. %v", err)))
 			} else if msinst != nil {
 				if msdef, err := persistence.FindMicroserviceDefWithKey(w.db, msinst.MicroserviceDefId); err != nil {
-					glog.Errorf(logString(fmt.Sprintf("Error finding service definition fron db for %v version %v key %v. %v", msinst.SpecRef, msinst.Version, msinst.MicroserviceDefId, err)))
+					glog.Errorf(logString(fmt.Sprintf("Error finding service definition fron db for %v version %v key %v. %v", cutil.FormOrgSpecUrl(msinst.SpecRef, msinst.Org), msinst.Version, msinst.MicroserviceDefId, err)))
 				} else if msdef == nil {
-					glog.Errorf(logString(fmt.Sprintf("No service definition record in db for %v version %v key %v. %v", msinst.SpecRef, msinst.Version, msinst.MicroserviceDefId, err)))
+					glog.Errorf(logString(fmt.Sprintf("No service definition record in db for %v version %v key %v. %v", cutil.FormOrgSpecUrl(msinst.SpecRef, msinst.Org), msinst.Version, msinst.MicroserviceDefId, err)))
 				} else {
 					if cmd.ExecutionStarted {
 						eventlog.LogServiceEvent(w.db, persistence.SEVERITY_INFO,
-							fmt.Sprintf("Service containers for %v started.", msinst.SpecRef),
+							fmt.Sprintf("Service containers for %v started.", cutil.FormOrgSpecUrl(msinst.SpecRef, msinst.Org)),
 							persistence.EC_COMPLETE_DEPENDENT_SERVICE,
 							*msinst)
 					} else {
@@ -1273,7 +1273,7 @@ func (w *GovernanceWorker) RecordReply(proposal abstractprotocol.Proposal, proto
 			envAdds := make(map[string]string)
 
 			// The service config variables are stored in the device's attributes.
-			if envAdds, err = w.GetWorkloadPreference(workload.WorkloadURL); err != nil {
+			if envAdds, err = w.GetWorkloadPreference(workload.WorkloadURL, workload.Org); err != nil {
 				glog.Errorf(logString(fmt.Sprintf("Error: %v", err)))
 				return err
 			}
@@ -1299,10 +1299,10 @@ func (w *GovernanceWorker) RecordReply(proposal abstractprotocol.Proposal, proto
 			deps := serviceDef.GetServiceDependencies()
 
 			// Create the service instance dependency path with the workload as the root.
-			instancePath := []persistence.ServiceInstancePathElement{*persistence.NewServiceInstancePathElement(workload.WorkloadURL, workload.Version)}
+			instancePath := []persistence.ServiceInstancePathElement{*persistence.NewServiceInstancePathElement(workload.WorkloadURL, workload.Org, workload.Version)}
 
 			eventlog.LogAgreementEvent(w.db, persistence.SEVERITY_INFO,
-				fmt.Sprintf("Start dependent services for %v.", ag.RunningWorkload.URL),
+				fmt.Sprintf("Start dependent services for %v/%v.", ag.RunningWorkload.Org, ag.RunningWorkload.URL),
 				persistence.EC_START_DEPENDENT_SERVICE,
 				*ag)
 
@@ -1310,7 +1310,7 @@ func (w *GovernanceWorker) RecordReply(proposal abstractprotocol.Proposal, proto
 				eventlog.LogAgreementEvent(
 					w.db,
 					persistence.SEVERITY_ERROR,
-					fmt.Sprintf("Encountered error starting dependen services for %v. %v", ag.RunningWorkload.URL, err),
+					fmt.Sprintf("Encountered error starting dependen services for %v/%v. %v", ag.RunningWorkload.Org, ag.RunningWorkload.URL, err),
 					persistence.EC_ERROR_START_DEPENDENT_SERVICE,
 					*ag)
 				return err
@@ -1321,7 +1321,7 @@ func (w *GovernanceWorker) RecordReply(proposal abstractprotocol.Proposal, proto
 			}
 
 			eventlog.LogAgreementEvent(w.db, persistence.SEVERITY_INFO,
-				fmt.Sprintf("Start workload service for %v.", ag.RunningWorkload.URL),
+				fmt.Sprintf("Start workload service for %v/%v.", ag.RunningWorkload.Org, ag.RunningWorkload.URL),
 				persistence.EC_START_SERVICE,
 				*ag)
 
@@ -1345,29 +1345,29 @@ func (w *GovernanceWorker) processDependencies(dependencyPath []persistence.Serv
 
 	for _, sDep := range *deps {
 
-		if msdefs, err := persistence.FindUnarchivedMicroserviceDefs(w.db, sDep.URL); err != nil {
-			return ms_specs, errors.New(logString(fmt.Sprintf("Error finding service definition from the local db for %v version range %v. %v", sDep.URL, sDep.Version, err)))
+		if msdefs, err := persistence.FindUnarchivedMicroserviceDefs(w.db, sDep.URL, sDep.Org); err != nil {
+			return ms_specs, errors.New(logString(fmt.Sprintf("Error finding service definition from the local db for %v/%v version range %v. %v", sDep.Org, sDep.URL, sDep.Version, err)))
 		} else if msdefs != nil && len(msdefs) > 0 {
 			glog.V(5).Infof(logString(fmt.Sprintf("found dependent service definition locally: %v", msdefs)))
 			msdef := msdefs[0] // assuming there is only one msdef for a service/microservice at any time
 
 			// validate the version range
 			if vExp, err := policy.Version_Expression_Factory(sDep.Version); err != nil {
-				return ms_specs, errors.New(logString(fmt.Sprintf("Error converting APISpec version %v for %v to version range. %v", sDep.Version, sDep.URL, err)))
+				return ms_specs, errors.New(logString(fmt.Sprintf("Error converting APISpec version %v for %v/%v to version range. %v", sDep.Version, sDep.Org, sDep.URL, err)))
 			} else if inRange, err := vExp.Is_within_range(msdef.Version); err != nil {
-				return ms_specs, errors.New(logString(fmt.Sprintf("Error checking if service version %v is within APISpec version range %v for %v. %v", msdef.Version, vExp, sDep.URL, err)))
+				return ms_specs, errors.New(logString(fmt.Sprintf("Error checking if service version %v is within APISpec version range %v for %v/%v. %v", msdef.Version, vExp, sDep.Org, sDep.URL, err)))
 			} else if !inRange {
-				return ms_specs, errors.New(logString(fmt.Sprintf("Current service %v version %v is not within the APISpec version range %v. %v", msdef.SpecRef, msdef.Version, vExp, err)))
+				return ms_specs, errors.New(logString(fmt.Sprintf("Current service %v/%v version %v is not within the APISpec version range %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, vExp, err)))
 			}
 
-			msspec := events.MicroserviceSpec{SpecRef: msdef.SpecRef, Version: msdef.Version, MsdefId: msdef.Id}
+			msspec := events.MicroserviceSpec{SpecRef: msdef.SpecRef, Org: msdef.Org, Version: msdef.Version, MsdefId: msdef.Id}
 			ms_specs = append(ms_specs, msspec)
 
 			// Recursively work down the dependency tree, starting leaf node dependencies first and then start their parents.
-			fullPath := append(dependencyPath, *persistence.NewServiceInstancePathElement(msdef.SpecRef, msdef.Version))
+			fullPath := append(dependencyPath, *persistence.NewServiceInstancePathElement(msdef.SpecRef, msdef.Org, msdef.Version))
 			if err := w.startDependentService(fullPath, &msdef, agreementId, protocol); err != nil {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-					fmt.Sprintf("Error starting dependen service %v version %v for agreement %v. %v", msdef.SpecRef, msdef.Version, agreementId, err),
+					fmt.Sprintf("Error starting dependen service %v/%v version %v for agreement %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, agreementId, err),
 					persistence.EC_ERROR_START_DEPENDENT_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{agreementId})
 			}
@@ -1436,39 +1436,39 @@ func (w *GovernanceWorker) startAgreementLessServices() {
 			versions := strings.Join(a_versions, ",")
 
 			eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-				fmt.Sprintf("Start agreement-less service %v.", service.ServiceURL),
+				fmt.Sprintf("Start agreement-less service %v/%v.", service.ServiceOrg, service.ServiceURL),
 				persistence.EC_START_AGREEMENTLESS_SERVICE,
 				"", service.ServiceURL, service.ServiceOrg, versions, service.ServiceArch, []string{})
 
 			// Find the microservice definition for this service.
-			if msdefs, err := persistence.FindUnarchivedMicroserviceDefs(w.db, service.ServiceURL); err != nil {
+			if msdefs, err := persistence.FindUnarchivedMicroserviceDefs(w.db, service.ServiceURL, service.ServiceOrg); err != nil {
 				eventlog.LogDatabaseEvent(w.db, persistence.SEVERITY_ERROR,
-					fmt.Sprintf("Unable to start agreement-less service %v, error %v", service.ServiceURL, err),
+					fmt.Sprintf("Unable to start agreement-less service %v/%v, error %v", service.ServiceOrg, service.ServiceURL, err),
 					persistence.EC_DATABASE_ERROR)
-				glog.Errorf(logString(fmt.Sprintf("Unable to start agreement-less service %v, error %v", service.ServiceURL, err)))
+				glog.Errorf(logString(fmt.Sprintf("Unable to start agreement-less service %v/%v, error %v", service.ServiceOrg, service.ServiceURL, err)))
 				return
 			} else if msdefs == nil || len(msdefs) == 0 {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-					fmt.Sprintf("Unable to start agreement-less service %v, local service definition not found", service.ServiceURL),
+					fmt.Sprintf("Unable to start agreement-less service %v/%v, local service definition not found", service.ServiceOrg, service.ServiceURL),
 					persistence.EC_ERROR_START_AGREEMENTLESS_SERVICE,
 					"", service.ServiceURL, service.ServiceOrg, versions, service.ServiceArch, []string{})
-				glog.Errorf(logString(fmt.Sprintf("Unable to start agreement-less service %v, local service definition not found", service.ServiceURL)))
+				glog.Errorf(logString(fmt.Sprintf("Unable to start agreement-less service %v/%v, local service definition not found", service.ServiceOrg, service.ServiceURL)))
 				return
 			} else {
 
 				// Create the service instance dependency path with the agreement-less service as the root.
-				instancePath := []persistence.ServiceInstancePathElement{*persistence.NewServiceInstancePathElement(msdefs[0].SpecRef, msdefs[0].Version)}
+				instancePath := []persistence.ServiceInstancePathElement{*persistence.NewServiceInstancePathElement(msdefs[0].SpecRef, msdefs[0].Org, msdefs[0].Version)}
 
 				if err := w.startDependentService(instancePath, &msdefs[0], "", policy.BasicProtocol); err != nil {
 					eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-						fmt.Sprintf("Unable to start agreement-less service %v, error %v", service.ServiceURL, err),
+						fmt.Sprintf("Unable to start agreement-less service %v/%v, error %v", service.ServiceOrg, service.ServiceURL, err),
 						persistence.EC_ERROR_START_AGREEMENTLESS_SERVICE,
 						"", service.ServiceURL, service.ServiceOrg, versions, service.ServiceArch, []string{})
 
-					glog.Errorf(logString(fmt.Sprintf("Unable to start agreement-less service %v, error %v", service.ServiceURL, err)))
+					glog.Errorf(logString(fmt.Sprintf("Unable to start agreement-less service %v/%v, error %v", service.ServiceOrg, service.ServiceURL, err)))
 				} else {
 					eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-						fmt.Sprintf("Complete starting agreement-less service %v and its dependents.", service.ServiceURL),
+						fmt.Sprintf("Complete starting agreement-less service %v/%v and its dependents.", service.ServiceOrg, service.ServiceURL),
 						persistence.EC_COMPLETE_AGREEMENTLESS_SERVICE_STARTUP,
 						"", service.ServiceURL, service.ServiceOrg, versions, service.ServiceArch, []string{})
 				}
@@ -1482,8 +1482,8 @@ func (w *GovernanceWorker) startAgreementLessServices() {
 }
 
 // Get the environmental variables for a service (this is about launching).
-func (w *GovernanceWorker) GetWorkloadPreference(url string) (map[string]string, error) {
-	attrs, err := persistence.FindApplicableAttributes(w.db, url)
+func (w *GovernanceWorker) GetWorkloadPreference(url string, org string) (map[string]string, error) {
+	attrs, err := persistence.FindApplicableAttributes(w.db, url, org)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to fetch workload %v preferences. Err: %v", url, err)
 	}

--- a/governance/microservice.go
+++ b/governance/microservice.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/api"
 	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/eventlog"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/exchange"
@@ -87,15 +88,15 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 		return nil, fmt.Errorf(logString(fmt.Sprintf("No service definition available for key %v.", ms_key)))
 	} else {
 		if !msdef.HasDeployment() {
-			glog.Infof(logString(fmt.Sprintf("No workload needed for service %v.", msdef.SpecRef)))
+			glog.Infof(logString(fmt.Sprintf("No workload needed for service %v/%v.", msdef.Org, msdef.SpecRef)))
 			var mi *persistence.MicroserviceInstance
 
 			if isRetry {
 				mi = msinst_given
 			} else {
-				mi, err1 = persistence.NewMicroserviceInstance(w.db, msdef.SpecRef, msdef.Version, ms_key, dependencyPath)
+				mi, err1 = persistence.NewMicroserviceInstance(w.db, msdef.SpecRef, msdef.Org, msdef.Version, ms_key, dependencyPath)
 				if err1 != nil {
-					return nil, fmt.Errorf(logString(fmt.Sprintf("Error creating service instance for %v %v %v. %v", msdef.SpecRef, msdef.Version, ms_key, err1)))
+					return nil, fmt.Errorf(logString(fmt.Sprintf("Error persisting service instance for %v/%v %v %v.", msdef.Org, msdef.SpecRef, msdef.Version, ms_key)))
 				}
 			}
 
@@ -116,7 +117,7 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 			// convert to torrent structure only if the torrent string exists on the exchange
 			if torr != "" {
 				if err := json.Unmarshal([]byte(torr), &torrent); err != nil {
-					return nil, fmt.Errorf(logString(fmt.Sprintf("The torrent definition for service %v has error: %v", msdef.SpecRef, err)))
+					return nil, fmt.Errorf(logString(fmt.Sprintf("The torrent definition for service %v/%v has error: %v", msdef.Org, msdef.SpecRef, err)))
 				}
 			} else {
 				// this is the service case where the image server is defined
@@ -143,7 +144,7 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 				if w.Config.Edge.TrustCertUpdatesFromOrg {
 					key_map, err := exchange.GetHTTPObjectSigningKeysHandler(w)(exchange.SERVICE, msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch)
 					if err != nil {
-						return nil, fmt.Errorf(logString(fmt.Sprintf("received error getting signing keys from the exchange: %v %v %v %v. %v", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, err)))
+						return nil, fmt.Errorf(logString(fmt.Sprintf("received error getting signing keys from the exchange: %v/%v %v %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Arch, err)))
 					}
 
 					if key_map != nil {
@@ -179,11 +180,11 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 				// be greater than the dependency version.
 				ms_specs := []events.MicroserviceSpec{}
 				for _, rs := range msdef.RequiredServices {
-					if msdefs, err := persistence.FindUnarchivedMicroserviceDefs(w.db, rs.URL); err != nil {
-						return nil, fmt.Errorf(logString(fmt.Sprintf("received error reading service definition for %v: %v", rs.URL, err)))
+					if msdefs, err := persistence.FindUnarchivedMicroserviceDefs(w.db, rs.URL, rs.Org); err != nil {
+						return nil, fmt.Errorf(logString(fmt.Sprintf("received error reading service definition for %v/%v: %v", rs.Org, rs.URL, err)))
 					} else {
 						// Assume the first msdef is the one we want.
-						msspec := events.MicroserviceSpec{SpecRef: rs.URL, Version: msdefs[0].Version, MsdefId: msdefs[0].Id}
+						msspec := events.MicroserviceSpec{SpecRef: rs.URL, Org: rs.Org, Version: msdefs[0].Version, MsdefId: msdefs[0].Id}
 						ms_specs = append(ms_specs, msspec)
 					}
 				}
@@ -193,9 +194,9 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 				if isRetry {
 					ms_instance = msinst_given
 				} else {
-					ms_instance, err1 = persistence.NewMicroserviceInstance(w.db, msdef.SpecRef, msdef.Version, ms_key, dependencyPath)
+					ms_instance, err1 = persistence.NewMicroserviceInstance(w.db, msdef.SpecRef, msdef.Org, msdef.Version, ms_key, dependencyPath)
 					if err1 != nil {
-						return nil, fmt.Errorf(logString(fmt.Sprintf("Error creating service instance for %v %v %v. %v", msdef.SpecRef, msdef.Version, ms_key, err1)))
+						return nil, fmt.Errorf(logString(fmt.Sprintf("Error persisting service instance for %v/%v %v %v.", msdef.Org, msdef.SpecRef, msdef.Version, ms_key)))
 					}
 				}
 
@@ -203,7 +204,7 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 				img_auths := make([]events.ImageDockerAuth, 0)
 				if w.Config.Edge.TrustDockerAuthFromOrg {
 					if ias, err := exchange.GetHTTPServiceDockerAuthsHandler(w)(msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch); err != nil {
-						glog.V(5).Infof(logString(fmt.Sprintf("received error querying exchange for service image auths: %v version %v, error %v", msdef.SpecRef, msdef.Version, err)))
+						glog.V(5).Infof(logString(fmt.Sprintf("received error querying exchange for service image auths: %v/%v version %v, error %v", msdef.Org, msdef.SpecRef, msdef.Version, err)))
 					} else {
 						if ias != nil {
 							for _, iau_temp := range ias {
@@ -221,10 +222,10 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 				cc := events.NewContainerConfig(*url, ms_workload.Torrent.Signature, ms_workload.Deployment, ms_workload.DeploymentSignature, ms_workload.DeploymentUserInfo, "", img_auths)
 
 				// convert the user input from the service attributes to env variables
-				if attrs, err := persistence.FindApplicableAttributes(w.db, msdef.SpecRef); err != nil {
-					return nil, fmt.Errorf(logString(fmt.Sprintf("Unable to fetch service preferences for %v. Err: %v", msdef.SpecRef, err)))
+				if attrs, err := persistence.FindApplicableAttributes(w.db, msdef.SpecRef, msdef.Org); err != nil {
+					return nil, fmt.Errorf(logString(fmt.Sprintf("Unable to fetch service preferences for %v/%v. Err: %v", msdef.Org, msdef.SpecRef, err)))
 				} else if envAdds, err := persistence.AttributesToEnvvarMap(attrs, make(map[string]string), config.ENVVAR_PREFIX, w.Config.Edge.DefaultServiceRegistrationRAM); err != nil {
-					return nil, fmt.Errorf(logString(fmt.Sprintf("Failed to convert service preferences to environmental variables for %v. Err: %v", msdef.SpecRef, err)))
+					return nil, fmt.Errorf(logString(fmt.Sprintf("Failed to convert service preferences to environmental variables for %v/%v. Err: %v", msdef.Org, msdef.SpecRef, err)))
 				} else {
 					envAdds[config.ENVVAR_PREFIX+"DEVICE_ID"] = exchange.GetId(w.GetExchangeId())
 					envAdds[config.ENVVAR_PREFIX+"ORGANIZATION"] = exchange.GetOrg(w.GetExchangeId())
@@ -248,7 +249,7 @@ func (w *GovernanceWorker) StartMicroservice(ms_key string, agreementId string, 
 						// retry case or agreementless case
 						agIds = ms_instance.AssociatedAgreements
 					}
-					lc := events.NewContainerLaunchContext(cc, &envAdds, events.BlockchainConfig{}, ms_instance.GetKey(), agIds, ms_specs, persistence.NewServiceInstancePathElement(msdef.SpecRef, msdef.Version), isRetry)
+					lc := events.NewContainerLaunchContext(cc, &envAdds, events.BlockchainConfig{}, ms_instance.GetKey(), agIds, ms_specs, persistence.NewServiceInstancePathElement(msdef.SpecRef, msdef.Org, msdef.Version), isRetry)
 					w.Messages() <- events.NewLoadContainerMessage(events.LOAD_CONTAINER, lc)
 				}
 
@@ -324,7 +325,7 @@ func (w *GovernanceWorker) CleanupMicroservice(spec_ref string, version string, 
 // It changes the current running microservice from the old to new, assuming the given microservice is ready for a change.
 // One can check it by calling microservice.MicroserviceReadyForUpgrade to find out.
 func (w *GovernanceWorker) UpgradeMicroservice(msdef *persistence.MicroserviceDefinition, new_msdef *persistence.MicroserviceDefinition, upgrade bool) error {
-	glog.V(3).Infof(logString(fmt.Sprintf("Start changing service %v from version %v to version %v", msdef.SpecRef, msdef.Version, new_msdef.Version)))
+	glog.V(3).Infof(logString(fmt.Sprintf("Start changing service %v/%v from version %v to version %v", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version)))
 
 	// archive the old ms def and save the new one to db
 	if _, err := persistence.MsDefArchived(w.db, msdef.Id); err != nil {
@@ -332,17 +333,17 @@ func (w *GovernanceWorker) UpgradeMicroservice(msdef *persistence.MicroserviceDe
 	} else if err := persistence.SaveOrUpdateMicroserviceDef(w.db, new_msdef); err != nil {
 		return fmt.Errorf(logString(fmt.Sprintf("Failed to save service definition to db. %v. %v", new_msdef, err)))
 	} else if _, err := persistence.MSDefUpgradeNewMsId(w.db, msdef.Id, new_msdef.Id); err != nil {
-		return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeNewMsId to %v for service def %v version %v id %v. %v", new_msdef.Id, msdef.SpecRef, msdef.Version, msdef.Id, err)))
+		return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeNewMsId to %v for service def %v/%v version %v id %v. %v", new_msdef.Id, new_msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 	} else if _, err := persistence.MSDefUpgradeStarted(w.db, new_msdef.Id); err != nil {
-		return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeStartTime for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+		return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeStartTime for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 	}
 
 	// clean up old microservice
 	var eClearError error
 	var ms_insts []persistence.MicroserviceInstance
 	eClearError = nil
-	if ms_insts, eClearError = persistence.FindMicroserviceInstances(w.db, []persistence.MIFilter{persistence.AllInstancesMIFilter(msdef.SpecRef, msdef.Version), persistence.UnarchivedMIFilter()}); eClearError != nil {
-		glog.Errorf(logString(fmt.Sprintf("Error retrieving all the service instances from db for %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, eClearError)))
+	if ms_insts, eClearError = persistence.FindMicroserviceInstances(w.db, []persistence.MIFilter{persistence.AllInstancesMIFilter(msdef.SpecRef, msdef.Org, msdef.Version), persistence.UnarchivedMIFilter()}); eClearError != nil {
+		glog.Errorf(logString(fmt.Sprintf("Error retrieving all the service instances from db for %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, eClearError)))
 	} else if ms_insts != nil && len(ms_insts) > 0 {
 		for _, msi := range ms_insts {
 			if msi.MicroserviceDefId == msdef.Id {
@@ -359,11 +360,11 @@ func (w *GovernanceWorker) UpgradeMicroservice(msdef *persistence.MicroserviceDe
 	// update msdef UpgradeAgreementsClearedTime
 	if eClearError != nil {
 		if _, err := persistence.MSDefUpgradeFailed(w.db, new_msdef.Id, microservice.MS_CLEAR_OLD_AGS_FAILED, microservice.DecodeReasonCode(microservice.MS_CLEAR_OLD_AGS_FAILED)); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeAgreementsClearedTime for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeAgreementsClearedTime for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	} else {
 		if _, err := persistence.MsDefUpgradeAgreementsCleared(w.db, new_msdef.Id); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeAgreementsClearedTime for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeAgreementsClearedTime for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	}
 
@@ -372,35 +373,35 @@ func (w *GovernanceWorker) UpgradeMicroservice(msdef *persistence.MicroserviceDe
 	unregError = nil
 	unregError = microservice.RemoveMicroservicePolicy(msdef.SpecRef, msdef.Org, msdef.Version, msdef.Id, w.Config.Edge.PolicyPath, w.pm)
 	if unregError != nil {
-		glog.Errorf(logString(fmt.Sprintf("Failed to remove service policy for service def %v version %v. %v", msdef.SpecRef, msdef.Version, unregError)))
-	} else if unregError = microservice.UnregisterMicroserviceExchange(exchange.GetHTTPDeviceHandler(w), exchange.GetHTTPPutDeviceHandler(w), msdef.SpecRef, w.GetExchangeId(), w.GetExchangeToken(), w.db); unregError != nil {
-		glog.Errorf(logString(fmt.Sprintf("Failed to unregister service from the exchange for service def %v. %v", msdef.SpecRef, unregError)))
+		glog.Errorf(logString(fmt.Sprintf("Failed to remove service policy for service def %v/%v version %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, unregError)))
+	} else if unregError = microservice.UnregisterMicroserviceExchange(exchange.GetHTTPDeviceHandler(w), exchange.GetHTTPPutDeviceHandler(w), msdef.SpecRef, msdef.Org, w.GetExchangeId(), w.GetExchangeToken(), w.db); unregError != nil {
+		glog.Errorf(logString(fmt.Sprintf("Failed to unregister service from the exchange for service def %v/%v. %v", msdef.Org, msdef.SpecRef, unregError)))
 	}
 
 	// update msdef UpgradeMsUnregisteredTime
 	if unregError != nil {
 		if _, err := persistence.MSDefUpgradeFailed(w.db, new_msdef.Id, microservice.MS_UNREG_EXCH_FAILED, microservice.DecodeReasonCode(microservice.MS_UNREG_EXCH_FAILED)); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update service upgrading failure reason for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update service upgrading failure reason for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	} else {
 		if _, err := persistence.MSDefUpgradeMsUnregistered(w.db, new_msdef.Id); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeMsUnregisteredTime for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeMsUnregisteredTime for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	}
 
 	// create a new policy file and register the new microservice in exchange
 	if err := microservice.GenMicroservicePolicy(new_msdef, w.Config.Edge.PolicyPath, w.db, w.Messages(), exchange.GetOrg(w.GetExchangeId())); err != nil {
 		if _, err := persistence.MSDefUpgradeFailed(w.db, new_msdef.Id, microservice.MS_REREG_EXCH_FAILED, microservice.DecodeReasonCode(microservice.MS_REREG_EXCH_FAILED)); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update service upgrading failure reason for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update service upgrading failure reason for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	} else {
 		if _, err := persistence.MSDefUpgradeMsReregistered(w.db, new_msdef.Id); err != nil {
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeMsReregisteredTime for service def %v version %v id %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to update the UpgradeMsReregisteredTime for service def %v/%v version %v id %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 		}
 	}
 
 	// done for the microservices without containers.
-	glog.V(3).Infof(logString(fmt.Sprintf("End changing service %v version %v key %v", msdef.SpecRef, msdef.Version, msdef.Id)))
+	glog.V(3).Infof(logString(fmt.Sprintf("End changing service %v/%v version %v key %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id)))
 
 	return nil
 }
@@ -432,27 +433,27 @@ func (w *GovernanceWorker) RollbackMicroservice(msdef *persistence.MicroserviceD
 		// get next lower version
 		if new_msdef, err := microservice.GetRollbackMicroserviceDef(exchange.GetHTTPServiceResolverHandler(w), msdef, w.db); err != nil {
 			eventlog.LogDatabaseEvent(w.db, persistence.SEVERITY_ERROR,
-				fmt.Sprintf("Error finding the new service definition to downgrade to for %v %v version key %v. error: %v", msdef.SpecRef, msdef.Version, msdef.Id, err),
+				fmt.Sprintf("Error finding the new service definition to downgrade to for %v/%v version %v key %v. error: %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err),
 				persistence.EC_DATABASE_ERROR)
-			return fmt.Errorf(logString(fmt.Sprintf("Error finding the new service definition to downgrade to for %v %v version key %v. error: %v", msdef.SpecRef, msdef.Version, msdef.Id, err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Error finding the new service definition to downgrade to for %v/%v version %v key %v. error: %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 		} else if new_msdef == nil { //no more to try, exit out
 			eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-				fmt.Sprintf("Could not find lower version to downgrade for %v version %v.", msdef.SpecRef, msdef.Version),
+				fmt.Sprintf("Could not find lower version to downgrade for %v/%v version %v.", msdef.Org, msdef.SpecRef, msdef.Version),
 				persistence.EC_NO_VERSION_TO_DOWNGRADE,
 				"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
-			glog.Warningf(logString(fmt.Sprintf("Unable to find the service definition to downgrade to for %v %v version key %v.", msdef.SpecRef, msdef.Version, msdef.Id)))
-			return fmt.Errorf(logString(fmt.Sprintf("Unable to find the service definition to downgrade to for %v %v version key %v.", msdef.SpecRef, msdef.Version, msdef.Id)))
+			glog.Warningf(logString(fmt.Sprintf("Unable to find the service definition to downgrade to for %v/%v version %v key %v.", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id)))
+			return fmt.Errorf(logString(fmt.Sprintf("Unable to find the service definition to downgrade to for %v/%v version %v key %v.", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id)))
 		} else {
 			if err := w.UpgradeMicroservice(msdef, new_msdef, false); err != nil {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-					fmt.Sprintf("Error downgrading service %v frpm version %v to version %v. Eror: %v", msdef.SpecRef, msdef.Version, new_msdef.Version, err),
+					fmt.Sprintf("Error downgrading service %v/%v frpm version %v to version %v. Eror: %v", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version, err),
 					persistence.EC_ERROR_DOWNGRADE_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
-				glog.Errorf(logString(fmt.Sprintf("Failed to downgrade %v from version %v key %v to version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, new_msdef.Version, new_msdef.Id, err)))
+				glog.Errorf(logString(fmt.Sprintf("Failed to downgrade %v/%v from version %v key %v to version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, new_msdef.Version, new_msdef.Id, err)))
 				msdef = new_msdef
 			} else {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-					fmt.Sprintf("Complete downgrading service %v from version %v to version %v.", msdef.SpecRef, msdef.Version, new_msdef.Version),
+					fmt.Sprintf("Complete downgrading service %v/%v from version %v to version %v.", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version),
 					persistence.EC_COMPLETE_DOWNGRADE_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
 				return nil
@@ -476,11 +477,11 @@ func (w *GovernanceWorker) startMicroserviceInstForAgreement(msdef *persistence.
 		// For other sharing modes, start a new instance only if there is no existing one.
 		// The "exclusive" sharing mode is handled by maxAgreements=1 in the node side policy file. This ensures that agbots and nodes will
 		// only support one agreement at any time.
-	} else if ms_insts, err := persistence.FindMicroserviceInstances(w.db, []persistence.MIFilter{persistence.AllInstancesMIFilter(msdef.SpecRef, msdef.Version), persistence.UnarchivedMIFilter()}); err != nil {
+	} else if ms_insts, err := persistence.FindMicroserviceInstances(w.db, []persistence.MIFilter{persistence.AllInstancesMIFilter(msdef.SpecRef, msdef.Org, msdef.Version), persistence.UnarchivedMIFilter()}); err != nil {
 		eventlog.LogDatabaseEvent(w.db, persistence.SEVERITY_ERROR,
-			fmt.Sprintf("Error retrieving all the service instances from db for %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, err),
+			fmt.Sprintf("Error retrieving all the service instances from db for %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err),
 			persistence.EC_DATABASE_ERROR)
-		return fmt.Errorf(logString(fmt.Sprintf("Error retrieving all the service instances from db for %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, err)))
+		return fmt.Errorf(logString(fmt.Sprintf("Error retrieving all the service instances from db for %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 	} else if ms_insts == nil || len(ms_insts) == 0 {
 		needs_new_ms = true
 	} else {
@@ -492,33 +493,33 @@ func (w *GovernanceWorker) startMicroserviceInstForAgreement(msdef *persistence.
 		if msi, inst_err = w.StartMicroservice(msdef.Id, agreementId, dependencyPath, ""); inst_err != nil {
 
 			eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-				fmt.Sprintf("Service starting failed for %v version %v, error: %v", msdef.SpecRef, msdef.Version, inst_err),
+				fmt.Sprintf("Service starting failed for %v/%v version %v, error: %v", msdef.Org, msdef.SpecRef, msdef.Version, inst_err),
 				persistence.EC_ERROR_START_SERVICE,
 				"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{agreementId})
 
 			// Try to downgrade the service/microservice to a lower version.
-			glog.V(3).Infof(logString(fmt.Sprintf("Ending the agreement: %v because service %v failed to start", agreementId, msdef.SpecRef)))
+			glog.V(3).Infof(logString(fmt.Sprintf("Ending the agreement: %v because service %v/%v failed to start", agreementId, msdef.Org, msdef.SpecRef)))
 			ag_reason_code := w.producerPH[protocol].GetTerminationCode(producer.TERM_REASON_MS_DOWNGRADE_REQUIRED)
 			ag_reason_text := w.producerPH[protocol].GetTerminationReason(ag_reason_code)
 			if agreementId != "" {
 				w.cancelAgreement(agreementId, protocol, ag_reason_code, ag_reason_text)
 			}
 
-			glog.V(3).Infof(logString(fmt.Sprintf("Downgrading service %v because version %v key %v failed to start. Error: %v", msdef.SpecRef, msdef.Version, msdef.Id, inst_err)))
+			glog.V(3).Infof(logString(fmt.Sprintf("Downgrading service %v/%v because version %v key %v failed to start. Error: %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, inst_err)))
 			eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-				fmt.Sprintf("Start downgrading service %v version %v because service for aagreement failed to start.", msdef.SpecRef, msdef.Version),
+				fmt.Sprintf("Start downgrading service %v/%v version %v because service for aagreement failed to start.", msdef.Org, msdef.SpecRef, msdef.Version),
 				persistence.EC_START_DOWNGRADE_SERVICE,
 				"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{agreementId})
 
 			if err := w.RollbackMicroservice(msdef); err != nil {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-					fmt.Sprintf("Error downgrading service %v version %v. %v", msdef.SpecRef, msdef.Version, err),
+					fmt.Sprintf("Error downgrading service %v/%v version %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, err),
 					persistence.EC_ERROR_DOWNGRADE_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{agreementId})
-				glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, err)))
+				glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 			}
 
-			return fmt.Errorf(logString(fmt.Sprintf("Failed to start service instance for %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, inst_err)))
+			return fmt.Errorf(logString(fmt.Sprintf("Failed to start service instance for %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, inst_err)))
 		}
 	} else if _, err := persistence.UpdateMSInstanceAddDependencyPath(w.db, msi.GetKey(), &dependencyPath); err != nil {
 		return fmt.Errorf(logString(fmt.Sprintf("error adding dependency path %v to the service %v: %v", dependencyPath, msi.GetKey(), err)))
@@ -555,11 +556,11 @@ func (w *GovernanceWorker) handleMicroserviceInstForAgEnded(agreementId string, 
 					if id == agreementId {
 						msd, err := persistence.FindMicroserviceDefWithKey(w.db, msi.MicroserviceDefId)
 						if err != nil {
-							glog.Errorf(logString(fmt.Sprintf("Error retrieving service definition %v version %v key %v from database, error: %v", msi.SpecRef, msi.Version, msi.MicroserviceDefId, err)))
+							glog.Errorf(logString(fmt.Sprintf("Error retrieving service definition %v version %v key %v from database, error: %v", cutil.FormOrgSpecUrl(msi.SpecRef, msi.Org), msi.Version, msi.MicroserviceDefId, err)))
 							// delete the microservice instance if the sharing mode is "multiple"
 						} else {
 							eventlog.LogServiceEvent(w.db, persistence.SEVERITY_INFO,
-								fmt.Sprintf("Start cleaning up service %v because agreement %v ended.", msi.SpecRef, agreementId),
+								fmt.Sprintf("Start cleaning up service %v because agreement %v ended.", cutil.FormOrgSpecUrl(msi.SpecRef, msi.Org), agreementId),
 								persistence.EC_START_CLEANUP_SERVICE,
 								msi)
 
@@ -585,7 +586,7 @@ func (w *GovernanceWorker) handleMicroserviceInstForAgEnded(agreementId string, 
 								glog.Errorf(logString(fmt.Sprintf("Should have one agreement from the db but found %v.", len(ags))))
 							} else if ags[0].RunningWorkload.URL != "" {
 								// remove the related partent path from the service instance
-								tpe := persistence.NewServiceInstancePathElement(ags[0].RunningWorkload.URL, ags[0].RunningWorkload.Version)
+								tpe := persistence.NewServiceInstancePathElement(ags[0].RunningWorkload.URL, ags[0].RunningWorkload.Org, ags[0].RunningWorkload.Version)
 								if _, err := persistence.UpdateMSInstanceRemoveDependencyPath2(w.db, msi.GetKey(), tpe); err != nil {
 									glog.Errorf(logString(fmt.Sprintf("error removing parent path from the db for service instance %v fro agreement %v: %v", msi.GetKey(), agreementId, err)))
 								}
@@ -643,10 +644,10 @@ func (w *GovernanceWorker) getMiceroserviceRetryCount(msi *persistence.Microserv
 		}
 
 		if total_nums > 0 {
-			retry_count = int(math.Round(float64(total_retries) / float64(total_nums)))
+			retry_count = int(math.Ceil(float64(total_retries) / float64(total_nums)))
 		}
 		if total_duration_nums > 0 {
-			retry_duration = uint(math.Round(float64(total_retry_duration) / float64(total_duration_nums)))
+			retry_duration = uint(math.Ceil(float64(total_retry_duration) / float64(total_duration_nums)))
 		}
 	}
 
@@ -723,17 +724,17 @@ func (w *GovernanceWorker) handleMicroserviceExecFailure(msdef *persistence.Micr
 		// rollback the microservice to lower version
 		// a new ms instance will be created if successful
 		eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-			fmt.Sprintf("Start downgrading dependent service %v version %v because service failed.", msdef.SpecRef, msdef.Version),
+			fmt.Sprintf("Start downgrading service %v/%v version %v because service failed to start.", msdef.Org, msdef.SpecRef, msdef.Version),
 			persistence.EC_START_DOWNGRADE_SERVICE,
 			msinst_key, msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
 
 		if err := w.RollbackMicroservice(msdef); err != nil {
 			eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-				fmt.Sprintf("Failed to downgrade service %v version %v, error: %v", msdef.SpecRef, msdef.Version, err),
+				fmt.Sprintf("Failed to downgrade service %v/%v version %v, error: %v", msdef.Org, msdef.SpecRef, msdef.Version, err),
 				persistence.EC_ERROR_DOWNGRADE_SERVICE,
 				msinst_key, msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
 
-			glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, err)))
+			glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 
 			// this service just could not be started. we have to cancel all the associated agreements
 			// a new instance will be created.
@@ -756,37 +757,37 @@ func (w *GovernanceWorker) handleMicroserviceUpgrade(msdef_id string) {
 	} else if microservice.MicroserviceReadyForUpgrade(msdef, w.db) {
 		// find the new ms def to upgrade to
 		if new_msdef, err := microservice.GetUpgradeMicroserviceDef(exchange.GetHTTPServiceResolverHandler(w), msdef, w.db); err != nil {
-			glog.Errorf(logString(fmt.Sprintf("Error finding the new service definition to upgrade to for %v version %v. %v", msdef.SpecRef, msdef.Version, err)))
+			glog.Errorf(logString(fmt.Sprintf("Error finding the new service definition to upgrade to for %v/%v version %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, err)))
 		} else if new_msdef == nil {
-			glog.V(5).Infof(logString(fmt.Sprintf("No changes for service definition %v, no need to upgrade.", msdef.SpecRef)))
+			glog.V(5).Infof(logString(fmt.Sprintf("No changes for service definition %v/%v, no need to upgrade.", msdef.Org, msdef.SpecRef)))
 		} else {
 			eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-				fmt.Sprintf("Start upgrading service %v from version %v to version %v.", msdef.SpecRef, msdef.Version, new_msdef.Version),
+				fmt.Sprintf("Start upgrading service %v/%v from version %v to version %v.", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version),
 				persistence.EC_START_UPGRADE_SERVICE,
 				"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
 
 			if err := w.UpgradeMicroservice(msdef, new_msdef, true); err != nil {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-					fmt.Sprintf("Failed to upgrade service %v from version %v to version %v, error: %v", msdef.SpecRef, msdef.Version, new_msdef.Version, err),
+					fmt.Sprintf("Failed to upgrade service %v/%v from version %v to version %v, error: %v", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version, err),
 					persistence.EC_ERROR_UPGRADE_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
-				glog.Errorf(logString(fmt.Sprintf("Error upgrading service %v version %v key %v. %v", msdef.SpecRef, msdef.Version, msdef.Id, err)))
+				glog.Errorf(logString(fmt.Sprintf("Error upgrading service %v/%v version %v key %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, msdef.Id, err)))
 
 				// rollback the microservice to lower version
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-					fmt.Sprintf("Start downgrading service %v version %v because upgrade failed.", new_msdef.SpecRef, new_msdef.Version),
+					fmt.Sprintf("Start downgrading service %v/%v version %v because upgrade failed.", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version),
 					persistence.EC_START_DOWNGRADE_SERVICE,
 					"", new_msdef.SpecRef, new_msdef.Org, new_msdef.Version, new_msdef.Arch, []string{})
 				if err := w.RollbackMicroservice(new_msdef); err != nil {
 					eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_ERROR,
-						fmt.Sprintf("Failed to downgrade service %v version %v, error: %v", new_msdef.SpecRef, new_msdef.Version, err),
+						fmt.Sprintf("Failed to downgrade service %v/%v version %v, error: %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, err),
 						persistence.EC_ERROR_DOWNGRADE_SERVICE,
 						"", new_msdef.SpecRef, new_msdef.Org, new_msdef.Version, new_msdef.Arch, []string{})
-					glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v version %v key %v. %v", new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
+					glog.Errorf(logString(fmt.Sprintf("Error downgrading service %v/%v version %v key %v. %v", new_msdef.Org, new_msdef.SpecRef, new_msdef.Version, new_msdef.Id, err)))
 				}
 			} else {
 				eventlog.LogServiceEvent2(w.db, persistence.SEVERITY_INFO,
-					fmt.Sprintf("Complete upgrading service %v from version %v to version %v.", msdef.SpecRef, msdef.Version, new_msdef.Version),
+					fmt.Sprintf("Complete upgrading service %v/%v from version %v to version %v.", msdef.Org, msdef.SpecRef, msdef.Version, new_msdef.Version),
 					persistence.EC_COMPLETE_UPGRADE_SERVICE,
 					"", msdef.SpecRef, msdef.Org, msdef.Version, msdef.Arch, []string{})
 			}

--- a/governance/shutdown.go
+++ b/governance/shutdown.go
@@ -273,7 +273,7 @@ func (w *GovernanceWorker) patchNodeKey() error {
 // Remove all attributes from the DB.
 func (w *GovernanceWorker) deleteAttributes() error {
 	// Retrieve all attributes in the DB.
-	attrs, err := persistence.FindApplicableAttributes(w.db, "")
+	attrs, err := persistence.FindApplicableAttributes(w.db, "", "")
 	if err != nil {
 		return errors.New(fmt.Sprintf("unable to retrieve attribute objects from database, error: %v", err))
 	} else if attrs == nil || len(attrs) == 0 {

--- a/microservice/microservice.go
+++ b/microservice/microservice.go
@@ -208,7 +208,7 @@ func GetUpgradeMicroserviceDef(getService exchange.ServiceResolverHandler, msdef
 		} else if c == 0 && bytes.Equal(msdef.MetadataHash, new_msdef.MetadataHash) {
 			return nil, nil // no change, do nothing
 		} else {
-			if msdefs, err := persistence.FindMicroserviceDefs(db, []persistence.MSFilter{persistence.UrlVersionMSFilter(new_msdef.SpecRef, new_msdef.Version), persistence.ArchivedMSFilter()}); err != nil {
+			if msdefs, err := persistence.FindMicroserviceDefs(db, []persistence.MSFilter{persistence.UrlOrgVersionMSFilter(new_msdef.SpecRef, new_msdef.Org, new_msdef.Version), persistence.ArchivedMSFilter()}); err != nil {
 				return nil, fmt.Errorf("Failed to get archived service definition for %v/%v version %v. %v", msdef.Org, msdef.SpecRef, msdef.Version, err)
 			} else if msdefs != nil && len(msdefs) > 0 {
 				for _, ms := range msdefs {

--- a/microservice/microservice_test.go
+++ b/microservice/microservice_test.go
@@ -63,7 +63,7 @@ func TestMicroserviceReadyForUpgrade(t *testing.T) {
 	pms.UpgradeStartTime = uint64(0)
 
 	pms.Id = "1"
-	msi, err := persistence.NewMicroserviceInstance(db, pms.SpecRef, pms.Version, pms.Id, []persistence.ServiceInstancePathElement{})
+	msi, err := persistence.NewMicroserviceInstance(db, pms.SpecRef, pms.Org, pms.Version, pms.Id, []persistence.ServiceInstancePathElement{})
 	assert.Nil(t, err, fmt.Sprintf("should not return error, but got this: %v", err))
 
 	pms.AutoUpgrade = true
@@ -166,19 +166,19 @@ func TestUnregisterServiceExchange(t *testing.T) {
 	assert.Nil(t, err, fmt.Sprintf("should not return error, but got this: %v", err))
 
 	m1 := exchange.Microservice{
-		Url:           "gps",
+		Url:           "myorg/gps",
 		Properties:    nil,
 		NumAgreements: 0,
 		Policy:        "blahblah",
 	}
 	m2 := exchange.Microservice{
-		Url:           "network",
+		Url:           "myorg/network",
 		Properties:    nil,
 		NumAgreements: 0,
 		Policy:        "blahblah",
 	}
 	m3 := exchange.Microservice{
-		Url:           "pwsms",
+		Url:           "myorg/pwsms",
 		Properties:    nil,
 		NumAgreements: 0,
 		Policy:        "blahblah",
@@ -193,7 +193,7 @@ func TestUnregisterServiceExchange(t *testing.T) {
 
 	err = UnregisterMicroserviceExchange(getVariableDeviceHandler(nil, mss),
 		checkPutDeviceHandler(t, mss, url),
-		url, device_id, device_token, db)
+		url, org, device_id, device_token, db)
 	assert.NotNil(t, err, "Device not created in the db yet.")
 
 	// save device in db
@@ -202,12 +202,12 @@ func TestUnregisterServiceExchange(t *testing.T) {
 
 	err = UnregisterMicroserviceExchange(getVariableDeviceHandler(nil, nil),
 		checkPutDeviceHandler(t, nil, url),
-		url, device_id, device_token, db)
+		url, org, device_id, device_token, db)
 	assert.Nil(t, err, "no registered ms, nothing to do")
 
 	err = UnregisterMicroserviceExchange(getVariableDeviceHandler(nil, mss),
 		checkPutDeviceHandler(t, mss, url),
-		url, device_id, device_token, db)
+		url, org, device_id, device_token, db)
 	assert.Nil(t, err, "eveything should have worked")
 
 	err = cleanupDB(dir)

--- a/persistence/attribute_types.go
+++ b/persistence/attribute_types.go
@@ -19,8 +19,8 @@ func (a LocationAttributes) GetMeta() *AttributeMeta {
 
 func (a LocationAttributes) GetGenericMappings() map[string]interface{} {
 	return map[string]interface{}{
-		"lat": a.Lat,
-		"lon": a.Lon,
+		"lat":                  a.Lat,
+		"lon":                  a.Lon,
 		"location_accuracy_km": a.LocationAccuracyKM,
 		"use_gps":              a.UseGps,
 	}

--- a/persistence/attribute_types.go
+++ b/persistence/attribute_types.go
@@ -58,9 +58,10 @@ func (a ArchitectureAttributes) String() string {
 }
 
 type ComputeAttributes struct {
-	Meta *AttributeMeta `json:"meta"`
-	CPUs int64          `json:"cpus"`
-	RAM  int64          `json:"ram"`
+	Meta         *AttributeMeta `json:"meta"`
+	ServiceSpecs *ServiceSpecs  `json:"service_specs"`
+	CPUs         int64          `json:"cpus"`
+	RAM          int64          `json:"ram"`
 }
 
 func (a ComputeAttributes) GetMeta() *AttributeMeta {
@@ -80,7 +81,18 @@ func (a ComputeAttributes) Update(other Attribute) error {
 }
 
 func (a ComputeAttributes) String() string {
-	return fmt.Sprintf("Meta: %v, CPUs: %v, RAM: %v", a.Meta, a.CPUs, a.RAM)
+	if a.ServiceSpecs == nil {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, CPUs: %v, RAM: %v", a.Meta, nil, a.CPUs, a.RAM)
+	} else {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, CPUs: %v, RAM: %v", a.Meta, *a.ServiceSpecs, a.CPUs, a.RAM)
+	}
+}
+
+func (a ComputeAttributes) GetServiceSpecs() *ServiceSpecs {
+	if a.ServiceSpecs == nil {
+		a.ServiceSpecs = new(ServiceSpecs)
+	}
+	return a.ServiceSpecs
 }
 
 type HAAttributes struct {
@@ -118,6 +130,7 @@ func (a HAAttributes) String() string {
 
 type MeteringAttributes struct {
 	Meta                  *AttributeMeta `json:"meta"`
+	ServiceSpecs          *ServiceSpecs  `json:"service_specs"`
 	Tokens                uint64         `json:"tokens"`
 	PerTimeUnit           string         `json:"per_time_unit"`
 	NotificationIntervalS int            `json:"notification_interval"`
@@ -141,12 +154,24 @@ func (a MeteringAttributes) Update(other Attribute) error {
 }
 
 func (a MeteringAttributes) String() string {
-	return fmt.Sprintf("Meta: %v, Tokens: %v, PerTimeUnit: %v, NotificationIntervalS: %v", a.Meta, a.Tokens, a.PerTimeUnit, a.NotificationIntervalS)
+	if a.ServiceSpecs == nil {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, Tokens: %v, PerTimeUnit: %v, NotificationIntervalS: %v", a.Meta, nil, a.Tokens, a.PerTimeUnit, a.NotificationIntervalS)
+	} else {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, Tokens: %v, PerTimeUnit: %v, NotificationIntervalS: %v", a.Meta, *(a.ServiceSpecs), a.Tokens, a.PerTimeUnit, a.NotificationIntervalS)
+	}
+}
+
+func (a MeteringAttributes) GetServiceSpecs() *ServiceSpecs {
+	if a.ServiceSpecs == nil {
+		a.ServiceSpecs = new(ServiceSpecs)
+	}
+	return a.ServiceSpecs
 }
 
 type CounterPartyPropertyAttributes struct {
-	Meta       *AttributeMeta         `json:"meta"`
-	Expression map[string]interface{} `json:"expression"`
+	Meta         *AttributeMeta         `json:"meta"`
+	ServiceSpecs *ServiceSpecs          `json:"service_specs"`
+	Expression   map[string]interface{} `json:"expression"`
 }
 
 func (a CounterPartyPropertyAttributes) GetMeta() *AttributeMeta {
@@ -159,18 +184,30 @@ func (a CounterPartyPropertyAttributes) GetGenericMappings() map[string]interfac
 	}
 }
 
+func (a CounterPartyPropertyAttributes) GetServiceSpecs() *ServiceSpecs {
+	if a.ServiceSpecs == nil {
+		a.ServiceSpecs = new(ServiceSpecs)
+	}
+	return a.ServiceSpecs
+}
+
 // TODO: duplicate this for the others too
 func (a CounterPartyPropertyAttributes) Update(other Attribute) error {
 	return fmt.Errorf("Update not implemented for type: %T", a)
 }
 
 func (a CounterPartyPropertyAttributes) String() string {
-	return fmt.Sprintf("Meta: %v, Expression: %v", a.Meta, a.Expression)
+	if a.ServiceSpecs == nil {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, Expression: %v", a.Meta, nil, a.Expression)
+	} else {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, Expression: %v", a.Meta, *a.ServiceSpecs, a.Expression)
+	}
 }
 
 type PropertyAttributes struct {
-	Meta     *AttributeMeta         `json:"meta"`
-	Mappings map[string]interface{} `json:"mappings"`
+	Meta         *AttributeMeta         `json:"meta"`
+	ServiceSpecs *ServiceSpecs          `json:"service_specs"`
+	Mappings     map[string]interface{} `json:"mappings"`
 }
 
 func (a PropertyAttributes) GetMeta() *AttributeMeta {
@@ -193,12 +230,24 @@ func (a PropertyAttributes) Update(other Attribute) error {
 }
 
 func (a PropertyAttributes) String() string {
-	return fmt.Sprintf("Meta: %v, Mappings: %v", a.Meta, a.Mappings)
+	if a.ServiceSpecs == nil {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, Mappings: %v", a.Meta, nil, a.Mappings)
+	} else {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, Mappings: %v", a.Meta, *a.ServiceSpecs, a.Mappings)
+	}
+}
+
+func (a PropertyAttributes) GetServiceSpecs() *ServiceSpecs {
+	if a.ServiceSpecs == nil {
+		a.ServiceSpecs = new(ServiceSpecs)
+	}
+	return a.ServiceSpecs
 }
 
 type UserInputAttributes struct {
-	Meta     *AttributeMeta         `json:"meta"`
-	Mappings map[string]interface{} `json:"mappings"`
+	Meta         *AttributeMeta         `json:"meta"`
+	ServiceSpecs *ServiceSpecs          `json:"service_specs"`
+	Mappings     map[string]interface{} `json:"mappings"`
 }
 
 func (a UserInputAttributes) GetMeta() *AttributeMeta {
@@ -220,6 +269,7 @@ func (a UserInputAttributes) Update(other Attribute) error {
 	case *UserInputAttributes:
 		o := other.(*UserInputAttributes)
 		a.GetMeta().Update(*o.GetMeta())
+		a.GetServiceSpecs().Update(*o.GetServiceSpecs())
 		// update a's members with any in o that are specified
 
 		for k, v := range o.Mappings {
@@ -233,12 +283,24 @@ func (a UserInputAttributes) Update(other Attribute) error {
 }
 
 func (a UserInputAttributes) String() string {
-	return fmt.Sprintf("Meta: %v, Mappings: %v", a.Meta, a.Mappings)
+	if a.ServiceSpecs == nil {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, Mappings: %v", a.Meta, nil, a.Mappings)
+	} else {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, Mappings: %v", a.Meta, *a.ServiceSpecs, a.Mappings)
+	}
+}
+
+func (a UserInputAttributes) GetServiceSpecs() *ServiceSpecs {
+	if a.ServiceSpecs == nil {
+		a.ServiceSpecs = new(ServiceSpecs)
+	}
+	return a.ServiceSpecs
 }
 
 type AgreementProtocolAttributes struct {
-	Meta      *AttributeMeta `json:"meta"`
-	Protocols interface{}    `json:"protocols"`
+	Meta         *AttributeMeta `json:"meta"`
+	ServiceSpecs *ServiceSpecs  `json:"service_specs"`
+	Protocols    interface{}    `json:"protocols"`
 }
 
 func (a AgreementProtocolAttributes) GetMeta() *AttributeMeta {
@@ -257,17 +319,29 @@ func (a AgreementProtocolAttributes) Update(other Attribute) error {
 }
 
 func (a AgreementProtocolAttributes) String() string {
-	return fmt.Sprintf("Meta: %v, Protocols: %v", a.Meta, a.Protocols)
+	if a.ServiceSpecs == nil {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, Protocols: %v", a.Meta, nil, a.Protocols)
+	} else {
+		return fmt.Sprintf("Meta: %v, ServiceSpecs: %v, Protocols: %v", a.Meta, *a.ServiceSpecs, a.Protocols)
+	}
+}
+
+func (a AgreementProtocolAttributes) GetServiceSpecs() *ServiceSpecs {
+	if a.ServiceSpecs == nil {
+		a.ServiceSpecs = new(ServiceSpecs)
+	}
+	return a.ServiceSpecs
 }
 
 type HTTPSBasicAuthAttributes struct {
 	Meta     *AttributeMeta `json:"meta"`
+	Url      string         `json:"url"`
 	Username string         `json:"username"`
 	Password string         `json:"password"`
 }
 
 func (a HTTPSBasicAuthAttributes) String() string {
-	return fmt.Sprintf("meta: %v, username: %v, password: <withheld>", a.GetMeta(), a.Username)
+	return fmt.Sprintf("meta: %v, url: %v, username: %v, password: <withheld>", a.GetMeta(), a.Url, a.Username)
 }
 
 func (a HTTPSBasicAuthAttributes) GetMeta() *AttributeMeta {
@@ -282,6 +356,7 @@ func (a HTTPSBasicAuthAttributes) GetGenericMappings() map[string]interface{} {
 	}
 
 	return map[string]interface{}{
+		"url":      a.Url,
 		"username": a.Username,
 		"password": obf,
 	}
@@ -303,6 +378,7 @@ func (a HTTPSBasicAuthAttributes) Update(other Attribute) error {
 }
 
 type Auth struct {
+	Registry string `json:"registry"`
 	UserName string `json:"username"` // The name of the user, the default is 'token'
 	Token    string `json:"token"`    // It can be a token, a password, an api key etc.
 }
@@ -315,7 +391,7 @@ type DockerRegistryAuthAttributes struct {
 func (a DockerRegistryAuthAttributes) String() string {
 	auths_show := make([]Auth, 0)
 	for _, au := range a.Auths {
-		auths_show = append(auths_show, Auth{UserName: au.UserName, Token: "********"})
+		auths_show = append(auths_show, Auth{Registry: au.Registry, UserName: au.UserName, Token: "********"})
 	}
 
 	return fmt.Sprintf("meta: %v, auths: %v", a.GetMeta(), auths_show)

--- a/persistence/eventlog_types_test.go
+++ b/persistence/eventlog_types_test.go
@@ -9,9 +9,16 @@ import (
 
 func Test_AgreementEventSource_Matches(t *testing.T) {
 
-	source1 := NewAgreementEventSource("agreement id 1", WorkloadInfo{"http://top1.com", "mycomp", "1.0.0", "amd64"}, []string{"http://mycom.com", "http://service12.com"}, "agbot1", "basic")
-	source2 := NewAgreementEventSource("agreement id 2", WorkloadInfo{"http://top2.com", "mycomp", "1.0.0", "amd64"}, []string{"http://mycom21.com", "http://mycome22.com"}, "agbot2", "cs")
-	source3 := NewAgreementEventSource("agreement id 3", WorkloadInfo{"http://top3.com", "mycomp", "1.0.0", "amd64"}, []string{"http://service31.com", "http://service32.com"}, "agbot1", "basic")
+	sp11 := ServiceSpec{Url: "http://mycom.com", Org: "mycom"}
+	sp12 := ServiceSpec{Url: "http://service12.com", Org: "service12"}
+	sp21 := ServiceSpec{Url: "http://mycom21.com", Org: "mycom21"}
+	sp22 := ServiceSpec{Url: "http://mycome22.com", Org: "mycome22"}
+	sp31 := ServiceSpec{Url: "http://service31.com", Org: "service31"}
+	sp32 := ServiceSpec{Url: "http://service32.com", Org: "service32"}
+
+	source1 := NewAgreementEventSource("agreement id 1", WorkloadInfo{"http://top1.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp11, sp12}, "agbot1", "basic")
+	source2 := NewAgreementEventSource("agreement id 2", WorkloadInfo{"http://top2.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp21, sp22}, "agbot2", "cs")
+	source3 := NewAgreementEventSource("agreement id 3", WorkloadInfo{"http://top3.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp31, sp32}, "agbot1", "basic")
 
 	s1 := []Selector{{"~", "service"}}
 	s2 := []Selector{{"~", "id"}}

--- a/persistence/eventlogs_test.go
+++ b/persistence/eventlogs_test.go
@@ -10,9 +10,16 @@ import (
 )
 
 func Test_EventLog_Matches(t *testing.T) {
-	source1 := NewAgreementEventSource("agreement id 1", WorkloadInfo{"http://top1.com", "mycomp", "1.0.0", "amd64"}, []string{"http://mycom.com", "http://service12.com"}, "agbot1", "basic")
-	source2 := NewAgreementEventSource("agreement id 2", WorkloadInfo{"http://top2.com", "mycomp", "1.0.0", "amd64"}, []string{"http://mycom21.com", "http://mycome22.com"}, "agbot2", "cs")
-	source3 := NewAgreementEventSource("agreement id 3", WorkloadInfo{"http://top3.com", "mycomp", "1.0.0", "amd64"}, []string{"http://service31.com", "http://service32.com"}, "agbot1", "basic")
+	sp11 := ServiceSpec{Url: "http://mycom.com", Org: "mycom"}
+	sp12 := ServiceSpec{Url: "http://service12.com", Org: "service12"}
+	sp21 := ServiceSpec{Url: "http://mycom21.com", Org: "mycom21"}
+	sp22 := ServiceSpec{Url: "http://mycome22.com", Org: "mycome22"}
+	sp31 := ServiceSpec{Url: "http://service31.com", Org: "service31"}
+	sp32 := ServiceSpec{Url: "http://service32.com", Org: "service32"}
+
+	source1 := NewAgreementEventSource("agreement id 1", WorkloadInfo{"http://top1.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp11, sp12}, "agbot1", "basic")
+	source2 := NewAgreementEventSource("agreement id 2", WorkloadInfo{"http://top2.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp21, sp22}, "agbot2", "cs")
+	source3 := NewAgreementEventSource("agreement id 3", WorkloadInfo{"http://top3.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp31, sp32}, "agbot1", "basic")
 
 	e1 := NewEventLog(SEVERITY_INFO, "message 11", EC_START_NODE_CONFIG_REG, SRC_TYPE_AG, *source1)
 	e2 := NewEventLog(SEVERITY_INFO, "message 21", EC_START_NODE_CONFIG_REG, SRC_TYPE_AG, *source2)
@@ -65,9 +72,16 @@ func Test_EventLog_Matches(t *testing.T) {
 }
 
 func Test_EventLog_Matches2(t *testing.T) {
-	source1 := NewAgreementEventSource("agreement id 1", WorkloadInfo{"http://top1.com", "mycomp", "1.0.0", "amd64"}, []string{"http://mycom.com", "http://service12.com"}, "agbot1", "basic")
-	source2 := NewAgreementEventSource("agreement id 2", WorkloadInfo{"http://top2.com", "mycomp", "1.0.0", "amd64"}, []string{"http://mycom21.com", "http://mycome22.com"}, "agbot2", "cs")
-	source3 := NewAgreementEventSource("agreement id 3", WorkloadInfo{"http://top3.com", "mycomp", "1.0.0", "amd64"}, []string{"http://service31.com", "http://service32.com"}, "agbot1", "basic")
+	sp11 := ServiceSpec{Url: "http://mycom.com", Org: "mycom"}
+	sp12 := ServiceSpec{Url: "http://service12.com", Org: "service12"}
+	sp21 := ServiceSpec{Url: "http://mycom21.com", Org: "mycom21"}
+	sp22 := ServiceSpec{Url: "http://mycome22.com", Org: "mycome22"}
+	sp31 := ServiceSpec{Url: "http://service31.com", Org: "service31"}
+	sp32 := ServiceSpec{Url: "http://service32.com", Org: "service32"}
+
+	source1 := NewAgreementEventSource("agreement id 1", WorkloadInfo{"http://top1.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp11, sp12}, "agbot1", "basic")
+	source2 := NewAgreementEventSource("agreement id 2", WorkloadInfo{"http://top2.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp21, sp22}, "agbot2", "cs")
+	source3 := NewAgreementEventSource("agreement id 3", WorkloadInfo{"http://top3.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp31, sp32}, "agbot1", "basic")
 
 	e1 := NewEventLog(SEVERITY_INFO, "message 11", EC_START_NODE_CONFIG_REG, SRC_TYPE_AG, *source1)
 	e2 := NewEventLog(SEVERITY_INFO, "message 21", EC_START_NODE_CONFIG_REG, SRC_TYPE_AG, *source2)
@@ -383,9 +397,16 @@ func Test_SaveLastUnregistrationTime(t *testing.T) {
 	}
 	defer cleanTestDir(dir)
 
-	source1 := NewAgreementEventSource("agreement id 1", WorkloadInfo{"http://top1.com", "mycomp", "1.0.0", "amd64"}, []string{"http://mycom.com", "http://service12.com"}, "agbot1", "basic")
-	source2 := NewAgreementEventSource("agreement id 2", WorkloadInfo{"http://top2.com", "mycomp", "1.0.0", "amd64"}, []string{"http://mycom21.com", "http://mycome22.com"}, "agbot2", "cs")
-	source3 := NewAgreementEventSource("agreement id 3", WorkloadInfo{"http://top3.com", "mycomp", "1.0.0", "amd64"}, []string{"http://service31.com", "http://service32.com"}, "agbot1", "basic")
+	sp11 := ServiceSpec{Url: "http://mycom.com", Org: "mycom"}
+	sp12 := ServiceSpec{Url: "http://service12.com", Org: "service12"}
+	sp21 := ServiceSpec{Url: "http://mycom21.com", Org: "mycom21"}
+	sp22 := ServiceSpec{Url: "http://mycome22.com", Org: "mycome22"}
+	sp31 := ServiceSpec{Url: "http://service31.com", Org: "service31"}
+	sp32 := ServiceSpec{Url: "http://service32.com", Org: "service32"}
+
+	source1 := NewAgreementEventSource("agreement id 1", WorkloadInfo{"http://top1.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp11, sp12}, "agbot1", "basic")
+	source2 := NewAgreementEventSource("agreement id 2", WorkloadInfo{"http://top2.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp21, sp22}, "agbot2", "cs")
+	source3 := NewAgreementEventSource("agreement id 3", WorkloadInfo{"http://top3.com", "mycomp", "1.0.0", "amd64"}, []ServiceSpec{sp31, sp32}, "agbot1", "basic")
 
 	e1 := NewEventLog(SEVERITY_INFO, "message 11", EC_START_NODE_CONFIG_REG, SRC_TYPE_AG, *source1)
 	e2 := NewEventLog(SEVERITY_INFO, "message 21", EC_START_NODE_CONFIG_REG, SRC_TYPE_AG, *source2)

--- a/persistence/microservices.go
+++ b/persistence/microservices.go
@@ -306,9 +306,9 @@ func SaveOrUpdateMicroserviceDef(db *bolt.DB, msdef *MicroserviceDefinition) err
 	return writeErr
 }
 
-// find the unarchived microservice definitions for the given url
-func FindUnarchivedMicroserviceDefs(db *bolt.DB, url string) ([]MicroserviceDefinition, error) {
-	return FindMicroserviceDefs(db, []MSFilter{UnarchivedMSFilter(), UrlMSFilter(url)})
+// find the unarchived microservice definitions for the given url and org
+func FindUnarchivedMicroserviceDefs(db *bolt.DB, url string, org string) ([]MicroserviceDefinition, error) {
+	return FindMicroserviceDefs(db, []MSFilter{UnarchivedMSFilter(), UrlOrgMSFilter(url, org)})
 }
 
 // find the microservice definition from the db
@@ -370,6 +370,13 @@ func UrlVersionMSFilter(spec_url string, version string) MSFilter {
 func UrlOrgVersionMSFilter(spec_url string, org string, version string) MSFilter {
 	return func(e MicroserviceDefinition) bool {
 		return (e.SpecRef == spec_url && e.Org == org && e.Version == version)
+	}
+}
+
+// filter on the url + + org
+func UrlOrgMSFilter(spec_url string, org string) MSFilter {
+	return func(e MicroserviceDefinition) bool {
+		return (e.SpecRef == spec_url && e.Org == org)
 	}
 }
 
@@ -580,6 +587,7 @@ func persistUpdatedMicroserviceDef(db *bolt.DB, key string, update *Microservice
 
 type MicroserviceInstance struct {
 	SpecRef              string                         `json:"ref_url"`
+	Org                  string                         `json:"organization"`
 	Version              string                         `json:"version"`
 	Arch                 string                         `json:"arch"`
 	InstanceId           string                         `json:"instance_id"`
@@ -601,6 +609,7 @@ type MicroserviceInstance struct {
 
 func (w MicroserviceInstance) String() string {
 	return fmt.Sprintf("SpecRef: %v, "+
+		"Org: %v, "+
 		"Version: %v, "+
 		"Arch: %v, "+
 		"InstanceId: %v, "+
@@ -618,17 +627,17 @@ func (w MicroserviceInstance) String() string {
 		"MaxRetryDuration: %v, "+
 		"CurrentRetryCount: %v, "+
 		"RetryStartTime: %v",
-		w.SpecRef, w.Version, w.Arch, w.InstanceId, w.Archived, w.InstanceCreationTime,
+		w.SpecRef, w.Org, w.Version, w.Arch, w.InstanceId, w.Archived, w.InstanceCreationTime,
 		w.ExecutionStartTime, w.ExecutionFailureCode, w.ExecutionFailureDesc,
 		w.CleanupStartTime, w.AssociatedAgreements, w.MicroserviceDefId, w.ParentPath, w.AgreementLess,
 		w.MaxRetries, w.MaxRetryDuration, w.CurrentRetryCount, w.RetryStartTime)
 }
 
 // create a unique name for a microservice def
-// If SpecRef is https://bluehorizon.network/microservices/network, version is 2.3.1 and the instance id is "abcd1234"
-// the output string will be "bluehorizon.network-microservices-network_2.3.1_abcd1234"
+// If SpecRef is https://bluehorizon.network/microservices/network, Org is myorg, version is 2.3.1 and the instance id is "abcd1234"
+// the output string will be "myorg_bluehorizon.network-microservices-network_2.3.1_abcd1234"
 func (m MicroserviceInstance) GetKey() string {
-	return cutil.MakeMSInstanceKey(m.SpecRef, m.Version, m.InstanceId)
+	return cutil.MakeMSInstanceKey(m.SpecRef, m.Org, m.Version, m.InstanceId)
 }
 
 // Check if this microservice instance has a container dpeloyment.
@@ -647,7 +656,7 @@ func (m MicroserviceInstance) HasWorkload(db *bolt.DB) (bool, error) {
 func (m *MicroserviceInstance) HasDirectParent(parent *ServiceInstancePathElement) bool {
 	for _, pathList := range m.ParentPath {
 		for ix, element := range pathList {
-			if parent != nil && parent.IsSame(&element) && (len(pathList) > (ix + 1)) && (&pathList[ix+1]).IsSame(NewServiceInstancePathElement(m.SpecRef, m.Version)) {
+			if parent != nil && parent.IsSame(&element) && (len(pathList) > (ix + 1)) && (&pathList[ix+1]).IsSame(NewServiceInstancePathElement(m.SpecRef, m.Org, m.Version)) {
 				return true
 			}
 		}
@@ -681,27 +690,26 @@ func (m *MicroserviceInstance) GetDirectParents() []ServiceInstancePathElement {
 }
 
 // create a new microservice instance and save it to db.
-func NewMicroserviceInstance(db *bolt.DB, ref_url string, version string, msdef_id string, dependencyPath []ServiceInstancePathElement) (*MicroserviceInstance, error) {
+func NewMicroserviceInstance(db *bolt.DB, ref_url string, org string, version string, msdef_id string, dependencyPath []ServiceInstancePathElement) (*MicroserviceInstance, error) {
 
-	if ref_url == "" || version == "" {
-		return nil, errors.New("Microservice ref url id or version is empty, cannot persist")
+	if ref_url == "" || org == "" || version == "" {
+		return nil, errors.New("Microservice ref url id, org or version is empty, cannot persist")
 	}
 
-	var instance_id string
-	if id, err := uuid.NewV4(); err != nil {
-		return nil, errors.New(fmt.Sprintf("Unable to generate UUID for service %v instance id %v, error: %v", ref_url, msdef_id, err))
-	} else {
-		instance_id = id.String()
+	instance_id, err := createInstanceId()
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Error creating an instance id for the service instance %v/%v version %v", org, ref_url, version))
 	}
 
-	if ms_instance, err := FindMicroserviceInstance(db, ref_url, version, instance_id); err != nil {
+	if ms_instance, err := FindMicroserviceInstance(db, ref_url, org, version, instance_id); err != nil {
 		return nil, err
 	} else if ms_instance != nil {
-		return nil, fmt.Errorf("Not expecting any records with SpecRef %v, version %v and instance id %v, found %v", ref_url, version, instance_id, ms_instance)
+		return nil, fmt.Errorf("Not expecting any records with Org %v, SpecRef %v, version %v and instance id %v, found %v", org, ref_url, version, instance_id, ms_instance)
 	}
 
 	new_inst := &MicroserviceInstance{
 		SpecRef:              ref_url,
+		Org:                  org,
 		Version:              version,
 		Arch:                 cutil.ArchString(),
 		InstanceId:           instance_id,
@@ -720,24 +728,15 @@ func NewMicroserviceInstance(db *bolt.DB, ref_url string, version string, msdef_
 		RetryStartTime:       0,
 	}
 
-	return new_inst, db.Update(func(tx *bolt.Tx) error {
-		if b, err := tx.CreateBucketIfNotExists([]byte(MICROSERVICE_INSTANCES)); err != nil {
-			return err
-		} else if bytes, err := json.Marshal(new_inst); err != nil {
-			return fmt.Errorf("Unable to marshal new record: %v", err)
-		} else if err := b.Put([]byte(new_inst.GetKey()), []byte(bytes)); err != nil {
-			return fmt.Errorf("Unable to persist service instance: %v", err)
-		}
-		// success, close tx
-		return nil
-	})
+	return saveMicroserviceInstance(db, new_inst)
 }
 
 // Create an microservice instance object out of an agreement. The object is not be saved into the db.
 func AgreementToMicroserviceInstance(ag EstablishedAgreement, msdef_id string) *MicroserviceInstance {
-	sipe := NewServiceInstancePathElement(ag.RunningWorkload.URL, ag.RunningWorkload.Version)
+	sipe := NewServiceInstancePathElement(ag.RunningWorkload.URL, ag.RunningWorkload.Org, ag.RunningWorkload.Version)
 	return &MicroserviceInstance{
 		SpecRef:              ag.RunningWorkload.URL,
+		Org:                  ag.RunningWorkload.Org,
 		Version:              ag.RunningWorkload.Version,
 		Arch:                 ag.RunningWorkload.Arch,
 		InstanceId:           ag.CurrentAgreementId,
@@ -754,7 +753,7 @@ func AgreementToMicroserviceInstance(ag EstablishedAgreement, msdef_id string) *
 }
 
 // find the microservice instance from the db
-func FindMicroserviceInstance(db *bolt.DB, url string, version string, instance_id string) (*MicroserviceInstance, error) {
+func FindMicroserviceInstance(db *bolt.DB, url string, org string, version string, instance_id string) (*MicroserviceInstance, error) {
 	var pms *MicroserviceInstance
 	pms = nil
 
@@ -769,7 +768,10 @@ func FindMicroserviceInstance(db *bolt.DB, url string, version string, instance_
 				if err := json.Unmarshal(v, &ms); err != nil {
 					glog.Errorf("Unable to deserialize service_instance db record: %v", v)
 				} else if ms.SpecRef == url && ms.Version == version && ms.InstanceId == instance_id {
-					pms = &ms
+					// ms.Org == "" is for ms instances created by older versions
+					if ms.Org == "" || ms.Org == org {
+						pms = &ms
+					}
 					return nil
 				}
 				return nil
@@ -826,14 +828,16 @@ func AllMIFilter() MIFilter {
 	return func(e MicroserviceInstance) bool { return true }
 }
 
-// filter for all the microservice instances for the given url and version
-func AllInstancesMIFilter(spec_url string, version string) MIFilter {
+// filter for all the microservice instances for the given url and org and version
+func AllInstancesMIFilter(spec_url string, org string, version string) MIFilter {
 	return func(e MicroserviceInstance) bool {
 		if e.SpecRef == spec_url && e.Version == version {
-			return true
-		} else {
-			return false
+			// e.Org == "" is for ms instances created by older versions
+			if e.Org == "" || e.Org == org {
+				return true
+			}
 		}
+		return false
 	}
 }
 
@@ -1173,18 +1177,44 @@ func DeleteMicroserviceInstance(db *bolt.DB, key string) (*MicroserviceInstance,
 
 type ServiceInstancePathElement struct {
 	URL     string `json:"url"`
+	Org     string `json:"org"`
 	Version string `json:"version"`
 }
 
-func NewServiceInstancePathElement(url string, version string) *ServiceInstancePathElement {
+func NewServiceInstancePathElement(url string, org string, version string) *ServiceInstancePathElement {
 	return &ServiceInstancePathElement{
 		URL:     url,
+		Org:     org,
 		Version: version,
 	}
 }
 
 func (s *ServiceInstancePathElement) IsSame(other *ServiceInstancePathElement) bool {
-	return (s.URL == other.URL) && (s.Version == other.Version)
+	return (s.URL == other.URL) && (s.Org == other.Org) && (s.Version == other.Version)
+}
+
+// create an instance
+func createInstanceId() (string, error) {
+	if id, err := uuid.NewV4(); err != nil {
+		return "", errors.New(fmt.Sprintf("Unable to generate UUID, error: %v", err))
+	} else {
+		return id.String(), nil
+	}
+}
+
+// save the given microservice instance into the db
+func saveMicroserviceInstance(db *bolt.DB, new_inst *MicroserviceInstance) (*MicroserviceInstance, error) {
+	return new_inst, db.Update(func(tx *bolt.Tx) error {
+		if b, err := tx.CreateBucketIfNotExists([]byte(MICROSERVICE_INSTANCES)); err != nil {
+			return err
+		} else if bytes, err := json.Marshal(new_inst); err != nil {
+			return fmt.Errorf("Unable to marshal new record: %v", err)
+		} else if err := b.Put([]byte(new_inst.GetKey()), []byte(bytes)); err != nil {
+			return fmt.Errorf("Unable to persist service instance: %v", err)
+		}
+		// success, close tx
+		return nil
+	})
 }
 
 func CompareServiceInstancePath(a, b []ServiceInstancePathElement) bool {

--- a/persistence/microservices.go
+++ b/persistence/microservices.go
@@ -361,11 +361,6 @@ func ArchivedMSFilter() MSFilter {
 	return func(e MicroserviceDefinition) bool { return e.Archived }
 }
 
-// filter on the url + version
-func UrlVersionMSFilter(spec_url string, version string) MSFilter {
-	return func(e MicroserviceDefinition) bool { return (e.SpecRef == spec_url && e.Version == version) }
-}
-
 // filter on the url + version + org
 func UrlOrgVersionMSFilter(spec_url string, org string, version string) MSFilter {
 	return func(e MicroserviceDefinition) bool {

--- a/persistence/microservices_test.go
+++ b/persistence/microservices_test.go
@@ -25,16 +25,18 @@ func Test_ServiceInstancePath_HasDirectParent_simple(t *testing.T) {
 	// Setup initial variable values
 	parentURL := "url1"
 	parentVersion := "1.0.0"
+	parentOrg := "myorg"
 	childURL := "url2"
+	childOrg := "childorg"
 	childVersion := "2.0.0"
 
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement(parentURL, parentVersion)
-	child := NewServiceInstancePathElement(childURL, childVersion)
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
 
 	depPath := []ServiceInstancePathElement{*parent, *child}
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, childURL, childVersion, "1234", depPath); err != nil {
+	if msi, err := NewMicroserviceInstance(db, childURL, childOrg, childVersion, "1234", depPath); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if !msi.HasDirectParent(parent) {
 		t.Errorf("Child %v has direct parent: %v", child, depPath)
@@ -54,19 +56,21 @@ func Test_ServiceInstancePath_HasDirectParent_fail1(t *testing.T) {
 
 	// Setup initial variable values
 	parentURL := "url1"
+	parentOrg := "myorg"
 	parentVersion := "1.0.0"
 	childURL := "url2"
+	childOrg := "childorg"
 	childVersion := "2.0.0"
 
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement(parentURL, parentVersion)
-	child := NewServiceInstancePathElement(childURL, childVersion)
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
 
-	notParent := NewServiceInstancePathElement("other", parentVersion)
+	notParent := NewServiceInstancePathElement("other", parentOrg, parentVersion)
 
 	depPath := []ServiceInstancePathElement{*parent, *child}
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, childURL, childVersion, "1234", depPath); err != nil {
+	if msi, err := NewMicroserviceInstance(db, childURL, childOrg, childVersion, "1234", depPath); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if msi.HasDirectParent(notParent) {
 		t.Errorf("Child %v does not have direct parent: %v", child, depPath)
@@ -86,20 +90,23 @@ func Test_ServiceInstancePath_HasDirectParent_fail2(t *testing.T) {
 
 	// Setup initial variable values
 	parentURL := "url1"
+	parentOrg := "myorg"
 	parentVersion := "1.0.0"
 	childURL := "url2"
+	childOrg := "childorg"
 	childVersion := "2.0.0"
 	child2URL := "url3"
+	child2Org := "child2org"
 	child2Version := "3.0.0"
 
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement(parentURL, parentVersion)
-	child := NewServiceInstancePathElement(childURL, childVersion)
-	child2 := NewServiceInstancePathElement(child2URL, child2Version)
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Org, child2Version)
 
 	depPath := []ServiceInstancePathElement{*parent, *child, *child2}
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, child2URL, child2Version, "1234", depPath); err != nil {
+	if msi, err := NewMicroserviceInstance(db, child2URL, child2Org, child2Version, "1234", depPath); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if msi.HasDirectParent(parent) {
 		t.Errorf("Child %v does not have direct parent: %v", child2, depPath)
@@ -119,24 +126,27 @@ func Test_ServiceInstancePath_HasDirectParent_fail3(t *testing.T) {
 
 	// Setup initial variable values
 	parentURL := "url1"
+	parentOrg := "myorg"
 	parentVersion := "1.0.0"
 	childURL := "url2"
+	childOrg := "childorg2"
 	childVersion := "2.0.0"
 	child2URL := "url3"
+	child2Org := "child2Org"
 	child2Version := "3.0.0"
 
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement(parentURL, parentVersion)
-	child := NewServiceInstancePathElement(childURL, childVersion)
-	child2 := NewServiceInstancePathElement(child2URL, child2Version)
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Org, child2Version)
 
-	notParent := NewServiceInstancePathElement("other", parentVersion)
+	notParent := NewServiceInstancePathElement("other", parentOrg, parentVersion)
 
 	depPath := []ServiceInstancePathElement{*parent, *child, *child2}
 	dp2 := []ServiceInstancePathElement{*parent, *child2}
 
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, child2URL, child2Version, "1234", depPath); err != nil {
+	if msi, err := NewMicroserviceInstance(db, child2URL, child2Org, child2Version, "1234", depPath); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if _, err := UpdateMSInstanceAddDependencyPath(db, msi.GetKey(), &dp2); err != nil {
 		t.Errorf("Error updating instance: %v", err)
@@ -158,22 +168,25 @@ func Test_ServiceInstancePath_HasDirectParent_second(t *testing.T) {
 
 	// Setup initial variable values
 	parentURL := "url1"
+	parentOrg := "myorg"
 	parentVersion := "1.0.0"
 	childURL := "url2"
+	childOrg := "childorg"
 	childVersion := "2.0.0"
 	child2URL := "url3"
+	child2Org := "childorg3"
 	child2Version := "3.0.0"
 
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement(parentURL, parentVersion)
-	child := NewServiceInstancePathElement(childURL, childVersion)
-	child2 := NewServiceInstancePathElement(child2URL, child2Version)
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Org, child2Version)
 
 	depPath := []ServiceInstancePathElement{*parent, *child, *child2}
 	dp2 := []ServiceInstancePathElement{*parent, *child2}
 
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, child2URL, child2Version, "1234", depPath); err != nil {
+	if msi, err := NewMicroserviceInstance(db, child2URL, child2Org, child2Version, "1234", depPath); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if newmsi, err := UpdateMSInstanceAddDependencyPath(db, msi.GetKey(), &dp2); err != nil {
 		t.Errorf("Error updating instance: %v", err)
@@ -184,9 +197,19 @@ func Test_ServiceInstancePath_HasDirectParent_second(t *testing.T) {
 
 func Test_CompareServiceInstancePath(t *testing.T) {
 	// Establish the dependency path objects
-	parent := NewServiceInstancePathElement("parentUrl", "1.0.0")
-	child := NewServiceInstancePathElement("childURL", "2.0.0")
-	child2 := NewServiceInstancePathElement("child2URL", "3.0.0")
+	parentURL := "url1"
+	parentOrg := "myorg"
+	parentVersion := "1.0.0"
+	childURL := "url2"
+	childOrg := "childorg"
+	childVersion := "2.0.0"
+	child2URL := "url3"
+	child2Org := "childorg3"
+	child2Version := "3.0.0"
+
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Org, child2Version)
 
 	dep1 := []ServiceInstancePathElement{*parent, *child, *child2}
 	dep2 := []ServiceInstancePathElement{*parent, *child}
@@ -226,15 +249,25 @@ func Test_UpdateMSInstanceAddDependencyPath(t *testing.T) {
 
 	defer cleanTestDir(dir)
 
-	parent := NewServiceInstancePathElement("parentUrl", "1.0.0")
-	child := NewServiceInstancePathElement("childURL", "2.0.0")
-	child2 := NewServiceInstancePathElement("child2URL", "3.0.0")
+	parentURL := "parentUrl"
+	parentOrg := "myorg1"
+	parentVersion := "1.0.0"
+	childURL := "childURL"
+	childOrg := "childorg"
+	childVersion := "2.0.0"
+	child2URL := "child2URL"
+	child2Org := "childorg2"
+	child2Version := "3.0.0"
+
+	parent := NewServiceInstancePathElement(parentURL, parentOrg, parentVersion)
+	child := NewServiceInstancePathElement(childURL, childOrg, childVersion)
+	child2 := NewServiceInstancePathElement(child2URL, child2Org, child2Version)
 
 	dep1 := []ServiceInstancePathElement{*parent, *child, *child2}
 	dep2 := []ServiceInstancePathElement{*parent, *child}
 
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, "child2URL", "2.0.0", "1234", dep1); err != nil {
+	if msi, err := NewMicroserviceInstance(db, "child2UR", "childorg2", "2.0.0", "1234", dep1); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if newmsi, err := UpdateMSInstanceAddDependencyPath(db, msi.GetKey(), &dep2); err != nil {
 		t.Errorf("Error updating instance: %v", err)
@@ -261,11 +294,11 @@ func Test_UpdateMSInstanceRemoveDependencyPath(t *testing.T) {
 
 	defer cleanTestDir(dir)
 
-	parent1 := NewServiceInstancePathElement("parentUrl", "1.0.0")
-	parent2 := NewServiceInstancePathElement("parentUrl2", "1.0.0")
-	parent3 := NewServiceInstancePathElement("parentUrl", "2.0.0")
-	child := NewServiceInstancePathElement("childURL", "2.0.0")
-	child2 := NewServiceInstancePathElement("child2URL", "3.0.0")
+	parent1 := NewServiceInstancePathElement("parentUrl", "parentOrg", "1.0.0")
+	parent2 := NewServiceInstancePathElement("parentUrl2", "parentOrg2", "1.0.0")
+	parent3 := NewServiceInstancePathElement("parentUrl", "parentOrg", "2.0.0")
+	child := NewServiceInstancePathElement("childURL", "childorg", "2.0.0")
+	child2 := NewServiceInstancePathElement("child2URL", "childorg2", "3.0.0")
 
 	dep1 := []ServiceInstancePathElement{*parent1, *child, *child2}
 	dep2 := []ServiceInstancePathElement{*parent1, *child}
@@ -273,7 +306,7 @@ func Test_UpdateMSInstanceRemoveDependencyPath(t *testing.T) {
 	dep4 := []ServiceInstancePathElement{*parent3, *child, *child2}
 
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, "child2URL", "2.0.0", "1234", dep1); err != nil {
+	if msi, err := NewMicroserviceInstance(db, "child2UR", "childorg2", "2.0.0", "1234", dep1); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if _, err := UpdateMSInstanceAddDependencyPath(db, msi.GetKey(), &dep2); err != nil {
 		t.Errorf("Error updating instance: %v", err)
@@ -305,11 +338,11 @@ func Test_UpdateMSInstanceRemoveDependencyPath2(t *testing.T) {
 
 	defer cleanTestDir(dir)
 
-	parent1 := NewServiceInstancePathElement("parentUrl", "1.0.0")
-	parent2 := NewServiceInstancePathElement("parentUrl2", "1.0.0")
-	parent3 := NewServiceInstancePathElement("parentUrl", "2.0.0")
-	child := NewServiceInstancePathElement("childURL", "2.0.0")
-	child2 := NewServiceInstancePathElement("child2URL", "3.0.0")
+	parent1 := NewServiceInstancePathElement("parentUrl", "parentOrg", "1.0.0")
+	parent2 := NewServiceInstancePathElement("parentUrl2", "parentOrg2", "1.0.0")
+	parent3 := NewServiceInstancePathElement("parentUrl", "parentOrg", "2.0.0")
+	child := NewServiceInstancePathElement("childURL", "childorg", "2.0.0")
+	child2 := NewServiceInstancePathElement("child2URL", "childorg2", "3.0.0")
 
 	dep1 := []ServiceInstancePathElement{*parent1, *child, *child2}
 	dep2 := []ServiceInstancePathElement{*parent1, *child}
@@ -317,7 +350,7 @@ func Test_UpdateMSInstanceRemoveDependencyPath2(t *testing.T) {
 	dep4 := []ServiceInstancePathElement{*parent3, *child, *child2}
 
 	// Create the test microservice instance to represent the child
-	if msi, err := NewMicroserviceInstance(db, "child2URL", "2.0.0", "1234", dep1); err != nil {
+	if msi, err := NewMicroserviceInstance(db, "child2UR", "childorg2", "2.0.0", "1234", dep1); err != nil {
 		t.Errorf("Error creating instance: %v", err)
 	} else if _, err := UpdateMSInstanceAddDependencyPath(db, msi.GetKey(), &dep2); err != nil {
 		t.Errorf("Error updating instance: %v", err)

--- a/persistence/persistence_test.go
+++ b/persistence/persistence_test.go
@@ -1,0 +1,210 @@
+// +build unit
+
+package persistence
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/boltdb/bolt"
+	"testing"
+	"time"
+)
+
+type EstablishedAgreement_Old struct {
+	Name                         string   `json:"name"`
+	SensorUrl                    []string `json:"sensor_url"`
+	Archived                     bool     `json:"archived"`
+	CurrentAgreementId           string   `json:"current_agreement_id"`
+	ConsumerId                   string   `json:"consumer_id"`
+	CounterPartyAddress          string   `json:"counterparty_address"`
+	AgreementCreationTime        uint64   `json:"agreement_creation_time"`
+	AgreementAcceptedTime        uint64   `json:"agreement_accepted_time"`
+	AgreementBCUpdateAckTime     uint64   `json:"agreement_bc_update_ack_time"` // V2 protocol - time when consumer acks our blockchain update
+	AgreementFinalizedTime       uint64   `json:"agreement_finalized_time"`
+	AgreementTerminatedTime      uint64   `json:"agreement_terminated_time"`
+	AgreementForceTerminatedTime uint64   `json:"agreement_force_terminated_time"`
+	AgreementExecutionStartTime  uint64   `json:"agreement_execution_start_time"`
+	AgreementDataReceivedTime    uint64   `json:"agreement_data_received_time"`
+	// One of the following 2 fields are set when the worker that owns deployment for this agreement, starts deploying the services in the agreement.
+	CurrentDeployment               map[string]ServiceConfig `json:"current_deployment"`  // Native Horizon deployment config goes here, mutually exclusive with the extended deployment field. This field is set before the torrent worker starts the workload.
+	ExtendedDeployment              map[string]interface{}   `json:"extended_deployment"` // All non-native deployment configs go here. This field is set before the helm worker installs the release.
+	Proposal                        string                   `json:"proposal"`
+	ProposalSig                     string                   `json:"proposal_sig"`           // the proposal currently in effect
+	AgreementProtocol               string                   `json:"agreement_protocol"`     // the agreement protocol being used. It is also in the proposal.
+	ProtocolVersion                 int                      `json:"protocol_version"`       // the agreement protocol version being used.
+	TerminatedReason                uint64                   `json:"terminated_reason"`      // the reason that the agreement was terminated
+	TerminatedDescription           string                   `json:"terminated_description"` // a string form of the reason that the agreement was terminated
+	AgreementProtocolTerminatedTime uint64                   `json:"agreement_protocol_terminated_time"`
+	WorkloadTerminatedTime          uint64                   `json:"workload_terminated_time"`
+	MeteringNotificationMsg         MeteringNotification     `json:"metering_notification,omitempty"` // the most recent metering notification received
+	BlockchainType                  string                   `json:"blockchain_type,omitempty"`       // the name of the type of the blockchain
+	BlockchainName                  string                   `json:"blockchain_name,omitempty"`       // the name of the blockchain instance
+	BlockchainOrg                   string                   `json:"blockchain_org,omitempty"`        // the org of the blockchain instance
+	RunningWorkload                 WorkloadInfo             `json:"workload_to_run,omitempty"`       // For display purposes, a copy of the workload info that this agreement is managing. It should be the same info that is buried inside the proposal.
+}
+
+func (c EstablishedAgreement_Old) String() string {
+
+	return fmt.Sprintf("Name: %v, "+
+		"SensorUrl: %v, "+
+		"Archived: %v, "+
+		"CurrentAgreementId: %v, "+
+		"ConsumerId: %v, "+
+		"CounterPartyAddress: %v, "+
+		"CurrentDeployment (service names): %v, "+
+		"ExtendedDeployment: %v, "+
+		"Proposal Signature: %v, "+
+		"AgreementCreationTime: %v, "+
+		"AgreementExecutionStartTime: %v, "+
+		"AgreementAcceptedTime: %v, "+
+		"AgreementBCUpdateAckTime: %v, "+
+		"AgreementFinalizedTime: %v, "+
+		"AgreementDataReceivedTime: %v, "+
+		"AgreementTerminatedTime: %v, "+
+		"AgreementForceTerminatedTime: %v, "+
+		"TerminatedReason: %v, "+
+		"TerminatedDescription: %v, "+
+		"Agreement Protocol: %v, "+
+		"Agreement ProtocolVersion: %v, "+
+		"AgreementProtocolTerminatedTime : %v, "+
+		"WorkloadTerminatedTime: %v, "+
+		"MeteringNotificationMsg: %v, "+
+		"BlockchainType: %v, "+
+		"BlockchainName: %v, "+
+		"BlockchainOrg: %v",
+		c.Name, c.SensorUrl, c.Archived, c.CurrentAgreementId, c.ConsumerId, c.CounterPartyAddress, ServiceConfigNames(&c.CurrentDeployment),
+		c.ExtendedDeployment, c.ProposalSig,
+		c.AgreementCreationTime, c.AgreementExecutionStartTime, c.AgreementAcceptedTime, c.AgreementBCUpdateAckTime, c.AgreementFinalizedTime,
+		c.AgreementDataReceivedTime, c.AgreementTerminatedTime, c.AgreementForceTerminatedTime, c.TerminatedReason, c.TerminatedDescription,
+		c.AgreementProtocol, c.ProtocolVersion, c.AgreementProtocolTerminatedTime, c.WorkloadTerminatedTime,
+		c.MeteringNotificationMsg, c.BlockchainType, c.BlockchainName, c.BlockchainOrg)
+
+}
+
+func NewEstablishedAgreement_Old(db *bolt.DB, name string, agreementId string, consumerId string, proposal string, protocol string, protocolVersion int, sensorUrl []string, signature string, address string, bcType string, bcName string, bcOrg string, wi *WorkloadInfo) (*EstablishedAgreement_Old, error) {
+
+	if name == "" || agreementId == "" || consumerId == "" || proposal == "" || protocol == "" || protocolVersion == 0 {
+		return nil, errors.New("Agreement id, consumer id, proposal, protocol, or protocol version are empty, cannot persist")
+	}
+
+	newAg := &EstablishedAgreement_Old{
+		Name:                            name,
+		SensorUrl:                       sensorUrl,
+		Archived:                        false,
+		CurrentAgreementId:              agreementId,
+		ConsumerId:                      consumerId,
+		CounterPartyAddress:             address,
+		AgreementCreationTime:           uint64(time.Now().Unix()),
+		AgreementAcceptedTime:           0,
+		AgreementBCUpdateAckTime:        0,
+		AgreementFinalizedTime:          0,
+		AgreementTerminatedTime:         0,
+		AgreementForceTerminatedTime:    0,
+		AgreementExecutionStartTime:     0,
+		AgreementDataReceivedTime:       0,
+		CurrentDeployment:               map[string]ServiceConfig{},
+		ExtendedDeployment:              map[string]interface{}{},
+		Proposal:                        proposal,
+		ProposalSig:                     signature,
+		AgreementProtocol:               protocol,
+		ProtocolVersion:                 protocolVersion,
+		TerminatedReason:                0,
+		TerminatedDescription:           "",
+		AgreementProtocolTerminatedTime: 0,
+		WorkloadTerminatedTime:          0,
+		MeteringNotificationMsg:         MeteringNotification{},
+		BlockchainType:                  bcType,
+		BlockchainName:                  bcName,
+		BlockchainOrg:                   bcOrg,
+		RunningWorkload:                 *wi,
+	}
+
+	return newAg, db.Update(func(tx *bolt.Tx) error {
+
+		if b, err := tx.CreateBucketIfNotExists([]byte(E_AGREEMENTS + "-" + protocol)); err != nil {
+			return err
+		} else if bytes, err := json.Marshal(newAg); err != nil {
+			return fmt.Errorf("Unable to marshal new record: %v", err)
+		} else if err := b.Put([]byte(agreementId), []byte(bytes)); err != nil {
+			return fmt.Errorf("Unable to persist agreement: %v", err)
+		}
+
+		// success, close tx
+		return nil
+	})
+}
+
+func Test_Backward_Compitibility_EstablishedAgreement(t *testing.T) {
+	dir, testDb, err := utsetup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	// save an agreement with old structure
+	wi_old1, _ := NewWorkloadInfo("myurl_old1", "myorg_old1", "myversion_old1", "")
+	_, err = NewEstablishedAgreement_Old(testDb, "Old agreement structure 1", "123451", "agbot1", "proposal", "Basic", 1, []string{"url1", "url2"}, "signature", "address", "bcType", "bcName", "bcOrg", wi_old1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// save an agreement with old structure with empty sensor url
+	wi_old2, _ := NewWorkloadInfo("myurl_old2", "myorg_old2", "myversion_old2", "")
+	_, err = NewEstablishedAgreement_Old(testDb, "Old agreement structure 2", "123452", "agbot1", "proposal", "Basic", 1, []string{}, "signature", "address", "bcType", "bcName", "bcOrg", wi_old2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// save an agreement with new structure
+	wi_new1, _ := NewWorkloadInfo("myurl_new1", "myorg_new1", "myversion_new1", "")
+	sp3 := ServiceSpec{Url: "url3", Org: "myorg3"}
+	sp4 := ServiceSpec{Url: "url4", Org: "myorg4"}
+	_, err = NewEstablishedAgreement(testDb, "New agreement structure 1", "543211", "agbot2", "proposal2", "Basic2", 1, []ServiceSpec{sp3, sp4}, "signature2", "address2", "bcType2", "bcName2", "bcOrg2", wi_new1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// save an agreement with new structure with empty DependentServices
+	wi_new2, _ := NewWorkloadInfo("myurl_new2", "myorg_new2", "myversion_new2", "")
+	_, err = NewEstablishedAgreement(testDb, "New agreement structure 2", "543212", "agbot2", "proposal2", "Basic2", 1, []ServiceSpec{}, "signature2", "address2", "bcType2", "bcName2", "bcOrg2", wi_new2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// now retrive them
+	ags, err := FindEstablishedAgreementsAllProtocols(testDb, []string{"Basic", "Basic2"}, []EAFilter{})
+	if err != nil {
+		t.Error(err)
+	} else if len(ags) != 4 {
+		t.Errorf("Should get 3 agreements, but got %v", len(ags))
+	} else {
+		for _, ag := range ags {
+			if ag.Name == "Old agreement structure 1" {
+				if ag.CurrentAgreementId != "123451" || ag.DependentServices == nil || len(ag.DependentServices) != 2 ||
+					ag.DependentServices[0].Url != "url1" || ag.DependentServices[0].Org != "" ||
+					ag.DependentServices[1].Url != "url2" || ag.DependentServices[1].Org != "" ||
+					ag.RunningWorkload.URL != wi_old1.URL || ag.RunningWorkload.Org != wi_old1.Org {
+					t.Errorf("Retrieving old agreement1 from db failed. %v", ag)
+				}
+			} else if ag.Name == "Old agreement structure 2" {
+				if ag.CurrentAgreementId != "123452" || ag.DependentServices == nil || len(ag.DependentServices) != 0 ||
+					ag.RunningWorkload.URL != wi_old2.URL || ag.RunningWorkload.Org != wi_old2.Org {
+					t.Errorf("Retrieving old agreement2 from db failed. %v", ag)
+				}
+			} else if ag.Name == "New agreement structure 1" {
+				if ag.CurrentAgreementId != "543211" || ag.DependentServices == nil || len(ag.DependentServices) != 2 ||
+					ag.DependentServices[0].Url != sp3.Url || ag.DependentServices[0].Org != sp3.Org ||
+					ag.DependentServices[1].Url != sp4.Url || ag.DependentServices[1].Org != sp4.Org ||
+					ag.RunningWorkload.URL != wi_new1.URL || ag.RunningWorkload.Org != wi_new1.Org {
+					t.Errorf("Retrieving new agreement3 from db failed. %v", ag)
+				}
+			} else {
+				if ag.CurrentAgreementId != "543212" || ag.DependentServices == nil || len(ag.DependentServices) != 0 ||
+					ag.RunningWorkload.URL != wi_new2.URL || ag.RunningWorkload.Org != wi_new2.Org {
+					t.Errorf("Retrieving new agreement4 from db failed. %v", ag)
+				}
+			}
+		}
+	}
+}

--- a/policy/api_spec_list.go
+++ b/policy/api_spec_list.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"errors"
 	"fmt"
+	"github.com/open-horizon/anax/cutil"
 )
 
 // The purpose of this file is to provide APIs for working with the API spec list in a Policy.
@@ -70,7 +71,7 @@ func (self *APISpecList) Concatenate(new_list *APISpecList) {
 // This function adds an API spec to the list. Return an error if there are duplicates.
 func (self *APISpecList) Add_API_Spec(new_ele *APISpecification) error {
 	for _, ele := range *self {
-		if ele.SpecRef == new_ele.SpecRef {
+		if ele.SpecRef == new_ele.SpecRef && ele.Org == new_ele.Org {
 			return errors.New(fmt.Sprintf("APISpecList %v already has the element being added: %v", *self, *new_ele))
 		}
 	}
@@ -164,7 +165,7 @@ func (self *APISpecList) MergeWith(other *APISpecList) APISpecList {
 func (self *APISpecList) AsStringArray() []string {
 	res := make([]string, 0, 10)
 	for _, apiSpec := range *self {
-		res = append(res, apiSpec.SpecRef)
+		res = append(res, cutil.FormOrgSpecUrl(apiSpec.SpecRef, apiSpec.Org))
 	}
 	return res
 }
@@ -187,9 +188,9 @@ func (self *APISpecList) GetCommonVersionRanges() (*APISpecList, error) {
 
 				// get the intersection of the two version ranges
 				if v, err := Version_Expression_Factory(apiSpec.Version); err != nil {
-					return nil, fmt.Errorf("Error creating version range for %v, %v", apiSpec.SpecRef, apiSpec.Version)
+					return nil, fmt.Errorf("Error creating version range for %v/%v, %v", apiSpec.Org, apiSpec.SpecRef, apiSpec.Version)
 				} else if v_new, err := Version_Expression_Factory(newApiSpec.Version); err != nil {
-					return nil, fmt.Errorf("Error creating version range for %v, %v", newApiSpec.SpecRef, newApiSpec.Version)
+					return nil, fmt.Errorf("Error creating version range for %v/%v, %v", newApiSpec.Org, newApiSpec.SpecRef, newApiSpec.Version)
 				} else if err := v.IntersectsWith(v_new); err != nil {
 					// no intersection found, remove the microservice from the list.
 					(*new_list)[i].Version = NO_INTERSECTION

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"fmt"
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/events"
 	"strings"
@@ -15,11 +16,11 @@ import (
 
 func GeneratePolicy(sensorUrl string, sensorOrg string, sensorName string, sensorVersion string, arch string, props *map[string]interface{}, haPartners []string, meterPolicy Meter, counterPartyProperties RequiredProperty, agps []AgreementProtocol, maxAgreements int, filePath string, deviceOrg string) (*events.PolicyCreatedMessage, error) {
 
-	glog.V(5).Infof("Generating policy for %v", sensorUrl)
+	glog.V(5).Infof("Generating policy for %v/%v", sensorOrg, sensorUrl)
 
 	// Generate a policy file name
 	a_tmp := strings.Split(sensorUrl, "/")
-	fileName := a_tmp[len(a_tmp)-1]
+	fileName := fmt.Sprintf("%v_%v", sensorOrg, a_tmp[len(a_tmp)-1])
 
 	p := Policy_Factory("Policy for " + fileName)
 	p.Add_API_Spec(APISpecification_Factory(sensorUrl, sensorOrg, sensorVersion, arch))

--- a/policy/policy_manager.go
+++ b/policy/policy_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/config"
+	"github.com/open-horizon/anax/cutil"
 	"reflect"
 	"sync"
 )
@@ -123,7 +124,7 @@ func (self *PolicyManager) addPolicy(org string, newPolicy *Policy) error {
 
 		keyName := newPolicy.Header.Name
 		if self.APISpecCounts {
-			keyName = newPolicy.APISpecs[0].SpecRef
+			keyName = cutil.FormOrgSpecUrl(newPolicy.APISpecs[0].SpecRef, newPolicy.APISpecs[0].Org)
 		}
 
 		self.AgreementCounts[org][keyName] = cce
@@ -330,7 +331,7 @@ func (self *PolicyManager) AttemptingAgreement(policies []Policy, agreement stri
 		for _, pol := range policies {
 			keyName := pol.Header.Name
 			if self.APISpecCounts && len(pol.APISpecs) > 0 {
-				keyName = pol.APISpecs[0].SpecRef
+				keyName = cutil.FormOrgSpecUrl(pol.APISpecs[0].SpecRef, pol.APISpecs[0].Org)
 			}
 
 			if cce, there := orgMap[keyName]; !there {
@@ -370,7 +371,7 @@ func (self *PolicyManager) FinalAgreement(policies []Policy, agreement string, o
 
 			keyName := pol.Header.Name
 			if self.APISpecCounts && len(pol.APISpecs) > 0 {
-				keyName = pol.APISpecs[0].SpecRef
+				keyName = cutil.FormOrgSpecUrl(pol.APISpecs[0].SpecRef, pol.APISpecs[0].Org)
 			}
 
 			if cce, there := orgMap[keyName]; !there {
@@ -411,7 +412,7 @@ func (self *PolicyManager) CancelAgreement(policies []Policy, agreement string, 
 
 			keyName := pol.Header.Name
 			if self.APISpecCounts && len(pol.APISpecs) > 0 {
-				keyName = pol.APISpecs[0].SpecRef
+				keyName = cutil.FormOrgSpecUrl(pol.APISpecs[0].SpecRef, pol.APISpecs[0].Org)
 			}
 
 			if cce, there := orgMap[keyName]; !there {
@@ -449,7 +450,7 @@ func (self *PolicyManager) ReachedMaxAgreements(policies []Policy, org string) (
 
 			keyName := pol.Header.Name
 			if self.APISpecCounts {
-				keyName = pol.APISpecs[0].SpecRef
+				keyName = cutil.FormOrgSpecUrl(pol.APISpecs[0].SpecRef, pol.APISpecs[0].Org)
 			}
 
 			if cce, there := orgMap[keyName]; !there {
@@ -641,7 +642,7 @@ func (self *PolicyManager) GetAllAvailablePolicies(org string) []Policy {
 
 		keyName := pol.Header.Name
 		if self.APISpecCounts {
-			keyName = pol.APISpecs[0].SpecRef
+			keyName = cutil.FormOrgSpecUrl(pol.APISpecs[0].SpecRef, pol.APISpecs[0].Org)
 		}
 
 		if self.AgreementTracking && self.unlockedReachedMaxAgreements(pol, self.AgreementCounts[org][keyName].Count) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,7 @@ HORIZON_PKG_VER ?= $(shell curl -s $(PKGS_URL) | grep -A 2 'Package: horizon' | 
 #    MSGHUB_API_KEY
 #
 
-TEST_VARS ?= NOLOOP=1 TEST_DIFF_ORG=0 TEST_PATTERNS=sall
+TEST_VARS ?= NOLOOP=1 TEST_PATTERNS=sall
 APPSTORE = $(shell echo $(TEST_VARS) | awk -F "APPSTORE=" '{print $$2}' | cut -c1)
 
 # msghub

--- a/test/README.md
+++ b/test/README.md
@@ -52,11 +52,11 @@ Here is a full description of all the variables you can use to setup the test th
 - NOLOOP=1 - turns off the loop that cancels agreements on the device and agbot (alternating), every 10 mins. Usually you want to specify NOLOOP=1 when actively iterating code.
 - NOCANCEL=1 - when set with NOLOOP=1, skips the single round of cancellation tests for less log clutter and time when just interested in agreement formation.
 - UNCONFIG=1 - turns on the unconfig/reconfig loop tests.
-- PATTERN=name - specify the name of a configured pattern that you want the device to use. Builtin patterns are pws, spws, ns, sns, loc, sloc, gps, sgps, ns-keytest, all, sall, cpu2msghub etc. If you specify PATTERN, but turn off one of the microservices that the workload needs, the system will not work correctly. If you dont specify a PATTERN, the manually managed policy files will be used to run the workloads (unless you turn them off).
-- NONS=1 - dont register the netspeed microservice.
-- NOGPS=1 - dont register the gpstest microservice.
-- NOLOC=1 - dont register the location microservice.
-- NOPWS=1 - dont register the weather microservice. This is a good workload to run when iterating code because it is simple and reliable, it wont get in your way.
+- PATTERN=name - specify the name of a configured pattern that you want the device to use. Builtin patterns are spws, sns, sloc, sgps, sall, cpu2msghub etc. If you specify PATTERN, but turn off one of the dependent services that the top service needs, the system will not work correctly. If you dont specify a PATTERN, the manually managed policy files will be used to run the workloads (unless you turn them off).
+- NONS=1 - dont register the netspeed service.
+- NOGPS=1 - dont register the gpstest service.
+- NOLOC=1 - dont register the location service.
+- NOPWS=1 - dont register the weather service. This is a good workload to run when iterating code because it is simple and reliable, it wont get in your way.
 - NOANAX=1 - anax is started for API tests but is then stopped and is NOT restarted to run workloads.
 - NOAGBOT=1 - the agbot is never started.
 - HA=1 - register 2 devices (and the workload services) as an HA pair. You will get 2 anax device processes in the container.

--- a/test/docker/fs/etc/agbot/policy.d/e2edev/netspeed2.policy
+++ b/test/docker/fs/etc/agbot/policy.d/e2edev/netspeed2.policy
@@ -1,0 +1,63 @@
+{
+    "header": {
+        "name": "CS e2edev netspeed policy",
+        "version": "2.0"
+    },
+    "useServices": true,
+    "agreementProtocols": [
+      {
+        "name": "Basic"
+      }
+    ],
+    "workloads": [
+    {
+      "workloadUrl":"https://bluehorizon.network/services/netspeed",
+      "organization":"e2edev",
+      "version":"2.3.0",
+      "arch":"amd64",
+      "deployment_overrides":"{\"services\":{\"netspeed5\":{\"environment\":[\"E2EDEV_OVERRIDE=1\"]}}}",
+      "deployment_overrides_signature":"CoQb1Tw204vbMP0H1Faw7Sp9lHHSiIzvhlX9SEejx2kRY+x6uj7PB4fvJUBoYlWJJOkecQKDD9zdLm6hD32b+f9zMWaBdRF5Ab4pHU5gcDPpuPGnYup1ZreSe4eqPnThkGgfYIW5zcQd/vbxO9tx31EM8lJ5NrhcJ5rwhwbIPDh7Hstxi84IetNAygE1gPaTGQaJzzqATFYINwWkxjJXjihdEVuo5IvINJusHtIs7C6BIVy9+CExUXXxem1I/bzvwzY1wpKuubHxq1CddIKr+BaHAsErHIHvJQVc3JoDPgXPjVE8ew1QKjLCkC86wRbANN6rhCB2Q6+HhyaRfv8oJDz8XoLBcYw6bKerGMCxEBTuyUu0n9mTSCzEZZaaLdmxTzaLN47Svm8Gj18tT5CjvYkeSgDpISwRR0aME8YSHO6OtRKhLFGvZDzR4hu6kzyfp7aiYHRzVDrfcKhch/c0AuAEb6qEQ8nCHnSFJwEXP/3L3qKy8y8OT+42vumXTYOp7IadZ+UnFxLNJip9qnEsXFS8+WlT3PwaNMKFdg+zsJfUz5V+OXaotZKfe9PABn4+656PfngIi+N7q/unnrNSzc/BN8Dgy1FSHqVQ0UfRWST31pStJi2kS46UreIBgG9T6D/WgwnvATN3BaZkveiwDpUXRNv5nGzcWqnIerWWfL8=",
+      "priority":{
+        "priority_value": 3,
+        "retries": 1,
+        "retry_durations": 1800,
+        "verified_durations": 45
+      }
+    },
+    {
+      "workloadUrl":"https://bluehorizon.network/services/netspeed",
+      "organization":"e2edev",
+      "version":"2.3.0",
+      "arch":"amd64",
+      "deployment_overrides":"{\"services\":{\"netspeed5\":{\"environment\":[\"E2EDEV_OVERRIDE=1\"]}}}",
+      "deployment_overrides_signature":"CoQb1Tw204vbMP0H1Faw7Sp9lHHSiIzvhlX9SEejx2kRY+x6uj7PB4fvJUBoYlWJJOkecQKDD9zdLm6hD32b+f9zMWaBdRF5Ab4pHU5gcDPpuPGnYup1ZreSe4eqPnThkGgfYIW5zcQd/vbxO9tx31EM8lJ5NrhcJ5rwhwbIPDh7Hstxi84IetNAygE1gPaTGQaJzzqATFYINwWkxjJXjihdEVuo5IvINJusHtIs7C6BIVy9+CExUXXxem1I/bzvwzY1wpKuubHxq1CddIKr+BaHAsErHIHvJQVc3JoDPgXPjVE8ew1QKjLCkC86wRbANN6rhCB2Q6+HhyaRfv8oJDz8XoLBcYw6bKerGMCxEBTuyUu0n9mTSCzEZZaaLdmxTzaLN47Svm8Gj18tT5CjvYkeSgDpISwRR0aME8YSHO6OtRKhLFGvZDzR4hu6kzyfp7aiYHRzVDrfcKhch/c0AuAEb6qEQ8nCHnSFJwEXP/3L3qKy8y8OT+42vumXTYOp7IadZ+UnFxLNJip9qnEsXFS8+WlT3PwaNMKFdg+zsJfUz5V+OXaotZKfe9PABn4+656PfngIi+N7q/unnrNSzc/BN8Dgy1FSHqVQ0UfRWST31pStJi2kS46UreIBgG9T6D/WgwnvATN3BaZkveiwDpUXRNv5nGzcWqnIerWWfL8=",
+      "priority":{
+        "priority_value": 2,
+        "retries": 1,
+        "retry_durations": 3600
+      }
+    }
+    ],
+    "resourceLimits": {
+        "networkUpload": 1024,
+        "networkDownload": 1024,
+        "memory": 2048,
+        "cpus": 2
+    },
+    "properties": [
+      {
+          "name": "iame2edev",
+          "value": true
+      },
+      {
+          "name": "fred",
+          "value": 11
+      }
+    ],
+    "nodeHealth": {
+        "missing_heartbeat_interval": 240,
+        "check_agreement_status": 60
+    },
+    "dataVerification": {},
+    "maxAgreements": 2
+}

--- a/test/gov/gov-combined.sh
+++ b/test/gov/gov-combined.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+TEST_DIFF_ORG=${TEST_DIFF_ORG:-1}
+
 function set_exports {
     if [ "$NOANAX" != "1" ]
     then

--- a/test/gov/hzn_dev_services.sh
+++ b/test/gov/hzn_dev_services.sh
@@ -64,7 +64,7 @@ function createProject {
     sed -e 's|"image": ""|"image": "localhost:443/amd64_'$9':1.0"|' ${serviceDef} > ${serviceDef}.tmp && mv ${serviceDef}.tmp ${serviceDef}
     sed -e '/"ENV_VAR_HERE=SOME_VALUE"/d' ${serviceDef} > ${serviceDef}.tmp && mv ${serviceDef}.tmp ${serviceDef}
 
-    sed -e '/"global"/,+8d' ${userInput} > ${userInput}.tmp && mv ${userInput}.tmp ${userInput}
+    sed -e '/"global"/,+7d' ${userInput} > ${userInput}.tmp && mv ${userInput}.tmp ${userInput}
     sed -e 's|"url": ""|"url": "'${serviceURL}'"|' ${userInput} > ${userInput}.tmp && mv ${userInput}.tmp ${userInput}
     sed -e 's|"my_variable": "some_value"|"'$6'": "'$8'"|' ${userInput} > ${userInput}.tmp && mv ${userInput}.tmp ${userInput}
 

--- a/test/gov/loc2_apireg.sh
+++ b/test/gov/loc2_apireg.sh
@@ -43,11 +43,21 @@ fi
 
 read -d '' slocservice <<EOF
 {
-  "url": "https://bluehorizon.network/service-cpu",
-  "name": "cpu",
-  "organization": "IBM",
-  "versionRange": "1.0.0",
-  "attributes": []
+    "url": "https://bluehorizon.network/service-cpu",
+    "name": "cpu",
+    "organization": "IBM",
+    "versionRange": "1.0.0",
+    "attributes": [
+        {
+            "type": "UserInputAttributes",
+            "label": "User input variables",
+            "publishable": false,
+            "host_only": false,
+            "mappings": {
+                "cpu_var1": "ibmvar1"
+            }
+        }
+    ]
 }
 EOF
 
@@ -57,8 +67,10 @@ echo "Registering service based cpu service"
 
 ERR=$(echo "$slocservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
 if [ "$ERR" != "null" ]; then
-  echo -e "error occured: $ERR"
-  exit 2
+    if [ "$NONS" == "1" ] || [ "${ERR:0:22}" != "Duplicate registration" ]; then
+        echo -e "error occured: $ERR"
+        exit 2
+    fi 
 fi
 
 read -d '' slocservice <<EOF

--- a/test/gov/ns_apireg.sh
+++ b/test/gov/ns_apireg.sh
@@ -5,13 +5,18 @@ echo -e "\nBC setting is $BC"
 if [ "$BC" != "1" ]
 then
 
-echo -e "Pattern is set to $PATTERN"
-if [ "$PATTERN" == "" ]
-then
+    echo -e "Pattern is set to $PATTERN"
+    if [ "$PATTERN" == "" ]
+    then
 
-# Configure the netspeed service variables, at an older version level just to be sure
-# that the runtime will still pick them up for the newer version that is installed in the exchange.
-read -d '' snsconfig <<EOF
+        # Configure the netspeed service variables, at an older version level just to be sure
+        # that the runtime will still pick them up for the newer version that is installed in the exchange.
+        # To test the services from different orgs with same url, we have setup 2 netspeed services.
+        # IBM/netspeed depends on: IBM/nework, IBN/network2, IBM/cpu
+        # e2edev/netspeed depends on: e2edev/network, e2edev/network2, IBM/cpu e2edev/cpu
+
+        ### IBM/netspeed
+        read -d '' snsconfig <<EOF
 {
   "url": "https://bluehorizon.network/services/netspeed",
   "version": "2.2.0",
@@ -33,18 +38,47 @@ read -d '' snsconfig <<EOF
   ]
 }
 EOF
+        echo -e "\n\n[D] IBM/netspeed service config payload: $snsconfig"
+        echo "Registering IBM/netspeed service config on node"
+        ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo -e "\n\n[D] netspeed service config payload: $snsconfig"
+        ### e2edev/netspeed
+        read -d '' snsconfig <<EOF
+{
+  "url": "https://bluehorizon.network/services/netspeed",
+  "version": "2.2.0",
+  "organization": "e2edev",
+  "attributes": [
+    {
+      "type": "UserInputAttributes",
+      "label": "User input variables",
+      "publishable": false,
+      "host_only": false,
+      "mappings": {
+        "var1": "bString",
+        "var2": 10,
+        "var3": 10.22,
+        "var4": ["abcd", "1234"],
+        "var5": "override2"
+      }
+    }
+  ]
+}
+EOF
+        echo -e "\n\n[D] e2edev/netspeed service config payload: $snsconfig"
+        echo "Registering e2edev/netspeed service config on node"
+        ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo "Registering netspeed service config on node"
-
-ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
-if [ "$ERR" != "null" ]; then
-  echo -e "error occured: $ERR"
-  exit 2
-fi
-
-read -d '' networkservice <<EOF
+        ### IBM/network
+        read -d '' networkservice <<EOF
 {
   "url": "https://bluehorizon.network/services/network",
   "version": "1.0.0",
@@ -52,18 +86,34 @@ read -d '' networkservice <<EOF
   "attributes": []
 }
 EOF
+        echo -e "\n\n[D] networkservice payload: $networkservice"
+        echo "Registering IBM/network service"
+        ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo -e "\n\n[D] networkservice payload: $networkservice"
+        ### e2edev/network
+        read -d '' networkservice <<EOF
+{
+  "url": "https://bluehorizon.network/services/network",
+  "version": "1.0.0",
+  "organization": "e2edev",
+  "attributes": []
+}
+EOF
+        echo -e "\n\n[D] networkservice payload: $networkservice"
+        echo "Registering e2edev/network service"
+        ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo "Registering network service"
 
-ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
-if [ "$ERR" != "null" ]; then
-  echo -e "error occured: $ERR"
-  exit 2
-fi
-
-read -d '' networkservice <<EOF
+        ### IBM/network2
+        read -d '' networkservice <<EOF
 {
   "url": "https://bluehorizon.network/services/network2",
   "version": "1.0.0",
@@ -71,25 +121,101 @@ read -d '' networkservice <<EOF
   "attributes": []
 }
 EOF
+        echo -e "\n\n[D] networkservice payload: $networkservice"
+        echo "Registering IBM/network2 service"
+        ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            if [ "${ERR:0:22}" != "Duplicate registration" ]; then
+                echo -e "error occured: $ERR"
+                exit 2
+            fi
+        fi
 
-echo -e "\n\n[D] networkservice payload: $networkservice"
+        ### e2edev/network2
+        read -d '' networkservice <<EOF
+{
+  "url": "https://bluehorizon.network/services/network2",
+  "version": "1.0.0",
+  "organization": "e2edev",
+  "attributes": []
+}
+EOF
+        echo -e "\n\n[D] networkservice payload: $networkservice"
+        echo "Registering e2edev/network2 service"
+        ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            if [ "${ERR:0:22}" != "Duplicate registration" ]; then
+                echo -e "error occured: $ERR"
+                exit 2
+            fi
+        fi
 
-echo "Registering network service"
+         ### IBM/cpu
+        read -d '' slocservice <<EOF
+{
+    "url": "https://bluehorizon.network/service-cpu",
+    "name": "cpu",
+    "organization": "IBM",
+    "versionRange": "1.0.0",
+    "attributes": [
+        {
+            "type": "UserInputAttributes",
+            "label": "User input variables",
+            "publishable": false,
+            "host_only": false,
+            "mappings": {
+                "cpu_var1": "ibmvar1"
+            }
+        }
+    ]
+}
+EOF
+        echo -e "\n\n[D] service based cpu service payload: $slocservice"
+        echo "Registering service based IBM/cpu service"
+        ERR=$(echo "$slocservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            if [ "${ERR:0:22}" != "Duplicate registration" ]; then 
+                echo -e "error occured: $ERR"
+                exit 2
+            fi
+        fi
 
-ERR=$(echo "$networkservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
-if [ "$ERR" != "null" ]; then
-  if [ "${ERR:0:22}" != "Duplicate registration" ]; then
-    echo -e "error occured: $ERR"
-    exit 2
-  fi
-fi
+         ### e2edev/cpu
+        read -d '' slocservice <<EOF
+{
+    "url": "https://bluehorizon.network/service-cpu",
+    "name": "cpu",
+    "organization": "e2edev",
+    "versionRange": "1.0.0",
+    "attributes": [
+        {
+            "type": "UserInputAttributes",
+            "label": "User input variables",
+            "publishable": false,
+            "host_only": false,
+            "mappings": {
+                "cpu_var1": "e2edevvar1"
+             }
+        }
+    ]
+}
+EOF
+        echo -e "\n\n[D] service based cpu service payload: $slocservice"
+        echo "Registering service based e2edev/cpu service"
+        ERR=$(echo "$slocservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-elif [ "$PATTERN" == "sns" ] || [ "$PATTERN" == "sall" ]
-then
+    elif [ "$PATTERN" == "sns" ] || [ "$PATTERN" == "sall" ]
+    then
 
-# Configure the netspeed service variables, at an older version level just to be sure
-# that the runtime will still pick them up for the newer version that is installed in the exchange.
-read -d '' snsconfig <<EOF
+        # Configure the netspeed service variables, at an older version level just to be sure
+        # that the runtime will still pick them up for the newer version that is installed in the exchange.
+
+        ### IBM/netspeed
+        read -d '' snsconfig <<EOF
 {
   "url": "https://bluehorizon.network/services/netspeed",
   "version": "2.2.0",
@@ -111,17 +237,102 @@ read -d '' snsconfig <<EOF
   ]
 }
 EOF
+        echo -e "\n\n[D] IBM/netspeed service config payload: $snsconfig"
+        echo "Registering IBM/netspeed service config on node"
+        ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo -e "\n\n[D] netspeed service config payload: $snsconfig"
+        ### e2edev/netspeed
+        read -d '' snsconfig <<EOF
+{
+  "url": "https://bluehorizon.network/services/netspeed",
+  "version": "2.2.0",
+  "organization": "e2edev",
+  "attributes": [
+    {
+      "type": "UserInputAttributes",
+      "label": "User input variables",
+      "publishable": false,
+      "host_only": false,
+      "mappings": {
+        "var1": "aString",
+        "var2": 5,
+        "var3": 10.2,
+        "var4": ["abc", "123"],
+        "var5": "override"
+      }
+    }
+  ]
+}
+EOF
+        echo -e "\n\n[D] e2edev/netspeed service config payload: $snsconfig"
+        echo "Registering e2edev/netspeed service config on node"
+        ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-echo "Registering netspeed service config on node"
+         ### IBM/cpu
+        read -d '' slocservice <<EOF
+{
+    "url": "https://bluehorizon.network/service-cpu",
+    "name": "cpu",
+    "organization": "IBM",
+    "versionRange": "1.0.0",
+    "attributes": [
+        {
+            "type": "UserInputAttributes",
+            "label": "User input variables",
+            "publishable": false,
+            "host_only": false,
+            "mappings": {
+                "cpu_var1": "ibmvar1"
+            }
+        }
+    ]
+}
+EOF
+        echo -e "\n\n[D] service based cpu service payload: $slocservice"
+        echo "Registering service based IBM/cpu service"
+        ERR=$(echo "$slocservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            if [ "${ERR:0:22}" != "Duplicate registration" ]; then 
+                echo -e "error occured: $ERR"
+                exit 2
+            fi
+        fi
+        
+         ### e2edev/cpu
+        read -d '' slocservice <<EOF
+{
+    "url": "https://bluehorizon.network/service-cpu",
+    "name": "cpu",
+    "organization": "e2edev",
+    "versionRange": "1.0.0",
+    "attributes": [
+        {
+            "type": "UserInputAttributes",
+            "label": "User input variables",
+            "publishable": false,
+            "host_only": false,
+            "mappings": {
+                "cpu_var1": "e2edevvar1"
+             }
+        }
+    ]
+}
+EOF
+        echo -e "\n\n[D] service based cpu service payload: $slocservice"
+        echo "Registering service based e2edev/cpu service"
+        ERR=$(echo "$slocservice" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
+        if [ "$ERR" != "null" ]; then
+            echo -e "error occured: $ERR"
+            exit 2
+        fi
 
-ERR=$(echo "$snsconfig" | curl -sS -X POST -H "Content-Type: application/json" --data @- "$ANAX_API/service/config" | jq -r '.error')
-if [ "$ERR" != "null" ]; then
-  echo -e "error occured: $ERR"
-  exit 2
-fi
-
-fi
-
+    fi
 fi

--- a/test/gov/service_apitest.sh
+++ b/test/gov/service_apitest.sh
@@ -733,7 +733,7 @@ then
 fi
 
 ERR=$(echo $RES | jq -r ".error")
-if [ "${ERR:0:75}" != "Duplicate registration for https://bluehorizon.network/services/testservice" ]
+if [ "${ERR:0:82}" != "Duplicate registration for e2edev/https://bluehorizon.network/services/testservice" ]
 then
   echo -e "$snsconfig \nresulted in incorrect response: $RES"
   exit 2

--- a/test/gov/service_retry_test.sh
+++ b/test/gov/service_retry_test.sh
@@ -49,7 +49,7 @@ if [ "$PATTERN" = "sloc" ] ||[ "$PATTERN" = "sall" ]; then
         exit 2
     fi
 
-    cpu_inst_before=$(curl -s http://localhost/service | jq -r '.instances.active[] | select (.ref_url == "https://bluehorizon.network/service-cpu")')
+    cpu_inst_before=$(curl -s http://localhost/service | jq -r '.instances.active[] | select (.ref_url == "https://bluehorizon.network/service-cpu") | select (.organization == "IBM")')
     if [ $? -ne 0 ]; then
         echo -e "${PREFIX} failed to get cpu service instace. ${cpu_inst_before}"
         exit 2
@@ -70,7 +70,7 @@ if [ "$PATTERN" = "sloc" ] ||[ "$PATTERN" = "sall" ]; then
         exit 1
     fi
 
-    cpu_inst_after=$(curl -s http://localhost/service | jq -r '.instances.active[] | select (.ref_url == "https://bluehorizon.network/service-cpu")')
+    cpu_inst_after=$(curl -s http://localhost/service | jq -r '.instances.active[] | select (.ref_url == "https://bluehorizon.network/service-cpu") | select (.organization == "IBM")')
     if [ $? -ne 0 ]; then
         echo -e "${PREFIX} failed to get cpu service instace. ${cpu_inst_after}"
         exit 2
@@ -89,7 +89,7 @@ if [ "$PATTERN" = "sloc" ] ||[ "$PATTERN" = "sall" ]; then
         max_retry_duration=$(echo "$cpu_inst_after" | jq '.max_retry_duration')
         current_retry_count=$(echo "$cpu_inst_after" | jq '.current_retry_count')
         retry_start_time=$(echo "$cpu_inst_after" | jq '.retry_start_time')
-        if [ "$max_retries" != "2" ] || [ "$max_retry_duration" != "3600" ] || [ "$current_retry_count" != "2" ] || [ "$retry_start_time" == "0" ]; then
+        if [ "$max_retries" != "2" ] || [ "$max_retry_duration" != "2400" ] || [ "$current_retry_count" != "2" ] || [ "$retry_start_time" == "0" ]; then
              echo -e "${PREFIX} retry paramters are not right: max_retries=$max_retries, max_retry_duration=$max_retry_duration, current_retry_count=$current_retry_count, retry_start_time=$retry_start_time"
             exit 2
         fi

--- a/torrent/imagepull.go
+++ b/torrent/imagepull.go
@@ -136,7 +136,7 @@ func pullImageFromRepos(config config.Config, authConfigs map[string][]docker.Au
 			glog.Errorf("Docker image pull(s) failed for docker image %v. Error: %v.", service.Image, err)
 			return err
 		} else {
-			glog.V(3).Infof("Succeeded fetching image %v for service", service.Image, name)
+			glog.V(3).Infof("Succeeded fetching image %v for service %v", service.Image, name)
 		}
 	}
 

--- a/torrent/imagepull_test.go
+++ b/torrent/imagepull_test.go
@@ -18,28 +18,26 @@ func Test_authDockerFile(t *testing.T) {
 
 	// docker auths
 	meta_data1 := persistence.AttributeMeta{
-		SensorUrls:  []string{"myrepo1.com"},
 		Label:       "test1",
 		Publishable: &publishable,
 		HostOnly:    &host_only,
 		Type:        reflect.TypeOf(persistence.DockerRegistryAuthAttributes{}).Name(),
 	}
 	var auth_array1 []persistence.Auth
-	auth_array1 = append(auth_array1, persistence.Auth{Token: "t11"}, persistence.Auth{UserName: "iamapikey", Token: "t12"})
+	auth_array1 = append(auth_array1, persistence.Auth{Registry: "myrepo1.com", Token: "t11"}, persistence.Auth{Registry: "myrepo1.com", UserName: "iamapikey", Token: "t12"})
 	auth_attrib1 := persistence.DockerRegistryAuthAttributes{
 		Meta:  &meta_data1,
 		Auths: auth_array1,
 	}
 
 	meta_data2 := persistence.AttributeMeta{
-		SensorUrls:  []string{"myrepo2.com"},
 		Label:       "test2",
 		Publishable: &publishable,
 		HostOnly:    &host_only,
 		Type:        reflect.TypeOf(persistence.DockerRegistryAuthAttributes{}).Name(),
 	}
 	var auth_array2 []persistence.Auth
-	auth_array2 = append(auth_array2, persistence.Auth{UserName: "token", Token: "t21"}, persistence.Auth{Token: "t22"}, persistence.Auth{Token: "t23"})
+	auth_array2 = append(auth_array2, persistence.Auth{Registry: "myrepo2.com", UserName: "token", Token: "t21"}, persistence.Auth{Registry: "myrepo2.com", Token: "t22"}, persistence.Auth{Registry: "myrepo2.com", Token: "t23"})
 	auth_attrib2 := persistence.DockerRegistryAuthAttributes{
 		Meta:  &meta_data2,
 		Auths: auth_array2,
@@ -62,6 +60,6 @@ func Test_authDockerFile(t *testing.T) {
 	assert.Equal(t, 3, len(dockerAuthConfigurations), "the docker auth should have 3 elements.")
 	assert.Equal(t, 2, len(dockerAuthConfigurations["myrepo1.com"]), "The docker auth array should have 2 items.")
 	assert.Equal(t, 4, len(dockerAuthConfigurations["myrepo2.com"]), "The docker auth array should have 4 items.")
-	assert.Equal(t, 1, len(dockerAuthConfigurations["myrepo3.com"]), "The docker auth array should have 4 items.")
+	assert.Equal(t, 1, len(dockerAuthConfigurations["myrepo3.com"]), "The docker auth array should have 1 items.")
 
 }

--- a/torrent/torrent_int_test.go
+++ b/torrent/torrent_int_test.go
@@ -285,8 +285,8 @@ func Test_Torrent_Event_Suite(suite *testing.T) {
 	images := []string{
 		"summit.hovitos.engineering/amd64/neo4j:3.3.1",               // 189MB
 		"summit.hovitos.engineering/amd64/clojure:boot-2.7.2-alpine", // 147MB
-		"ubuntu:yakkety",                                             // 107MB
-		"registry.ng.bluemix.net/glendarling/x86/cpu:1.2.1",          // 9MB
+		"ubuntu:yakkety", // 107MB
+		"registry.ng.bluemix.net/glendarling/x86/cpu:1.2.1", // 9MB
 	}
 
 	var buf bytes.Buffer

--- a/torrent/torrent_test.go
+++ b/torrent/torrent_test.go
@@ -62,28 +62,26 @@ func Test_ExtractAuthAttributes(t *testing.T) {
 
 	// docker auths
 	meta_data1 := persistence.AttributeMeta{
-		SensorUrls:  []string{"myrepo1.com"},
 		Label:       "test1",
 		Publishable: &publishable,
 		HostOnly:    &host_only,
 		Type:        reflect.TypeOf(persistence.DockerRegistryAuthAttributes{}).Name(),
 	}
 	var auth_array1 []persistence.Auth
-	auth_array1 = append(auth_array1, persistence.Auth{Token: "t11"}, persistence.Auth{UserName: "iamapikey", Token: "t12"})
+	auth_array1 = append(auth_array1, persistence.Auth{Registry: "myrepo1.com", Token: "t11"}, persistence.Auth{Registry: "myrepo1.com", UserName: "iamapikey", Token: "t12"})
 	auth_attrib1 := persistence.DockerRegistryAuthAttributes{
 		Meta:  &meta_data1,
 		Auths: auth_array1,
 	}
 
 	meta_data2 := persistence.AttributeMeta{
-		SensorUrls:  []string{"myrepo2.com"},
 		Label:       "test2",
 		Publishable: &publishable,
 		HostOnly:    &host_only,
 		Type:        reflect.TypeOf(persistence.DockerRegistryAuthAttributes{}).Name(),
 	}
 	var auth_array2 []persistence.Auth
-	auth_array2 = append(auth_array2, persistence.Auth{UserName: "token", Token: "t21"}, persistence.Auth{Token: "t22"}, persistence.Auth{Token: "t23"})
+	auth_array2 = append(auth_array2, persistence.Auth{Registry: "myrepo2.com", UserName: "token", Token: "t21"}, persistence.Auth{Registry: "myrepo2.com", Token: "t22"}, persistence.Auth{Registry: "myrepo2.com", Token: "t23"})
 	auth_attrib2 := persistence.DockerRegistryAuthAttributes{
 		Meta:  &meta_data2,
 		Auths: auth_array2,
@@ -91,7 +89,6 @@ func Test_ExtractAuthAttributes(t *testing.T) {
 
 	// http auth
 	meta_data3 := persistence.AttributeMeta{
-		SensorUrls:  []string{"http://myrepo3.com"},
 		Label:       "test3",
 		Publishable: &publishable,
 		HostOnly:    &host_only,
@@ -99,12 +96,12 @@ func Test_ExtractAuthAttributes(t *testing.T) {
 	}
 	auth_attrib3 := persistence.HTTPSBasicAuthAttributes{
 		Meta:     &meta_data3,
+		Url:      "http://myrepo3.com",
 		Username: "user3",
 		Password: "password3",
 	}
 
 	meta_data4 := persistence.AttributeMeta{
-		SensorUrls:  []string{"http://myrepo4.com"},
 		Label:       "test3",
 		Publishable: &publishable,
 		HostOnly:    &host_only,
@@ -112,6 +109,7 @@ func Test_ExtractAuthAttributes(t *testing.T) {
 	}
 	auth_attrib4 := persistence.HTTPSBasicAuthAttributes{
 		Meta:     &meta_data4,
+		Url:      "http://myrepo4.com",
 		Username: "user4",
 		Password: "password4",
 	}
@@ -148,28 +146,26 @@ func Test_authExchange(t *testing.T) {
 
 	// docker auths
 	meta_data1 := persistence.AttributeMeta{
-		SensorUrls:  []string{"myrepo1.com"},
 		Label:       "test1",
 		Publishable: &publishable,
 		HostOnly:    &host_only,
 		Type:        reflect.TypeOf(persistence.DockerRegistryAuthAttributes{}).Name(),
 	}
 	var auth_array1 []persistence.Auth
-	auth_array1 = append(auth_array1, persistence.Auth{Token: "t11"}, persistence.Auth{UserName: "iamapikey", Token: "t12"})
+	auth_array1 = append(auth_array1, persistence.Auth{Registry: "myrepo1.com", Token: "t11"}, persistence.Auth{Registry: "myrepo1.com", UserName: "iamapikey", Token: "t12"})
 	auth_attrib1 := persistence.DockerRegistryAuthAttributes{
 		Meta:  &meta_data1,
 		Auths: auth_array1,
 	}
 
 	meta_data2 := persistence.AttributeMeta{
-		SensorUrls:  []string{"myrepo2.com"},
 		Label:       "test2",
 		Publishable: &publishable,
 		HostOnly:    &host_only,
 		Type:        reflect.TypeOf(persistence.DockerRegistryAuthAttributes{}).Name(),
 	}
 	var auth_array2 []persistence.Auth
-	auth_array2 = append(auth_array2, persistence.Auth{UserName: "token", Token: "t21"}, persistence.Auth{Token: "t22"}, persistence.Auth{Token: "t23"})
+	auth_array2 = append(auth_array2, persistence.Auth{Registry: "myrepo2.com", UserName: "token", Token: "t21"}, persistence.Auth{Registry: "myrepo2.com", Token: "t22"}, persistence.Auth{Registry: "myrepo2.com", Token: "t23"})
 	auth_attrib2 := persistence.DockerRegistryAuthAttributes{
 		Meta:  &meta_data2,
 		Auths: auth_array2,
@@ -177,7 +173,6 @@ func Test_authExchange(t *testing.T) {
 
 	// http auth
 	meta_data3 := persistence.AttributeMeta{
-		SensorUrls:  []string{"http://myrepo3.com"},
 		Label:       "test3",
 		Publishable: &publishable,
 		HostOnly:    &host_only,
@@ -185,6 +180,7 @@ func Test_authExchange(t *testing.T) {
 	}
 	auth_attrib3 := persistence.HTTPSBasicAuthAttributes{
 		Meta:     &meta_data3,
+		Url:      "http://myrepo3.com",
 		Username: "user3",
 		Password: "password3",
 	}


### PR DESCRIPTION
…m different org
1. added Org to MicroserviceInstance
2. for Attribute, removed SensorUrl from the meta and added ServiceSpecs to the necessary attributes.
3. changed policy manager to allow same url from different orgs.
4. changed EstablishedAgreement to replace SensorUrls with ServiceSpecs.
5. changed AgrementEventSource  for eventlog to replace SensorUrls with ServiceSpecs.
6. changed the eventlog messages so that it uses 'org/url' to refer to a service.
7. changed registeredServices.URL for a node on the exchange to use ’org/url' format.
8. changed abbot to use  'org/url' for node search.
9. added compatibility support. User needs to to `hzn unregiser` before upgrading to this version. Then register the node again. 