### PR TITLE
issue892 - added validation for constraints

### DIFF
--- a/externalpolicy/text_language/text_language.go
+++ b/externalpolicy/text_language/text_language.go
@@ -3,8 +3,13 @@ package text_language
 import (
 	"errors"
 	"fmt"
-	"github.com/open-horizon/anax/externalpolicy/plugin_registry"
+	"regexp"
+	"strconv"
 	"strings"
+
+	"github.com/open-horizon/anax/externalpolicy"
+	"github.com/open-horizon/anax/externalpolicy/plugin_registry"
+	"github.com/open-horizon/anax/policy"
 )
 
 func init() {
@@ -21,8 +26,66 @@ func NewTextConstraintLanguagePlugin() plugin_registry.ConstraintLanguagePlugin 
 func (p *TextConstraintLanguagePlugin) Validate(dconstraints interface{}) (bool, error) {
 
 	// Validate that the input is a ConstraintExpression type (string)
+	// if !isString(dconstraints) {
+	// 	return false, errors.New*(fmt.Sprintf("The Constrain input is not String"))
+	// }
+
+	var err error
+	var constrains []string
+	var nextExpression, nextLogicalOperator, remainder string
+	var validated bool
+
+	if !isConstraintExpression(dconstraints) {
+		return false, errors.New(fmt.Sprintf("The Constrain input: %v is not Contraint Express type", dconstraints))
+	}
 
 	// Validate that the expression is syntactically correct and parse-able
+	constrains = dconstraints.([]string)
+
+	for _, remainder = range constrains {
+		// 1 constrain inside constrain list
+		fmt.Println("remainder: ", remainder)
+
+		// handles space inside quote and inside string list
+		remainder = preprocessConstraintExpression(remainder)
+
+		for {
+			nextExpression, remainder, err = p.GetNextExpression(remainder)
+
+			if err != nil {
+				return false, errors.New(fmt.Sprintf("unable to convert policy constraint %v into internal format, error %v", remainder, err))
+			} else if nextExpression == "" {
+				break
+			}
+
+			// TODO: verify pieces[1] and pieces[2]
+			// 1. == is supported for all types except list of string, which would use 'in'.
+			// 2. for numeric types, the operators ==, <, >, <=, >= are supported
+			// 3. false and true are the only valid values for a boolean type
+			// 4. for string types, a list of comma separated strings provide acceptable values
+			// 5. string values that contain spaces must be quoted
+			// 6. for the version type, supported values are a single version or a range of versions in the semantic version format (the same as used for service verions). The == operator implies that the value is a single version. The 'in' operator treats the value as a version range. As with service versions, the version 1.0.0 when treated as a version range is equivalent to the explicit range [1.0.0,INFINITY).
+
+			validated, err = validateOneConstraintExpression(nextExpression)
+			if !validated {
+				return false, err
+			}
+
+			nextLogicalOperator, remainder, err = p.GetNextOperator(remainder)
+			if err != nil {
+				return false, errors.New(fmt.Sprintf("unable to convert policy constraint %v into internal format, error %v", remainder, err))
+			} else if nextLogicalOperator == "" {
+				break
+			}
+
+			// TODO: verify logical operators
+			if !isAllowedLogicalOpType(nextLogicalOperator) {
+				return false, errors.New(fmt.Sprintf("Logical operator %v is not valid", nextLogicalOperator))
+			}
+
+		}
+
+	}
 
 	return true, nil
 }
@@ -68,4 +131,190 @@ func (p *TextConstraintLanguagePlugin) GetNextOperator(expression string) (strin
 
 	// Reform the expression and return the remainder of the expression.
 	return pieces[0], strings.Join(pieces[1:], " "), nil
+}
+
+func isConstraintExpression(x interface{}) bool {
+	switch x.(type) {
+	case externalpolicy.ConstraintExpression:
+		return true
+	default:
+		return false
+	}
+}
+
+func isString(x interface{}) bool {
+	switch x.(type) {
+	case string:
+		return true
+	default:
+		return false
+	}
+}
+
+func isCommaSeparatedStringList(x string) bool {
+	if len(x) == 0 {
+		return false
+	}
+
+	s := strings.Split(x, ",")
+	if len(s) == 0 {
+		return false
+	}
+	return true
+}
+
+func canParseToInteger(s string) bool {
+	_, err := strconv.Atoi(s)
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+func canParseToFloat(s string) bool {
+	_, err := strconv.ParseFloat(s, 64)
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+func canParseToBoolean(s string) bool {
+	_, err := strconv.ParseBool(s)
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+func canParseToStringList(s interface{}) bool {
+	switch s.(type) {
+	case []string:
+		return true
+	default:
+		return false
+	}
+}
+
+func isAllowedType(s string) bool {
+	if canParseToBoolean(s) || canParseToInteger(s) || canParseToFloat(s) || canParseToStringList(s) || policy.IsVersionString(s) {
+		return true
+	}
+	return false
+}
+
+// These are the comparison operators that are supported (get from conter_party_properties.go)
+const lessthan = "<"
+const greaterthan = ">"
+const equalto = "="
+const doubleequalto = "=="
+const lessthaneq = "<="
+const greaterthaneq = ">="
+const notequalto = "!="
+const inoperator = "in"
+
+func isAllowedComparisonOpType(s string) bool {
+	if strings.Compare(s, lessthan) == 0 || strings.Compare(s, greaterthan) == 0 || strings.Compare(s, equalto) == 0 || strings.Compare(s, doubleequalto) == 0 || strings.Compare(s, lessthaneq) == 0 || strings.Compare(s, greaterthaneq) == 0 || strings.Compare(s, notequalto) == 0 || strings.Compare(s, inoperator) == 0 {
+		return true
+	}
+	return false
+}
+
+const andsimbol = "&&"
+const orsimbol = "||"
+const notsimbol = "^"
+const and = "AND"
+const or = "OR"
+const not = "NOT"
+
+func isAllowedLogicalOpType(s string) bool {
+	if strings.Compare(s, andsimbol) == 0 || strings.Compare(s, orsimbol) == 0 || strings.Compare(s, notsimbol) == 0 || strings.Compare(s, and) == 0 || strings.Compare(s, or) == 0 || strings.Compare(s, not) == 0 {
+		return true
+	}
+	return false
+}
+
+func preprocessConstraintExpression(str string) string {
+	re := regexp.MustCompile(`(?m)"(.*?)"(?m)`)
+
+	// remove space inside string list separate by ", "
+	space := regexp.MustCompile(`,\s+`)
+	str = space.ReplaceAllString(str, ",")
+	//str = strings.Replace(str, ", ", ",", -1)
+
+	for _, match := range re.FindAllString(str, -1) {
+		// if find "a b", replace space inside quote with invisiable charactor \a
+		newStr := strings.ReplaceAll(match, " ", "\a")
+		str = strings.Replace(str, match, newStr, -1)
+	}
+
+	return str
+}
+
+// 1. == is supported for all types except list of string, which would use 'in'.
+// 2. for numeric types, the operators ==, <, >, <=, >= are supported
+// 3. false and true are the only valid values for a boolean type
+// 4. for string types, a list of comma separated strings provide acceptable values
+// 5. string values that contain spaces must be quoted
+// 6. for the version type, supported values are a single version or a range of versions in the semantic version format (the same as used for service verions). The == operator implies that the value is a single version. The 'in' operator treats the value as a version range. As with service versions, the version 1.0.0 when treated as a version range is equivalent to the explicit range [1.0.0,INFINITY).
+
+func validateOneConstraintExpression(expression string) (bool, error) {
+	if len(expression) == 0 {
+		return true, nil
+	}
+
+	pieces := strings.Split(expression, " ")
+	if len(pieces) < 3 {
+		return false, errors.New(fmt.Sprintf("found %v token(s), expecting 3 in an expression %v, expected form is <property> == <value> in constraint expression", len(pieces), expression))
+	}
+
+	compOp := pieces[1]
+	value := pieces[2]
+
+	if !isAllowedType(value) {
+		return false, errors.New(fmt.Sprintf("The type constrain value: %v is not supported for this express %v ", value, expression))
+	}
+
+	// if will failed on case when string values that contain spaces but not quoted (starting from 2nd interation)
+	if !isAllowedComparisonOpType(pieces[1]) {
+		return false, errors.New(fmt.Sprintf("Expression: %v should contain valid comparison operator - wrong operator %v", expression, pieces[1]))
+	}
+
+	if canParseToFloat(value) || canParseToInteger(value) {
+		if strings.Compare(compOp, doubleequalto) == 0 || strings.Compare(compOp, equalto) == 0 || strings.Compare(compOp, lessthan) == 0 || strings.Compare(compOp, greaterthan) == 0 || strings.Compare(compOp, lessthaneq) == 0 || strings.Compare(compOp, greaterthaneq) == 0 {
+			return true, nil
+		}
+		return false, errors.New(fmt.Sprintf("Comparison operator: %v is not supported for numeric value: %v", compOp, value))
+	}
+
+	if canParseToBoolean(value) {
+		if strings.Compare(compOp, doubleequalto) == 0 || strings.Compare(compOp, equalto) == 0 {
+			return true, nil
+		}
+		return false, errors.New(fmt.Sprintf("Comparison operator: %v is not supported for boolean value: %v", compOp, value))
+	}
+
+	if isCommaSeparatedStringList(value) {
+		if strings.Compare(strings.ToLower(compOp), inoperator) == 0 {
+			return true, nil
+		}
+		return false, errors.New(fmt.Sprintf("Comparison operator: %v is not supported for string list value: %v", compOp, value))
+	}
+
+	if policy.IsVersionString(value) {
+		if strings.Compare(compOp, doubleequalto) == 0 || strings.Compare(compOp, equalto) == 0 {
+			return true, nil
+		}
+		return false, errors.New(fmt.Sprintf("Comparison operator: %v is not supported for single version: %v", compOp, value))
+	}
+
+	if policy.IsVersionExpression(value) {
+		if strings.Compare(compOp, inoperator) == 0 {
+			return true, nil
+		}
+		return false, errors.New(fmt.Sprintf("Comparison operator: %v is not supported for version expression: %v", compOp, value))
+	}
+
+	return false, errors.New(fmt.Sprintf("Expression: %v is not valid", expression))
+
 }

--- a/externalpolicy/text_language/text_language.go
+++ b/externalpolicy/text_language/text_language.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/open-horizon/anax/externalpolicy"
 	"github.com/open-horizon/anax/externalpolicy/plugin_registry"
 	"github.com/open-horizon/anax/policy"
@@ -40,8 +41,6 @@ func (p *TextConstraintLanguagePlugin) Validate(dconstraints interface{}) (bool,
 
 	for _, constraint = range constraints {
 		// 1 constrain inside constrain list
-		fmt.Println("constraint: ", constraint)
-
 		// handles space inside quote and inside string list
 		constraint = preprocessConstraintExpression(constraint)
 		remainder = constraint
@@ -153,8 +152,6 @@ func isCommaSeparatedStringList(x string) bool {
 		return false
 	}
 
-	//s := strings.Split(x, ",")
-
 	return true
 }
 
@@ -194,7 +191,7 @@ func canParseToStringList(s interface{}) bool {
 func canParseToString(s string) bool {
 	if len(s) > 0 && s[0] == '"' && s[len(s)-1] == '"' {
 		content := strings.Trim(s, "\"")
-		fmt.Printf("content after removing quote: %v", content)
+		glog.V(5).Infof("content after removing quote: %v", content)
 		if strings.ToLower(content) == "true" || strings.ToLower(content) == "false" {
 
 			return false
@@ -202,7 +199,7 @@ func canParseToString(s string) bool {
 	}
 
 	if strings.Contains(s, " ") {
-		fmt.Printf("word with space not quoted: %v", s)
+		glog.V(5).Infof("word with space not quoted: %v", s)
 		return false
 	}
 
@@ -233,15 +230,13 @@ func isAllowedComparisonOpType(s string) bool {
 	return false
 }
 
-const andsimbol = "&&"
-const orsimbol = "||"
-const notsimbol = "^"
+const andsymbol = "&&"
+const orsymbol = "||"
 const and = "AND"
 const or = "OR"
-const not = "NOT"
 
 func isAllowedLogicalOpType(s string) bool {
-	if strings.Compare(s, andsimbol) == 0 || strings.Compare(s, orsimbol) == 0 || strings.Compare(s, notsimbol) == 0 || strings.Compare(s, and) == 0 || strings.Compare(s, or) == 0 || strings.Compare(s, not) == 0 {
+	if strings.Compare(s, andsymbol) == 0 || strings.Compare(s, orsymbol) == 0 || strings.Compare(s, and) == 0 || strings.Compare(s, or) == 0 {
 		return true
 	}
 	return false

--- a/externalpolicy/text_language/text_language.go
+++ b/externalpolicy/text_language/text_language.go
@@ -280,7 +280,7 @@ func validateOneConstraintExpression(expression string) (bool, error) {
 
 	// if will failed on case when string values that contain spaces but not quoted (starting from 2nd interation)
 	if !isAllowedComparisonOpType(pieces[1]) {
-		return false, errors.New(fmt.Sprintf("Expression: %v should contain valid comparison operator - wrong operator %v", expression, pieces[1]))
+		return false, errors.New(fmt.Sprintf("Expression: %v should contain valid comparison operator - wrong operator %v. Allowed operators: %v, %v, %v, %v, %v, %v, %v, %v", expression, pieces[1], lessthan, greaterthan, equalto, doubleequalto, lessthaneq, greaterthaneq, notequalto, inoperator))
 	}
 
 	if canParseToFloat(value) || canParseToInteger(value) {

--- a/externalpolicy/text_language/text_language.go
+++ b/externalpolicy/text_language/text_language.go
@@ -25,13 +25,12 @@ func NewTextConstraintLanguagePlugin() plugin_registry.ConstraintLanguagePlugin 
 
 func (p *TextConstraintLanguagePlugin) Validate(dconstraints interface{}) (bool, error) {
 
-	// Validate that the input is a ConstraintExpression type (string[])
-
 	var err error
 	var constraints externalpolicy.ConstraintExpression
 	var nextExpression, nextLogicalOperator, remainder, constraint string
 	var validated bool
 
+	// Validate that the input is a ConstraintExpression type (string[])
 	if !isConstraintExpression(dconstraints) {
 		return false, errors.New(fmt.Sprintf("The Constrain input: %v is not Contraint Express type", dconstraints))
 	}
@@ -68,7 +67,7 @@ func (p *TextConstraintLanguagePlugin) Validate(dconstraints interface{}) (bool,
 				break
 			}
 
-			// TODO: verify logical operators
+			// verify logical operators
 			if !isAllowedLogicalOpType(nextLogicalOperator) {
 				return false, errors.New(fmt.Sprintf("Logical operator %v is not valid", nextLogicalOperator))
 			}

--- a/externalpolicy/text_language/text_language_test.go
+++ b/externalpolicy/text_language/text_language_test.go
@@ -1,0 +1,26 @@
+// +build unit
+
+package text_language
+
+import (
+	"testing"
+
+	"github.com/open-horizon/anax/externalpolicy"
+)
+
+func Test_Validate_Succeed1(t *testing.T) {
+	// "constraints": [
+	//	"iame2edev == true && cpu == 3",
+	//	"hello == world"
+	//  ]
+	textCLP := text_language.TextConstraintLanguagePlugin{}
+	testConstraints := []externalpolicy.ConstraintExpression{"iame2edev == true && cpu == 3", "hello == world"}
+	validated, err := textCLP.validate(testConstraints)
+
+	if !validated {
+		t.Errorf("Should validate successfully but not")
+	} else if err != nil {
+		t.Errorf("Should validated and don't return err, but returned err: %v", err)
+	}
+
+}

--- a/externalpolicy/text_language/text_language_test.go
+++ b/externalpolicy/text_language/text_language_test.go
@@ -15,6 +15,7 @@ func Test_Validate_Succeed1(t *testing.T) {
 	constraintStrings := []string{
 		"iame2edev == true && cpu == 3 NOT memory <= 32",
 		"hello == \"world\"",
+		"hello in \"'hi world', 'test'\"",
 		"eggs == \"truck load\" AND certification in \"USDA, Organic\"",
 		"version == 1.1.1 OR USDA == true",
 		"version in [1.1.1,INFINITY) ^ cert == USDA",
@@ -43,6 +44,17 @@ func Test_Validate_Failed1(t *testing.T) {
 
 	var validated bool
 	var err error
+
+	validated, err = textConstraintLanguagePlugin.Validate(interface{}(ce))
+	if validated == true {
+		t.Errorf("Validation should fail but not, err: %v", err)
+	} else if err == nil {
+		t.Errorf("Validated should fail and return err, but didn't")
+	}
+
+	// string list should not support ==
+	constraintStrings = []string{"hello == \"'hi world', 'test'\""}
+	ce = externalpolicy.ConstraintExpression(constraintStrings)
 
 	validated, err = textConstraintLanguagePlugin.Validate(interface{}(ce))
 	if validated == true {
@@ -90,7 +102,7 @@ func Test_Validate_Failed3(t *testing.T) {
 
 func Test_Validate_Failed4(t *testing.T) {
 
-	// true should only supported as boolean value, not string value
+	// string must be quoted if it has white space
 	textConstraintLanguagePlugin := NewTextConstraintLanguagePlugin()
 	constraintStrings := []string{"eggs == truck load"}
 	ce := externalpolicy.ConstraintExpression(constraintStrings)

--- a/externalpolicy/text_language/text_language_test.go
+++ b/externalpolicy/text_language/text_language_test.go
@@ -49,7 +49,7 @@ func Test_Validate_Failed1(t *testing.T) {
 		t.Errorf("Validation should fail but not, err: %v", err)
 	} else if err == nil {
 		t.Errorf("Validated should fail and return err, but didn't")
-	} else if err.Error() != "3. Comparison operator: == is not supported for string list value: \"USDA,Organic\"" {
+	} else if err.Error() != "Comparison operator: == is not supported for string list value: \"USDA,Organic\"" {
 		t.Errorf("Error message: %v is not the expected error message", err)
 	}
 
@@ -62,7 +62,7 @@ func Test_Validate_Failed1(t *testing.T) {
 		t.Errorf("Validation should fail but not, err: %v", err)
 	} else if err == nil {
 		t.Errorf("Validated should fail and return err, but didn't")
-	} else if err.Error() != "3. Comparison operator: == is not supported for string list value: \"'hi\aworld','test'\"" {
+	} else if err.Error() != "Comparison operator: == is not supported for string list value: \"'hi\aworld','test'\"" {
 		t.Errorf("Error message: %v is not the expected error message", err)
 	}
 }
@@ -82,7 +82,7 @@ func Test_Validate_Failed2(t *testing.T) {
 		t.Errorf("Validation should fail but not, err: %v", err)
 	} else if err == nil {
 		t.Errorf("Validated should fail and return err, but didn't")
-	} else if err.Error() != "2. Comparison operator: < is not supported for boolean value: true" {
+	} else if err.Error() != "Comparison operator: < is not supported for boolean value: true" {
 		t.Errorf("Error message: %v is not the expected error message", err)
 	}
 }
@@ -122,7 +122,7 @@ func Test_Validate_Failed4(t *testing.T) {
 		t.Errorf("Validation should fail but not, err: %v", err)
 	} else if err == nil {
 		t.Errorf("Validated should fail and return err, but didn't")
-	} else if err.Error() != "Logical operator load is not valid" {
+	} else if err.Error() != "Logical operator load is not valid, expecting AND, OR, &&, ||" {
 		t.Errorf("Error message: %v is not the expected error message", err)
 	}
 }
@@ -142,7 +142,7 @@ func Test_Validate_Failed5(t *testing.T) {
 		t.Errorf("Validation should fail but not, err: %v", err)
 	} else if err == nil {
 		t.Errorf("Validated should fail and return err, but didn't")
-	} else if err.Error() != "Logical operator abcdefg is not valid" {
+	} else if err.Error() != "Logical operator abcdefg is not valid, expecting AND, OR, &&, ||" {
 		t.Errorf("Error message: %v is not the expected error message", err)
 	}
 }

--- a/externalpolicy/text_language/text_language_test.go
+++ b/externalpolicy/text_language/text_language_test.go
@@ -3,24 +3,105 @@
 package text_language
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/open-horizon/anax/externalpolicy"
 )
 
 func Test_Validate_Succeed1(t *testing.T) {
-	// "constraints": [
-	//	"iame2edev == true && cpu == 3",
-	//	"hello == world"
-	//  ]
-	textCLP := text_language.TextConstraintLanguagePlugin{}
-	testConstraints := []externalpolicy.ConstraintExpression{"iame2edev == true && cpu == 3", "hello == world"}
-	validated, err := textCLP.validate(testConstraints)
+	// boolean, int, string
+	textConstraintLanguagePlugin := NewTextConstraintLanguagePlugin()
+	constraintStrings := []string{
+		"iame2edev == true && cpu == 3 NOT memory <= 32",
+		"hello == \"world\"",
+		"eggs == \"truck load\" AND certification in \"USDA, Organic\"",
+		"version == 1.1.1 OR USDA == true",
+		"version in [1.1.1,INFINITY) ^ cert == USDA",
+	}
+	ce := externalpolicy.ConstraintExpression(constraintStrings)
 
-	if !validated {
-		t.Errorf("Should validate successfully but not")
+	fmt.Println("ce: ", ce)
+
+	var validated bool
+	var err error
+
+	validated, err = textConstraintLanguagePlugin.Validate(interface{}(ce))
+	if validated == false {
+		t.Errorf("Should validate successfully but not, err: %v", err)
 	} else if err != nil {
 		t.Errorf("Should validated and don't return err, but returned err: %v", err)
 	}
+}
 
+func Test_Validate_Failed1(t *testing.T) {
+
+	// string with multiple words, string list should not support ==
+	textConstraintLanguagePlugin := NewTextConstraintLanguagePlugin()
+	constraintStrings := []string{"eggs == \"truck load\" || certification == \"USDA, Organic\""}
+	ce := externalpolicy.ConstraintExpression(constraintStrings)
+
+	var validated bool
+	var err error
+
+	validated, err = textConstraintLanguagePlugin.Validate(interface{}(ce))
+	if validated == true {
+		t.Errorf("Validation should fail but not, err: %v", err)
+	} else if err == nil {
+		t.Errorf("Validated should fail and return err, but didn't")
+	}
+}
+
+func Test_Validate_Failed2(t *testing.T) {
+
+	// <, > only supported for numeric value
+	textConstraintLanguagePlugin := NewTextConstraintLanguagePlugin()
+	constraintStrings := []string{"iame2edev < true && cpu == 3 NOT memory <= 32", "hello > world"}
+	ce := externalpolicy.ConstraintExpression(constraintStrings)
+
+	var validated bool
+	var err error
+
+	validated, err = textConstraintLanguagePlugin.Validate(interface{}(ce))
+	if validated == true {
+		t.Errorf("Validation should fail but not, err: %v", err)
+	} else if err == nil {
+		t.Errorf("Validated should fail and return err, but didn't")
+	}
+}
+
+func Test_Validate_Failed3(t *testing.T) {
+
+	// true should only supported as boolean value, not string value
+	textConstraintLanguagePlugin := NewTextConstraintLanguagePlugin()
+	constraintStrings := []string{"version in [1.1.1,INFINITY) OR USDA == \"true\""}
+	ce := externalpolicy.ConstraintExpression(constraintStrings)
+
+	var validated bool
+	var err error
+
+	validated, err = textConstraintLanguagePlugin.Validate(interface{}(ce))
+	if validated == true {
+		t.Errorf("Validation should fail but not, err: %v", err)
+	} else if err == nil {
+		t.Errorf("Validated should fail and return err, but didn't")
+	}
+}
+
+func Test_Validate_Failed4(t *testing.T) {
+
+	// true should only supported as boolean value, not string value
+	textConstraintLanguagePlugin := NewTextConstraintLanguagePlugin()
+	constraintStrings := []string{"eggs == truck load"}
+	ce := externalpolicy.ConstraintExpression(constraintStrings)
+
+	var validated bool
+	var err error
+
+	validated, err = textConstraintLanguagePlugin.Validate(interface{}(ce))
+	if validated == true {
+		t.Errorf("Validation should fail but not, err: %v", err)
+	} else if err == nil {
+		t.Errorf("Validated should fail and return err, but didn't")
+	}
 }


### PR DESCRIPTION
This PR is for first 2 items of issue 892 and unit test:
- Support version, integer, float, string, boolean and list of string types (Lily)
- Support boolean operators and aliases (&&, ||, etc) in the constraint language