### PR TITLE
Issue #986 - '--long' flag not working for hzn exchange pattern list

### DIFF
--- a/cli/exchange/agbot.go
+++ b/cli/exchange/agbot.go
@@ -18,6 +18,9 @@ type ExchangeAgbots struct {
 func AgbotList(org string, userPw string, agbot string, namesOnly bool) {
 	cliutils.SetWhetherUsingApiKey(userPw)
 	org, agbot = cliutils.TrimOrg(org, agbot)
+	if agbot == "*" {
+		agbot = ""
+	}
 	if namesOnly && agbot == "" {
 		// Only display the names
 		var resp ExchangeAgbots

--- a/cli/exchange/node.go
+++ b/cli/exchange/node.go
@@ -22,6 +22,9 @@ type ExchangeNodes struct {
 func NodeList(org string, credToUse string, node string, namesOnly bool) {
 	cliutils.SetWhetherUsingApiKey(credToUse)
 	org, node = cliutils.TrimOrg(org, node)
+	if node == "*" {
+		node = ""
+	}
 	if namesOnly && node == "" {
 		// Only display the names
 		var resp ExchangeNodes

--- a/cli/exchange/pattern.go
+++ b/cli/exchange/pattern.go
@@ -94,11 +94,11 @@ func PatternList(credOrg string, userPw string, pattern string, namesOnly bool) 
 	cliutils.SetWhetherUsingApiKey(userPw)
 	var patOrg string
 	patOrg, pattern = cliutils.TrimOrg(credOrg, pattern)
-	if namesOnly && (pattern == "" || pattern == "*") {
+	if pattern == "*" {
+		pattern = ""
+	}
+	if namesOnly && pattern == "" {
 		// Only display the names
-		if pattern == "*" {
-			pattern = ""
-		}
 		var resp ExchangePatterns
 		cliutils.ExchangeGet("Exchange", cliutils.GetExchangeUrl(), "orgs/"+patOrg+"/patterns"+cliutils.AddSlash(pattern), cliutils.OrgAndCreds(credOrg, userPw), []int{200, 404}, &resp)
 		patterns := []string{} // this is important (instead of leaving it nil) so json marshaling displays it as [] instead of null

--- a/cli/exchange/service.go
+++ b/cli/exchange/service.go
@@ -160,11 +160,11 @@ func ServiceList(credOrg, userPw, service string, namesOnly bool) {
 	cliutils.SetWhetherUsingApiKey(userPw)
 	var svcOrg string
 	svcOrg, service = cliutils.TrimOrg(credOrg, service)
-	if namesOnly && (service == "" || service == "*") {
+	if service == "*" {
+		service = ""
+	}
+	if namesOnly && service == "" {
 		// Only display the names
-		if service == "*" {
-			service = ""
-		}
 		var resp GetServicesResponse
 		cliutils.ExchangeGet("Exchange", cliutils.GetExchangeUrl(), "orgs/"+svcOrg+"/services"+cliutils.AddSlash(service), cliutils.OrgAndCreds(credOrg, userPw), []int{200, 404}, &resp)
 		services := []string{}


### PR DESCRIPTION
Allow all 'hzn exchange _____ list' commands that take '\<org\>/' as an argument to also take '\<org\>/*' 