### PR TITLE
Issue 980 - Provide node policy author a way to get a skeletal node policy

### DIFF
--- a/cli/exchange/business.go
+++ b/cli/exchange/business.go
@@ -12,6 +12,31 @@ import (
 	"net/http"
 )
 
+const BUSINESS_POLICY_TEMPLATE_OBJECT = `{
+  "label": "",  /* Business policy label. */
+  "description": "",  /* Business policy description. */
+  "service": {
+    "name": "",  /* The name of the service. */
+    "org": "put the $HZN_ORG_ID env var value in here",  /* The org of the service. */
+    "arch": "",  /* Can be omitted. */
+    "serviceVersions": [  /* A list of service versions. */
+      {
+        "version": "",
+        "priority":{}
+      }
+    ]
+  },
+  "properties": [  /* A list of policy properties that describe the object. */
+    {
+      "name": "",
+      "value": nil
+    }
+  ],
+  "constraints": [  /* A list of constraint expressions of the form <property name> <operator> <property value>, separated by boolean operators AND (&&) or OR (||). */
+    ""
+  ]
+}`
+
 //BusinessListPolicy lists all the policies in the org or only the specified policy if one is given
 func BusinessListPolicy(org string, credToUse string, policy string, namesOnly bool) {
 	cliutils.SetWhetherUsingApiKey(credToUse)
@@ -168,4 +193,9 @@ func BusinessRemovePolicy(org string, credToUse string, policy string, force boo
 	} else {
 		fmt.Println("Business policy " + org + "/" + policy + " removed")
 	}
+}
+
+// Display an empty business policy template as an object.
+func BusinessNewPolicy() {
+	fmt.Println(BUSINESS_POLICY_TEMPLATE_OBJECT)
 }

--- a/cli/exchange/service.go
+++ b/cli/exchange/service.go
@@ -19,6 +19,18 @@ import (
 	"strings"
 )
 
+const SERVICE_POLICY_TEMPLATE_OBJECT = `{
+  "properties": [   /* A list of policy properties that describe the object. */
+    {
+      "name": "",
+      "value": nil
+    }
+  ],
+  "constraints": [  /* A list of constraint expressions of the form <property name> <operator> <property value>, separated by boolean operators AND (&&) or OR (||). */
+    ""
+  ]
+}`
+
 type AbstractServiceFile interface {
 	GetOrg() string
 	GetURL() string
@@ -538,4 +550,9 @@ func ServiceRemovePolicy(org string, credToUse string, service string, force boo
 	//remove service policy
 	cliutils.ExchangeDelete("Exchange", cliutils.GetExchangeUrl(), "orgs/"+org+"/services/"+service+"/policy", cliutils.OrgAndCreds(org, credToUse), []int{204, 404})
 	fmt.Println("Service policy removed.")
+}
+
+// Display an empty service policy template as an object.
+func ServiceNewPolicy() {
+	fmt.Println(SERVICE_POLICY_TEMPLATE_OBJECT)
 }

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -219,6 +219,7 @@ Environment Variables:
 	exServiceListPolicyCmd := exServiceCmd.Command("listpolicy", "Display the service policy from the Horizon Exchange.")
 	exServiceListPolicyIdTok := exServiceListPolicyCmd.Flag("service-id-tok", "The Horizon Exchange id and password of the user").Short('n').PlaceHolder("ID:TOK").String()
 	exServiceListPolicyService := exServiceListPolicyCmd.Arg("service", "List policy for this service.").Required().String()
+	exServiceNewPolicyCmd := exServiceCmd.Command("newpolicy", "Display an empty service policy template that can be filled in.")
 	exServiceUpdatePolicyCmd := exServiceCmd.Command("updatepolicy", "Add or replace the service policy in the Horizon Exchange.")
 	exServiceUpdatePolicyIdTok := exServiceUpdatePolicyCmd.Flag("service-id-tok", "The Horizon Exchange ID and password of the user").Short('n').PlaceHolder("ID:TOK").String()
 	exServiceUpdatePolicyService := exServiceUpdatePolicyCmd.Arg("service", "Add or replace policy for this service.").Required().String()
@@ -233,6 +234,7 @@ Environment Variables:
 	exBusinessListPolicyIdTok := exBusinessListPolicyCmd.Flag("id-token", "The Horizon ID and password of the user.").Short('n').PlaceHolder("ID:TOK").String()
 	exBusinessListPolicyLong := exBusinessListPolicyCmd.Flag("long", "Display detailed output about the business policies.").Short('l').Bool()
 	exBusinessListPolicyPolicy := exBusinessListPolicyCmd.Arg("policy", "List just this one policy. Use <org>/<policy> to specify a public policy in another org, or <org>/ to list all of the public policies in another org.").String()
+	exBusinessNewPolicyCmd := exBusinessCmd.Command("new", "Display an empty business policy template that can be filled in.")
 	exBusinessAddPolicyCmd := exBusinessCmd.Command("addpolicy", "Add a new business policy or overwrite an existing policy by the same name in the Horizon Exchange.")
 	exBusinessAddPolicyIdTok := exBusinessAddPolicyCmd.Flag("id-token", "The Horizon ID and password of the user.").Short('n').PlaceHolder("ID:TOK").String()
 	exBusinessAddPolicyPolicy := exBusinessAddPolicyCmd.Arg("policy", "The name of the policy to add or overwrite.").Required().String()
@@ -290,6 +292,7 @@ Environment Variables:
 
 	policyCmd := app.Command("policy", "List and manage policy for this Horizon edge node.")
 	policyListCmd := policyCmd.Command("list", "Display this edge node's policy.")
+	policyNewCmd := policyCmd.Command("new", "Display an empty policy template that can be filled in.")
 	policyUpdateCmd := policyCmd.Command("update", "Update the node's policy. The node's built-in properties will be automatically added if the input policy does not contain them.")
 	policyUpdateInputFile := policyUpdateCmd.Flag("input-file", "The JSON input file name containing the node policy.").Short('f').Required().String()
 	policyPatchCmd := policyCmd.Command("patch", "Add or update node policy properties or overwrite the node policy constraint expression.")
@@ -609,12 +612,16 @@ Environment Variables:
 		exchange.ServiceRemoveAuth(*exOrg, *exUserPw, *exSvcRemAuthSvc, *exSvcRemAuthId)
 	case exServiceListPolicyCmd.FullCommand():
 		exchange.ServiceListPolicy(*exOrg, credToUse, *exServiceListPolicyService)
+	case exServiceNewPolicyCmd.FullCommand():
+		exchange.ServiceNewPolicy()
 	case exServiceUpdatePolicyCmd.FullCommand():
 		exchange.ServiceUpdatePolicy(*exOrg, credToUse, *exServiceUpdatePolicyService, *exServiceUpdatePolicyJsonFile)
 	case exServiceRemovePolicyCmd.FullCommand():
 		exchange.ServiceRemovePolicy(*exOrg, credToUse, *exServiceRemovePolicyService, *exServiceRemovePolicyForce)
 	case exBusinessListPolicyCmd.FullCommand():
 		exchange.BusinessListPolicy(*exOrg, credToUse, *exBusinessListPolicyPolicy, !*exBusinessListPolicyLong)
+	case exBusinessNewPolicyCmd.FullCommand():
+		exchange.BusinessNewPolicy()
 	case exBusinessAddPolicyCmd.FullCommand():
 		exchange.BusinessAddPolicy(*exOrg, credToUse, *exBusinessAddPolicyPolicy, *exBusinessAddPolicyJsonFile)
 	case exBusinessUpdatePolicyCmd.FullCommand():
@@ -637,6 +644,8 @@ Environment Variables:
 		node.List()
 	case policyListCmd.FullCommand():
 		policy.List()
+	case policyNewCmd.FullCommand():
+		policy.New()
 	case policyUpdateCmd.FullCommand():
 		policy.Update(*policyUpdateInputFile)
 	case policyPatchCmd.FullCommand():

--- a/cli/policy/policy.go
+++ b/cli/policy/policy.go
@@ -9,6 +9,18 @@ import (
 	"net/http"
 )
 
+const POLICY_TEMPLATE_OBJECT = `{
+  "properties": [   /* A list of policy properties that describe the object. */
+    {
+      "name": "",
+      "value": nil
+    }
+  ],
+  "constraints": [  /* A list of constraint expressions of the form <property name> <operator> <property value>, separated by boolean operators AND (&&) or OR (||). */
+    ""
+  ]
+}`
+
 func List() {
 	// Get the node policy info
 	nodePolicy := externalpolicy.ExternalPolicy{}
@@ -56,4 +68,9 @@ func Remove(force bool) {
 	cliutils.HorizonDelete("node/policy", []int{200, 204}, false)
 
 	fmt.Println("Horizon node policy deleted.")
+}
+
+// Display an empty policy template as an object.
+func New() {
+	fmt.Println(POLICY_TEMPLATE_OBJECT)
 }


### PR DESCRIPTION
For issue 980:
1. `hzn policy new` will show node policy template:
<img width="1210" alt="Screen Shot 2019-06-07 at 15 34 45" src="https://user-images.githubusercontent.com/49077510/59129097-dae39580-8939-11e9-96cf-5d7ea6bbcec4.png">

2. `hzn exchange business new` will show business policy template:
<img width="1208" alt="Screen Shot 2019-06-07 at 15 34 56" src="https://user-images.githubusercontent.com/49077510/59129122-ed5dcf00-8939-11e9-9312-f84cc48d333c.png">

3. `hzn exchange service newpolicy` will show service policy template:
<img width="1179" alt="Screen Shot 2019-06-07 at 15 35 05" src="https://user-images.githubusercontent.com/49077510/59129150-fc448180-8939-11e9-987a-18c1496d1c14.png">
