### PR TITLE
Issue 891 - hzn sub-cmd to display services in all IBM-type orgs

### DIFF
--- a/cli/exchange/catalog.go
+++ b/cli/exchange/catalog.go
@@ -1,0 +1,109 @@
+package exchange
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/open-horizon/anax/cli/cliutils"
+)
+
+const orgType = "IBM"
+
+type CatalogServiceWithMediumInfo struct {
+	Description	string	`json:"description"`
+	Documentation   string  `json:"documentation"`
+}
+
+type CatalogPatternWithMediumInfo struct {
+        Description     string  `json:"description"`
+}
+
+// List the public service resources for orgType:IBM.
+// The userPw can be the userId:password auth or the nodeId:token auth.
+func CatalogServiceList(credOrg string, userPw string, displayShort bool, displayLong bool) {
+	cliutils.SetWhetherUsingApiKey(userPw)
+	if displayShort && displayLong {
+		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "Flags -s and -l are mutually exclusive.")
+	}
+
+	var resp GetServicesResponse
+	cliutils.ExchangeGet("Exchange", cliutils.GetExchangeUrl(), "catalog/services?orgtype="+orgType, cliutils.OrgAndCreds(credOrg, userPw), []int{200}, &resp)
+
+	if displayLong {
+		jsonBytes, err := json.MarshalIndent(resp.Services, "", cliutils.JSON_INDENT)
+		if err != nil {
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange catalog servicelist -l' output: %v", err)
+		}
+		fmt.Printf("%s\n", jsonBytes)
+	} else if displayShort {
+		serviceNames := []string{}
+		for k := range resp.Services {
+			serviceNames = append(serviceNames, k)
+		}
+		jsonBytes, err := json.MarshalIndent(serviceNames, "", cliutils.JSON_INDENT)
+		if err != nil {
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange catalog servicelist -s' output: %v", err)
+		}
+		fmt.Printf("%s\n", jsonBytes)
+	} else {
+		// display medium information about public services
+		var servicesMedium = make(map[string]CatalogServiceWithMediumInfo)
+		for k, v:= range resp.Services {
+			catalogServiceMedium := CatalogServiceWithMediumInfo {
+				Description: v.Description,
+				Documentation : v.Documentation,
+			}
+			servicesMedium[k] = catalogServiceMedium
+		}
+		jsonBytes, err := json.MarshalIndent(servicesMedium, "", cliutils.JSON_INDENT)
+                if err != nil {
+                        cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange catalog servicelist' output: %v", err)
+                }
+                fmt.Printf("%s\n", jsonBytes)
+
+	}
+
+}
+
+// List the public pattern resources for orgType:IBM.
+func CatalogPatternList(credOrg string, userPw string, displayShort bool, displayLong bool) {
+	cliutils.SetWhetherUsingApiKey(userPw)
+        if displayShort && displayLong {
+                cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "Flags -s and -l are mutually exclusive.")
+        }
+
+	var resp ExchangePatterns
+	cliutils.ExchangeGet("Exchange", cliutils.GetExchangeUrl(), "catalog/patterns?orgtype="+orgType, cliutils.OrgAndCreds(credOrg, userPw), []int{200}, &resp)
+
+	if displayLong {
+                jsonBytes, err := json.MarshalIndent(resp.Patterns, "", cliutils.JSON_INDENT)
+                if err != nil {
+                        cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange catalog patternlist -l' output: %v", err)
+                }
+                fmt.Printf("%s\n", jsonBytes)
+        } else if displayShort {
+                patternNames := []string{}
+                for k := range resp.Patterns {
+                        patternNames = append(patternNames, k)
+                }
+                jsonBytes, err := json.MarshalIndent(patternNames, "", cliutils.JSON_INDENT)
+                if err != nil {
+                        cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange catalog patternlist -s' output: %v", err)
+                }
+                fmt.Printf("%s\n", jsonBytes)
+        } else {
+                // display medium information about public patterns
+                var patternsMedium = make(map[string]CatalogPatternWithMediumInfo)
+                for k, v:= range resp.Patterns {
+                        catalogPatternMedium := CatalogPatternWithMediumInfo {
+                                Description: v.Description,
+                        }
+                        patternsMedium[k] = catalogPatternMedium
+                }
+                jsonBytes, err := json.MarshalIndent(patternsMedium, "", cliutils.JSON_INDENT)
+                if err != nil {
+                        cliutils.Fatal(cliutils.JSON_PARSING_ERROR, "failed to marshal 'hzn exchange catalog patternlist' output: %v", err)
+                }
+                fmt.Printf("%s\n", jsonBytes)
+
+        }
+}

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -249,6 +249,14 @@ Environment Variables:
 	exBusinessRemovePolicyForce := exBusinessRemovePolicyCmd.Flag("force", "Skip the 'are you sure?' prompt.").Short('f').Bool()
 	exBusinessRemovePolicyPolicy := exBusinessRemovePolicyCmd.Arg("policy", "The name of the business policy to be removed.").Required().String()
 
+	exCatalogCmd := exchangeCmd.Command("catalog", "List all public services/patterns in all orgs that have orgType: IBM.")
+	exCatalogServiceListCmd := exCatalogCmd.Command("servicelist", "Display all public services in all orgs that have orgType: IBM.")
+	exCatalogServiceListShort := exCatalogServiceListCmd.Flag("short", "Only display org (IBM) and service names.").Short('s').Bool()
+	exCatalogServiceListLong := exCatalogServiceListCmd.Flag("long", "Display detailed output about public services in all orgs that have orgType: IBM.").Short('l').Bool()
+	exCatalogPatternListCmd := exCatalogCmd.Command("patternlist", "Display all public patterns in all orgs that have orgType: IBM. ")
+	exCatalogPatternListShort := exCatalogPatternListCmd.Flag("short", "Only display org (IBM) and pattern names.").Short('s').Bool()
+	exCatalogPatternListLong := exCatalogPatternListCmd.Flag("long", "Display detailed output about public patterns in all orgs that have orgType: IBM.").Short('l').Bool()
+
 	regInputCmd := app.Command("reginput", "Create an input file template for this pattern that can be used for the 'hzn register' command (once filled in). This examines the services that the specified pattern uses, and determines the node owner input that is required for them.")
 	regInputNodeIdTok := regInputCmd.Flag("node-id-tok", "The Horizon exchange node ID and token (it must already exist).").Short('n').PlaceHolder("ID:TOK").Required().String()
 	regInputInputFile := regInputCmd.Flag("input-file", "The JSON input template file name that should be created. This file will contain placeholders for you to fill in user input values.").Short('f').Required().String()
@@ -628,6 +636,10 @@ Environment Variables:
 		exchange.BusinessUpdatePolicy(*exOrg, credToUse, *exBusinessUpdatePolicyPolicy, *exBusinessUpdatePolicyAttribute, *exBusinessUpdatePolicyValue)
 	case exBusinessRemovePolicyCmd.FullCommand():
 		exchange.BusinessRemovePolicy(*exOrg, credToUse, *exBusinessRemovePolicyPolicy, *exBusinessRemovePolicyForce)
+	case exCatalogServiceListCmd.FullCommand():
+		exchange.CatalogServiceList(*exOrg, *exUserPw, *exCatalogServiceListShort, *exCatalogServiceListLong)
+	case exCatalogPatternListCmd.FullCommand():
+		exchange.CatalogPatternList(*exOrg, *exUserPw, *exCatalogPatternListShort, *exCatalogPatternListLong)
 	case regInputCmd.FullCommand():
 		register.CreateInputFile(*regInputOrg, *regInputPattern, *regInputArch, *regInputNodeIdTok, *regInputInputFile)
 	case registerCmd.FullCommand():


### PR DESCRIPTION
1. For catalog servicelist
  - `hzn exchange catalog servicelist -s`
<img width="651" alt="Screen Shot 2019-06-10 at 13 32 14" src="https://user-images.githubusercontent.com/49077510/59214156-7d8f5480-8b84-11e9-98e8-6d150d50da57.png">

  - `hzn exchange catalog servicelist`
<img width="848" alt="Screen Shot 2019-06-10 at 13 32 33" src="https://user-images.githubusercontent.com/49077510/59214168-841dcc00-8b84-11e9-8118-abb25be692fc.png">

  - `hzn exchange catalog servicelist -l`
<img width="668" alt="Screen Shot 2019-06-10 at 13 33 04" src="https://user-images.githubusercontent.com/49077510/59214178-88e28000-8b84-11e9-86b2-b0f89e914669.png">

  - `hzn exchange catalog servicelist -s -l`
<img width="658" alt="Screen Shot 2019-06-10 at 13 35 05" src="https://user-images.githubusercontent.com/49077510/59214194-939d1500-8b84-11e9-968c-67a5d04d6d8d.png">

2. For catalog patternlist
  - `hzn exchange catalog patternlist -s`
<img width="627" alt="Screen Shot 2019-06-10 at 13 36 22" src="https://user-images.githubusercontent.com/49077510/59214383-fdb5ba00-8b84-11e9-9f05-9ebfbde12d89.png">

  - `hzn exchange catalog patternlist`
<img width="740" alt="Screen Shot 2019-06-10 at 13 36 32" src="https://user-images.githubusercontent.com/49077510/59214394-04443180-8b85-11e9-876b-63fb658509ab.png">

  - `hzn exchange catalog patternlist -l`
<img width="697" alt="Screen Shot 2019-06-10 at 13 37 31" src="https://user-images.githubusercontent.com/49077510/59214410-0a3a1280-8b85-11e9-9f8b-02ce9bc0f06d.png">

  - `hzn exchange catalog patternlist -s -l`
<img width="685" alt="Screen Shot 2019-06-10 at 13 37 45" src="https://user-images.githubusercontent.com/49077510/59214429-102ff380-8b85-11e9-8e82-617e792fb1a3.png">

