### PR TITLE
Issue 1018 - hzn exchange business removepolicy should support input …

### DIFF
--- a/cli/exchange/business.go
+++ b/cli/exchange/business.go
@@ -200,6 +200,9 @@ func BusinessRemovePolicy(org string, credToUse string, policy string, force boo
 		cliutils.ConfirmRemove("Are you sure you want to remove business policy " + policy + " for org " + org + " from the Horizon Exchange?")
 	}
 
+	//check if policy name is passed in as <org>/<service>
+	org, policy = cliutils.TrimOrg(org, policy)
+
 	//remove policy
 	httpCode := cliutils.ExchangeDelete("Exchange", cliutils.GetExchangeUrl(), "orgs/"+org+"/business/policies"+cliutils.AddSlash(policy), cliutils.OrgAndCreds(org, credToUse), []int{204, 404})
 	if httpCode == 404 {


### PR DESCRIPTION
…for both businessPolicyName and org/businessPolicyName
1. `hzn exchange business removepolicy <org>/<businessPolicyName>` works
<img width="1075" alt="Screen Shot 2019-06-14 at 10 47 27" src="https://user-images.githubusercontent.com/49077510/59517680-11696500-8e92-11e9-9053-5462edf7452c.png">


2. `hzn exchange business removepolicy <businessPolicyName>` works and wrong format got error message
<img width="1061" alt="Screen Shot 2019-06-14 at 10 47 47" src="https://user-images.githubusercontent.com/49077510/59517699-19290980-8e92-11e9-917c-981226f14d49.png">

