### PR TITLE
Convert CSS container to run as non-root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ FSS_REGISTRY ?= "dockerhub"
 # The CSS and its production container. This container is NOT used by hzn dev.
 CSS_EXECUTABLE := css/cloud-sync-service
 CSS_CONTAINER_DIR := css
-CSS_IMAGE_VERSION ?= 1.0.10$(BRANCH_NAME)
+CSS_IMAGE_VERSION ?= 1.0.11$(BRANCH_NAME)
 CSS_IMAGE_BASE = image/cloud-sync-service
 CSS_IMAGE_NAME = openhorizon/$(arch)_cloud-sync-service
 CSS_IMAGE = $(CSS_IMAGE_NAME):$(CSS_IMAGE_VERSION)

--- a/css/image/cloud-sync-service-amd64/Dockerfile
+++ b/css/image/cloud-sync-service-amd64/Dockerfile
@@ -1,7 +1,12 @@
 FROM alpine:3.6
 
-RUN apk --no-cache add libcrypto1.0 libssl1.0 ca-certificates 
+RUN addgroup -g 1000 -S cssuser && adduser -u 1000 -S cssuser -G cssuser \
+        && apk --no-cache add libcrypto1.0 libssl1.0 ca-certificates
 
-ADD cloud-sync-service /cloud-sync-service/
+ADD cloud-sync-service /home/cssuser/cloud-sync-service
 
-CMD ["/cloud-sync-service/cloud-sync-service"]
+RUN mkdir /var/edge-sync-service && chown -R cssuser:cssuser /var/edge-sync-service
+
+USER cssuser
+
+CMD ["/home/cssuser/cloud-sync-service"]


### PR DESCRIPTION
Runs the CSS in the container as a non-root user.

note: This will require the css to listen on a port above 1024 as this is a requirement to run as non-root.