### PR TITLE
Issue 1047 - Service policy should be optionally published when a ser…

### DIFF
--- a/cli/exchange/service.go
+++ b/cli/exchange/service.go
@@ -215,7 +215,7 @@ func ServiceList(credOrg, userPw, service string, namesOnly bool) {
 }
 
 // ServicePublish signs the MS def and puts it in the exchange
-func ServicePublish(org, userPw, jsonFilePath, keyFilePath, pubKeyFilePath string, dontTouchImage bool, pullImage bool, registryTokens []string, overwrite bool) {
+func ServicePublish(org, userPw, jsonFilePath, keyFilePath, pubKeyFilePath string, dontTouchImage bool, pullImage bool, registryTokens []string, overwrite bool, servicePolicyFilePath string) {
 	if dontTouchImage && pullImage {
 		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, "Flags -I and -P are mutually exclusive.")
 	}
@@ -236,6 +236,14 @@ func ServicePublish(org, userPw, jsonFilePath, keyFilePath, pubKeyFilePath strin
 	svcFile.SupportVersionRange()
 
 	svcFile.SignAndPublish(org, userPw, jsonFilePath, keyFilePath, pubKeyFilePath, dontTouchImage, pullImage, registryTokens, !overwrite)
+
+	// create service policy if servicePolicyFilePath is defined
+	if servicePolicyFilePath != "" {
+		serviceAddPolicyService := fmt.Sprintf("%s/%s_%s_%s", svcFile.Org, svcFile.URL, svcFile.Version, svcFile.Arch) //svcFile.URL + "_" + svcFile.Version + "_" +
+		fmt.Println("Adding service policy for service: ", serviceAddPolicyService)
+		ServiceAddPolicy(org, userPw, serviceAddPolicyService, servicePolicyFilePath)
+		fmt.Println("Service policy added for service: ", serviceAddPolicyService)
+	}
 }
 
 // Sign and publish the service definition. This is a function that is reusable across different hzn commands.

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -208,6 +208,7 @@ Environment Variables:
 	exSvcPubPullImage := exServicePublishCmd.Flag("pull-image", "Use the image from the image repository. It will pull the image from the image repository and overwrite the local image if exists. This flag is mutually exclusive with -I.").Short('P').Bool()
 	exSvcRegistryTokens := exServicePublishCmd.Flag("registry-token", "Docker registry domain and auth that should be stored with the service, to enable the Horizon edge node to access the service's docker images. This flag can be repeated, and each flag should be in the format: registry:user:token").Short('r').Strings()
 	exSvcOverwrite := exServicePublishCmd.Flag("overwrite", "Overwrite the existing version if the service exists in the exchange. It will skip the 'do you want to overwrite' prompt.").Short('O').Bool()
+	exSvcPolicyFile := exServicePublishCmd.Flag("service-policy-file", "The path of the service policy JSON file to be used for the service to be published. This flag is optional").Short('p').String()
 	exServiceVerifyCmd := exServiceCmd.Command("verify", "Verify the signatures of a service resource in the Horizon Exchange.")
 	exVerService := exServiceVerifyCmd.Arg("service", "The service to verify.").Required().String()
 	exServiceVerifyNodeIdTok := exServiceVerifyCmd.Flag("node-id-tok", "The Horizon Exchange node ID and token to be used as credentials to query and modify the node resources if -u flag is not specified. HZN_EXCHANGE_NODE_AUTH will be used as a default for -n. If you don't prepend it with the node's org, it will automatically be prepended with the -o value.").Short('n').PlaceHolder("ID:TOK").String()
@@ -638,7 +639,7 @@ Environment Variables:
 	case exServiceListCmd.FullCommand():
 		exchange.ServiceList(*exOrg, credToUse, *exService, !*exServiceLong)
 	case exServicePublishCmd.FullCommand():
-		exchange.ServicePublish(*exOrg, *exUserPw, *exSvcJsonFile, *exSvcPrivKeyFile, *exSvcPubPubKeyFile, *exSvcPubDontTouchImage, *exSvcPubPullImage, *exSvcRegistryTokens, *exSvcOverwrite)
+		exchange.ServicePublish(*exOrg, *exUserPw, *exSvcJsonFile, *exSvcPrivKeyFile, *exSvcPubPubKeyFile, *exSvcPubDontTouchImage, *exSvcPubPullImage, *exSvcRegistryTokens, *exSvcOverwrite, *exSvcPolicyFile)
 	case exServiceVerifyCmd.FullCommand():
 		exchange.ServiceVerify(*exOrg, credToUse, *exVerService, *exSvcPubKeyFile)
 	case exSvcDelCmd.FullCommand():


### PR DESCRIPTION
…vice is published
1. add `-p path/to/service.policy.json` to service publish command, it will add service policy when publish a service
<img width="1680" alt="Screen Shot 2019-06-19 at 16 53 48" src="https://user-images.githubusercontent.com/49077510/59799691-e0829900-92b2-11e9-9138-91b985e752c4.png">

2. Then list the service policy for the new published service:
<img width="1105" alt="Screen Shot 2019-06-19 at 16 54 05" src="https://user-images.githubusercontent.com/49077510/59799713-f09a7880-92b2-11e9-8e67-65804d72e36a.png">

3. When given wrong service policy path/fileName, it will still publish the service, but without service policy
<img width="1614" alt="Screen Shot 2019-06-19 at 16 57 44" src="https://user-images.githubusercontent.com/49077510/59800072-ad8cd500-92b3-11e9-93ab-5a3f7a5f409d.png">

