### PR TITLE
Issue 1074 -  hzn userinput add/update should verify the user input before saving it

### DIFF
--- a/api/api_node.go
+++ b/api/api_node.go
@@ -426,9 +426,10 @@ func (a *API) nodeuserinput(w http.ResponseWriter, r *http.Request) {
 		}
 		getDevice := exchange.GetHTTPDeviceHandler(a)
 		patchDevice := exchange.GetHTTPPatchDeviceHandler(a)
+		getService := exchange.GetHTTPServiceHandler(a)
 
 		// Validate and create or update the node policy.
-		errHandled, cfg, msgs := UpdateNodeUserInput(nodeUserInput, update_node_userinput_error_handler, getDevice, patchDevice, a.db)
+		errHandled, cfg, msgs := UpdateNodeUserInput(nodeUserInput, update_node_userinput_error_handler, getDevice, patchDevice, getService, a.db)
 		if errHandled {
 			return
 		}
@@ -463,9 +464,10 @@ func (a *API) nodeuserinput(w http.ResponseWriter, r *http.Request) {
 
 		getDevice := exchange.GetHTTPDeviceHandler(a)
 		patchDevice := exchange.GetHTTPPatchDeviceHandler(a)
+		getService := exchange.GetHTTPServiceHandler(a)
 
 		//Validate the patch and update the policy
-		errHandled, cfg, msgs := PatchNodeUserInput(nodeUserInput, patch_node_userinput_error_handler, getDevice, patchDevice, a.db)
+		errHandled, cfg, msgs := PatchNodeUserInput(nodeUserInput, patch_node_userinput_error_handler, getDevice, patchDevice, getService, a.db)
 
 		if errHandled {
 			return

--- a/api/path_node_userinput.go
+++ b/api/path_node_userinput.go
@@ -241,7 +241,7 @@ func isCorrectType(policyInputValue interface{}, serviceInputType string) (bool,
 		if isFloat64(policyInputValue) {
 			return true, nil
 		}
-	case "boolean":
+	case "boolean", "bool":
 		if isBoolean(policyInputValue) {
 			return true, nil
 		}

--- a/api/path_node_userinput.go
+++ b/api/path_node_userinput.go
@@ -4,11 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"github.com/boltdb/bolt"
+	"github.com/golang/glog"
 	"github.com/open-horizon/anax/events"
 	"github.com/open-horizon/anax/exchange"
 	"github.com/open-horizon/anax/exchangesync"
 	"github.com/open-horizon/anax/persistence"
 	"github.com/open-horizon/anax/policy"
+	"github.com/open-horizon/anax/semanticversion"
+	"strings"
 )
 
 // Return an empty user input object or the object that's in the local database.
@@ -28,6 +31,7 @@ func UpdateNodeUserInput(userInput []policy.UserInput,
 	errorhandler DeviceErrorHandler,
 	getDevice exchange.DeviceHandler,
 	patchDevice exchange.PatchDeviceHandler,
+	getService exchange.ServiceHandler,
 	db *bolt.DB) (bool, []policy.UserInput, []*events.NodeUserInputMessage) {
 
 	// Check for the device in the local database. If there are errors, they will be written
@@ -37,6 +41,17 @@ func UpdateNodeUserInput(userInput []policy.UserInput,
 		return errorhandler(nil, NewSystemError(fmt.Sprintf("Unable to read node object, error %v", err))), nil, nil
 	} else if pDevice == nil {
 		return errorhandler(nil, NewNotFoundError("Exchange registration not recorded. Complete account and node registration with an exchange and then record node registration using this API's /node path.", "node")), nil, nil
+	}
+
+	// verify userinput: 1) service exist, 2) variables definied in the service, otherwise return true but give warning message 3) values have correct type
+	validated := false
+	for _, u := range userInput {
+		validated, err = ValidateUserInput(u, getService)
+		if !validated {
+			return errorhandler(nil, NewSystemError(fmt.Sprintf("Failed to validate node userInput, error: %v", err))), nil, nil
+		} else if err != nil { // validate == true, but give back warning error message
+			glog.Warningf(logString(fmt.Sprintf("Warning message: Userinput validated: %v. error: %v \n", validated, err)))
+		}
 	}
 
 	if changedSvcs, err := exchangesync.UpdateNodeUserInput(pDevice, db, userInput, getDevice, patchDevice); err != nil {
@@ -54,6 +69,7 @@ func PatchNodeUserInput(patchObject []policy.UserInput,
 	errorhandler DeviceErrorHandler,
 	getDevice exchange.DeviceHandler,
 	patchDevice exchange.PatchDeviceHandler,
+	getService exchange.ServiceHandler,
 	db *bolt.DB) (bool, []policy.UserInput, []*events.NodeUserInputMessage) {
 
 	pDevice, err := persistence.FindExchangeDevice(db)
@@ -61,6 +77,17 @@ func PatchNodeUserInput(patchObject []policy.UserInput,
 		return errorhandler(nil, NewSystemError(fmt.Sprintf("Unable to read node object, error %v", err))), nil, nil
 	} else if pDevice == nil {
 		return errorhandler(nil, NewNotFoundError("Exchange registration not recorded. Complete account and node registration with an exchange and then record node registration using this API's /node path.", "node")), nil, nil
+	}
+
+	// verify userinput: 1) service exist, 2) variables definied in the service, otherwise return true but give warning message 3) values have correct type
+	validated := false
+	for _, u := range patchObject {
+		validated, err = ValidateUserInput(u, getService)
+		if !validated {
+			return errorhandler(nil, NewSystemError(fmt.Sprintf("Failed to validate node userInput, error: %v", err))), nil, nil
+		} else if err != nil { // validate == true, but give back warning error message
+			glog.Warningf(logString(fmt.Sprintf("Warning message: Userinput validated: %v. error: %v \n", validated, err)))
+		}
 	}
 
 	if err := exchangesync.PatchNodeUserInput(pDevice, db, patchObject, getDevice, patchDevice); err != nil {
@@ -114,4 +141,149 @@ func DeleteNodeUserInput(errorhandler DeviceErrorHandler, db *bolt.DB,
 	}
 	nodeUserInputUpdated := events.NewNodeUserInputMessage(events.UPDATE_NODE_USERINPUT, *chnagedSvcSpecs)
 	return false, []*events.NodeUserInputMessage{nodeUserInputUpdated}
+}
+
+var logString = func(v interface{}) string {
+	return fmt.Sprintf("path_node_userinput %v", v)
+}
+
+// Validate 1) service exist; 2) variables defined in the service; 3) values have correct type
+func ValidateUserInput(userInput policy.UserInput, getService exchange.ServiceHandler) (bool, error) {
+	glog.V(3).Infof(logString(fmt.Sprintf("Start validate userinput .... \n")))
+	serviceOrg := userInput.ServiceOrgid
+	serviceUrl := userInput.ServiceUrl
+	serviceVersionRange := userInput.ServiceVersionRange
+	serviceArch := userInput.ServiceArch
+
+	// The versionRange field is checked for valid characters by the Version_Expression_Factory, it has a very
+	// specific syntax and allows a subset of normally valid characters.
+
+	// Use a default sensor version that allows all version if not specified.
+	if &userInput.ServiceVersionRange == nil || userInput.ServiceVersionRange == "" {
+		def := "0.0.0"
+		serviceVersionRange = def
+	}
+
+	// Convert the sensor version to a version expression.
+	vExp, err := semanticversion.Version_Expression_Factory(serviceVersionRange)
+	var errorString string
+	if err != nil {
+		errorString = fmt.Sprintf("versionRange %v cannot be converted to a version expression, error %v", userInput.ServiceVersionRange, err)
+		return false, errors.New(errorString)
+	}
+
+	// service exist
+	var sdef *exchange.ServiceDefinition
+	sdef, _, err = getService(serviceUrl, serviceOrg, vExp.Get_expression(), serviceArch)
+	if sdef == nil {
+		errorString = fmt.Sprintf("Service not exist for org: %v, url: %v, version: %v, arch: %v, get error: %v \n", serviceOrg, serviceUrl, vExp.Get_expression, serviceArch, err)
+		return false, errors.New(errorString)
+	} else if err != nil {
+		errorString = fmt.Sprintf("Error from get exchange service: %v \n", err)
+		return false, errors.New(errorString)
+	}
+
+	// compare ServiceDefinition.Userinput (array) with userInput.Inputs (array)
+	serviceUserInputs := sdef.UserInputs
+	policyUserInputs := userInput.Inputs
+
+	serviceUserinputsMap := make(map[string]exchange.UserInput)
+	var serviceInputName string
+	var serviceInput exchange.UserInput
+
+	for _, serviceInput = range serviceUserInputs {
+		serviceInputName = serviceInput.Name
+		serviceUserinputsMap[serviceInputName] = serviceInput
+	}
+
+	// the variables in userInput.Inputs are defined in the service, if not, return true with warning message, check values are correct types
+	var policyInputName string
+	var policyInputValue interface{}
+	var ok bool
+	var inputNameNotDefinedInService []string
+
+	for _, policyInput := range policyUserInputs {
+		policyInputName = policyInput.Name
+		policyInputValue = policyInput.Value
+
+		serviceInput, ok = serviceUserinputsMap[policyInputName]
+		if !ok {
+			// give back a warning with this errorString
+			inputNameNotDefinedInService = append(inputNameNotDefinedInService, policyInputName)
+		} else {
+			typeValidated, err := isCorrectType(policyInputValue, serviceInput.Type)
+			if !typeValidated {
+				return false, err
+			}
+		}
+
+	}
+
+	if len(inputNameNotDefinedInService) != 0 {
+		errorString = fmt.Sprintf("The following variables are not defined in userInput for service in its highest version: %v \n", inputNameNotDefinedInService)
+		return true, errors.New(errorString)
+	}
+
+	return true, nil
+}
+
+func isCorrectType(policyInputValue interface{}, serviceInputType string) (bool, error) {
+	switch strings.ToLower(serviceInputType) {
+	case "string":
+		if isString(policyInputValue) {
+			return true, nil
+		}
+	case "int":
+		if isInt(policyInputValue) {
+			return true, nil
+		}
+	case "float":
+		if isFloat64(policyInputValue) {
+			return true, nil
+		}
+	case "boolean":
+		if isBoolean(policyInputValue) {
+			return true, nil
+		}
+	}
+	err := errors.New(fmt.Sprintf("Input value %v in userinput is not the correct type, should be %v", policyInputValue, serviceInputType))
+	return false, err
+}
+
+func isInt(x interface{}) bool {
+	switch x.(type) {
+	case int:
+		return true
+	default:
+		return false
+	}
+}
+
+func isFloat64(x interface{}) bool {
+	switch x.(type) {
+	case float64:
+		return true
+	default:
+		return false
+	}
+}
+
+// This function checks the type of the input interface object to see if it's a string.
+func isString(x interface{}) bool {
+	switch x.(type) {
+	case string:
+		return true
+	default:
+		return false
+	}
+}
+
+// This function checks the type of the input interface object to see if it's a boolean.
+func isBoolean(x interface{}) bool {
+	switch x.(type) {
+	case bool:
+		return true
+	default:
+		return false
+	}
 }

--- a/test/gov/gpstest_apireg.sh
+++ b/test/gov/gpstest_apireg.sh
@@ -13,7 +13,7 @@ echo -e "Pattern is set to $PATTERN"
     {
       "serviceOrgid": "IBM",
       "serviceUrl": "https://bluehorizon.network/service-gps",
-      "serviceArch": "amd64",
+      "serviceArch": "",
       "serviceVersionRange": "2.0.3",
       "inputs": [
         {

--- a/test/gov/gpstest_apireg.sh
+++ b/test/gov/gpstest_apireg.sh
@@ -13,7 +13,7 @@ echo -e "Pattern is set to $PATTERN"
     {
       "serviceOrgid": "IBM",
       "serviceUrl": "https://bluehorizon.network/service-gps",
-      "serviceArch": "",
+      "serviceArch": "amd64",
       "serviceVersionRange": "2.0.3",
       "inputs": [
         {

--- a/test/gov/pws_apireg.sh
+++ b/test/gov/pws_apireg.sh
@@ -9,7 +9,7 @@ then
     {
       "serviceOrgid": "e2edev@somecomp.com",
       "serviceUrl": "https://bluehorizon.network/services/weather",
-      "serviceArch": "amd64",
+      "serviceArch": "",
       "serviceVersionRange": "1.5.0",
       "inputs": [
         {

--- a/test/gov/pws_apireg.sh
+++ b/test/gov/pws_apireg.sh
@@ -9,7 +9,7 @@ then
     {
       "serviceOrgid": "e2edev@somecomp.com",
       "serviceUrl": "https://bluehorizon.network/services/weather",
-      "serviceArch": "",
+      "serviceArch": "amd64",
       "serviceVersionRange": "1.5.0",
       "inputs": [
         {


### PR DESCRIPTION
When service does not exist in the exchange:
<img width="1604" alt="Screen Shot 2019-07-08 at 16 15 15" src="https://user-images.githubusercontent.com/49077510/60839695-c6debe00-a19b-11e9-8c67-e20dbc7274a9.png">
<img width="1606" alt="Screen Shot 2019-07-08 at 16 15 29" src="https://user-images.githubusercontent.com/49077510/60839697-c6debe00-a19b-11e9-91bf-badd3caa42c2.png">
<img width="1604" alt="Screen Shot 2019-07-08 at 16 16 13" src="https://user-images.githubusercontent.com/49077510/60839698-c6debe00-a19b-11e9-81eb-515ed9fb8a15.png">

When given an userinput variable that doesn't define in the service, show a warning message in log but still save the userinput:
<img width="1604" alt="Screen Shot 2019-07-08 at 16 16 29" src="https://user-images.githubusercontent.com/49077510/60839769-f261a880-a19b-11e9-9333-a47c2deec5e5.png">

When given a wrong type of userinput variables, show errors:
<img width="1289" alt="Screen Shot 2019-07-08 at 16 18 56" src="https://user-images.githubusercontent.com/49077510/60839855-2c32af00-a19c-11e9-8e5a-c80f8f1bba45.png">
<img width="1291" alt="Screen Shot 2019-07-08 at 16 19 24" src="https://user-images.githubusercontent.com/49077510/60839856-2c32af00-a19c-11e9-97d0-42177e9f3cea.png">

Support for list of strings:
<img width="996" alt="Screen Shot 2019-07-09 at 11 54 45" src="https://user-images.githubusercontent.com/49077510/60904389-f98ec200-a240-11e9-8d32-05db48ee7b1d.png">
<img width="1596" alt="Screen Shot 2019-07-09 at 11 54 54" src="https://user-images.githubusercontent.com/49077510/60904390-f98ec200-a240-11e9-874b-9f874e1ade76.png">

Warning log updated:
<img width="1519" alt="Screen Shot 2019-07-09 at 11 55 45" src="https://user-images.githubusercontent.com/49077510/60904423-07444780-a241-11e9-96be-b73849667267.png">




