### PR TITLE
Issue #1071 - When node loses connectivity to the exchange, event log…

### DIFF
--- a/api/path_node_userinput.go
+++ b/api/path_node_userinput.go
@@ -289,8 +289,8 @@ func isString(x interface{}) bool {
 
 func isStringList(x interface{}) bool {
 	switch t := x.(type) {
-	case []interface {}:
-		for _,n := range t {
+	case []interface{}:
+		for _, n := range t {
 			if !isString(n) {
 				return false
 			}

--- a/eventlog/eventlog_manager.go
+++ b/eventlog/eventlog_manager.go
@@ -87,3 +87,17 @@ func LogExchangeEvent(db *bolt.DB, severity, message, event_code, exchange_url s
 func GetEventLogs(db *bolt.DB, all_logs bool, selectors map[string][]persistence.Selector) ([]persistence.EventLog, error) {
 	return persistence.FindEventLogsWithSelectors(db, all_logs, selectors)
 }
+
+type EventLogByTimestamp []persistence.EventLog
+
+func (s EventLogByTimestamp) Len() int {
+	return len(s)
+}
+
+func (s EventLogByTimestamp) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s EventLogByTimestamp) Less(i, j int) bool {
+	return s[i].Timestamp < s[j].Timestamp
+}


### PR DESCRIPTION
… is filled up with error msgs

There are two messages from the agreement worker that clog up the eventlog when the node is disconnected. 
When either of these 2 functions fails and logs an error, the worker will check the last 3 entries in eventlog. If these are all network errors, the worker is offline and logging will be curtailed until either of the 2 functions succeeds. 