### PR TITLE
Issue 783 - 'hzn register' handle node pattern defined in the exchange

### DIFF
--- a/api/api_node.go
+++ b/api/api_node.go
@@ -62,6 +62,7 @@ func (a *API) node(w http.ResponseWriter, r *http.Request) {
 		patternHandler := exchange.GetHTTPExchangePatternHandlerWithContext(a.Config)
 		versionHandler := exchange.GetHTTPExchangeVersionHandler(a.Config)
 		patchDeviceHandler := exchange.GetHTTPPatchDeviceHandler2(a.Config)
+		getDeviceHandler := exchange.GetHTTPDeviceHandler2(a.Config)
 
 		create_device_error_handler := func(err error) bool {
 			dev_id := ""
@@ -73,7 +74,7 @@ func (a *API) node(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Validate and create the new device registration.
-		errHandled, device, exDev := CreateHorizonDevice(&newDevice, create_device_error_handler, orgHandler, patternHandler, versionHandler, patchDeviceHandler, a.em, a.db)
+		errHandled, device, exDev := CreateHorizonDevice(&newDevice, create_device_error_handler, orgHandler, patternHandler, versionHandler, patchDeviceHandler, getDeviceHandler, a.em, a.db)
 		if errHandled {
 			return
 		}

--- a/api/path_node_test.go
+++ b/api/path_node_test.go
@@ -130,7 +130,7 @@ func Test_CreateHorizonDevice_NoDeviceid(t *testing.T) {
 	var myError error
 	errorhandler := GetPassThroughErrorHandler(&myError)
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getDummyDeviceHandler(), events.NewEventStateManager(), db)
 
 	if !errHandled {
 		t.Errorf("expected error")
@@ -162,7 +162,7 @@ func Test_CreateHorizonDevice_IllegalId(t *testing.T) {
 	var myError error
 	errorhandler := GetPassThroughErrorHandler(&myError)
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getDummyDeviceHandler(), events.NewEventStateManager(), db)
 
 	if !errHandled {
 		t.Errorf("expected error")
@@ -193,7 +193,7 @@ func Test_CreateHorizonDevice_IllegalOrg(t *testing.T) {
 	var myError error
 	errorhandler := GetPassThroughErrorHandler(&myError)
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getDummyDeviceHandler(), events.NewEventStateManager(), db)
 
 	if !errHandled {
 		t.Errorf("expected error")
@@ -224,7 +224,7 @@ func Test_CreateHorizonDevice_IllegalPattern(t *testing.T) {
 	var myError error
 	errorhandler := GetPassThroughErrorHandler(&myError)
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getDummyDeviceHandler(), events.NewEventStateManager(), db)
 
 	if !errHandled {
 		t.Errorf("expected error")
@@ -256,7 +256,7 @@ func Test_CreateHorizonDevice_IllegalName(t *testing.T) {
 	var myError error
 	errorhandler := GetPassThroughErrorHandler(&myError)
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getDummyDeviceHandler(), events.NewEventStateManager(), db)
 
 	if !errHandled {
 		t.Errorf("expected error")
@@ -287,7 +287,7 @@ func Test_CreateHorizonDevice_IllegalToken(t *testing.T) {
 	var myError error
 	errorhandler := GetPassThroughErrorHandler(&myError)
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getDummyDeviceHandler(), events.NewEventStateManager(), db)
 
 	if !errHandled {
 		t.Errorf("expected error")
@@ -320,7 +320,7 @@ func Test_CreateHorizonDevice_WrongExchangeVersion(t *testing.T) {
 		return "0.1.1", nil
 	}
 
-	errHandled, _, _ := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getExchangeVersion, getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, _, _ := CreateHorizonDevice(hd, errorhandler, getDummyGetOrg(), getDummyGetPatternsWithContext(), getExchangeVersion, getDummyPatchDeviceHandler(), getDummyDeviceHandler(), events.NewEventStateManager(), db)
 
 	if !errHandled {
 		t.Errorf("expected error")
@@ -375,7 +375,7 @@ func Test_CreateHorizonDevice0(t *testing.T) {
 		}
 	}
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getExchangeDevice(""), events.NewEventStateManager(), db)
 
 	if errHandled {
 		t.Errorf("unexpected error %v", myError)
@@ -436,7 +436,7 @@ func Test_CreateHorizonDevice_EnvVarDeviceid(t *testing.T) {
 		}
 	}
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getExchangeDevice(""), events.NewEventStateManager(), db)
 
 	if errHandled {
 		t.Errorf("unexpected error %v", myError)
@@ -496,12 +496,12 @@ func Test_CreateHorizonDevice_alreadythere(t *testing.T) {
 		}
 	}
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getExchangeDevice(""), events.NewEventStateManager(), db)
 	if errHandled {
 		t.Errorf("unexpected error %v", myError)
 	}
 
-	errHandled, device, exDevice = CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice = CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getExchangeDevice(""), events.NewEventStateManager(), db)
 
 	if !errHandled {
 		t.Errorf("expected error")
@@ -561,7 +561,7 @@ func Test_CreateHorizonDevice_badorg(t *testing.T) {
 		}
 	}
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getExchangeDevice(""), events.NewEventStateManager(), db)
 
 	if !errHandled {
 		t.Errorf("expected error")
@@ -577,7 +577,7 @@ func Test_CreateHorizonDevice_badorg(t *testing.T) {
 
 }
 
-// Org doesnt exist
+// Pattern doesnt exist
 func Test_CreateHorizonDevice_badpattern(t *testing.T) {
 
 	dir, db, err := utsetup()
@@ -621,7 +621,7 @@ func Test_CreateHorizonDevice_badpattern(t *testing.T) {
 		}
 	}
 
-	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), events.NewEventStateManager(), db)
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getExchangeDevice(""), events.NewEventStateManager(), db)
 
 	if !errHandled {
 		t.Errorf("expected error")
@@ -629,6 +629,68 @@ func Test_CreateHorizonDevice_badpattern(t *testing.T) {
 		t.Errorf("myError has the wrong type (%T)", myError)
 	} else if apiErr.Input != "device.pattern" {
 		t.Errorf("wrong error input field %v", *apiErr)
+	} else if device != nil {
+		t.Errorf("device should not be returned")
+	} else if exDevice != nil {
+		t.Errorf("output device should not be returned")
+	}
+
+}
+
+// Input pattern conflicts with the node pattern on the exchange
+func Test_CreateHorizonDevice_conflictpattern(t *testing.T) {
+
+	dir, db, err := utsetup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer cleanTestDir(dir)
+
+	myOrg := "testOrg"
+	myPattern := "testPattern"
+	hd := getBasicDevice(myOrg, "otherPattern")
+
+	var myError error
+	errorhandler := GetPassThroughErrorHandler(&myError)
+	getOrg := func(org string, id string, token string) (*exchange.Organization, error) {
+		if org == myOrg {
+			return &exchange.Organization{
+				Label:       "test label",
+				Description: "test description",
+				LastUpdated: "some time ago",
+			}, nil
+		} else {
+			return nil, errors.New("org not found")
+		}
+	}
+
+	getPatterns := func(org string, pattern string, id string, token string) (map[string]exchange.Pattern, error) {
+		if pattern == myPattern && org == myOrg {
+			patid := fmt.Sprintf("%v/%v", org, pattern)
+			return map[string]exchange.Pattern{
+				patid: exchange.Pattern{
+					Label:              "label",
+					Description:        "desc",
+					Public:             true,
+					Services:           []exchange.ServiceReference{},
+					AgreementProtocols: []exchange.AgreementProtocol{},
+				},
+			}, nil
+		} else {
+			return nil, errors.New("pattern not found")
+		}
+	}
+
+	errHandled, device, exDevice := CreateHorizonDevice(hd, errorhandler, getOrg, getPatterns, getDummyGetExchangeVersion(), getDummyPatchDeviceHandler(), getExchangeDevice("DifferentPattern"), events.NewEventStateManager(), db)
+
+	if !errHandled {
+		t.Errorf("expected error")
+	} else if apiErr, ok := myError.(*APIUserInputError); !ok {
+		t.Errorf("myError has the wrong type (%T)", myError)
+	} else if apiErr.Input != "device.pattern" {
+		t.Errorf("wrong error input field %v", *apiErr)
+	} else if !strings.Contains(apiErr.Err, "conflict") {
+		t.Errorf("Wrong error message: %v", apiErr.Err)
 	} else if device != nil {
 		t.Errorf("device should not be returned")
 	} else if exDevice != nil {
@@ -775,4 +837,16 @@ func getBasicDevice(org string, pattern string) *HorizonDevice {
 		HA:      &myHA,
 	}
 	return hd
+}
+
+// an exchange GetDevice handler that has an empty pattern
+func getExchangeDevice(pattern string) exchange.DeviceHandler {
+	return func(id string, token string) (*exchange.Device, error) {
+		return &exchange.Device{
+			Token:   token,
+			Name:    id,
+			Owner:   "someone",
+			Pattern: pattern,
+		}, nil
+	}
 }

--- a/cli/cliutils/cliutils.go
+++ b/cli/cliutils/cliutils.go
@@ -322,9 +322,22 @@ func TrimOrg(org, id string) (string, string) {
 	} else if len(substrings) == 2 {
 		return substrings[0], substrings[1] // in this case the org the prepended to the id will override the org they may have specified thru the -o flag or env var
 	} else {
-		Fatal(CLI_INPUT_ERROR, i18n.GetMessagePrinter().Sprintf("the resource id can not contain more than 1 '/'"))
+		Fatal(CLI_INPUT_ERROR, i18n.GetMessagePrinter().Sprintf("the id can not contain more than 1 '/'"))
 	}
 	return "", "" // will never get here
+}
+
+// Add the given org to the id if the id does not already contain an org
+func AddOrg(org, id string) string {
+	substrings := strings.Split(id, "/")
+	if len(substrings) <= 1 { // this means id was empty, or did not contain '/'
+		return fmt.Sprintf("%v/%v", org, id)
+	} else if len(substrings) == 2 {
+		return id
+	} else {
+		Fatal(CLI_INPUT_ERROR, i18n.GetMessagePrinter().Sprintf("the id can not contain more than 1 '/'"))
+	}
+	return "" // will never get here
 }
 
 // FormExchangeId combines url, version, arch the same way the exchange does to form the resource ID.

--- a/exchange/handlers.go
+++ b/exchange/handlers.go
@@ -73,6 +73,13 @@ func GetHTTPDeviceHandler(ec ExchangeContext) DeviceHandler {
 	}
 }
 
+// this is used when ExchangeContext is not set up yet.
+func GetHTTPDeviceHandler2(cfg *config.HorizonConfig) DeviceHandler {
+	return func(id string, token string) (*Device, error) {
+		return GetExchangeDevice(cfg.Collaborators.HTTPClientFactory, id, token, cfg.Edge.ExchangeURL)
+	}
+}
+
 // A handler for modifying the device information on the exchange
 type PutDeviceHandler func(deviceId string, deviceToken string, pdr *PutDeviceRequest) (*PutDeviceResponse, error)
 


### PR DESCRIPTION
Did the pattern checking for both hzn and anax api because we would like to give proper messages to the user who are using `hzn register` in some special cases.