### PR TITLE
Use credential org as pattern org when pattern org is not specified i…

### DIFF
--- a/cli/exchange/pattern.go
+++ b/cli/exchange/pattern.go
@@ -205,6 +205,9 @@ func PatternPublish(org, userPw, jsonFilePath, keyFilePath, pubKeyFilePath, patN
 	if patFile.Org != "" && patFile.Org != org {
 		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("the org specified in the input file (%s) must match the org specified on the command line (%s)", patFile.Org, org))
 	}
+	if patFile.Org == "" {
+		patFile.Org = org
+	}
 	patInput := PatternInput{Label: patFile.Label, Description: patFile.Description, Public: patFile.Public, AgreementProtocols: patFile.AgreementProtocols, UserInput: patFile.UserInput}
 
 	//issue 924: Patterns with no services are not allowed

--- a/cli/policy/policy.go
+++ b/cli/policy/policy.go
@@ -29,7 +29,6 @@ func Update(fileName string) {
 	ep := new(externalpolicy.ExternalPolicy)
 	readInputFile(fileName, ep)
 	i18n.GetMessagePrinter().Println("Updating Horizon node policy and re-evaluating all agreements based on this node policy. Existing agreements might be cancelled and re-negotiated.")
-	i18n.GetMessagePrinter().Println()
 	cliutils.HorizonPutPost(http.MethodPost, "node/policy", []int{201, 200}, ep)
 
 	i18n.GetMessagePrinter().Println("Horizon node policy updated.")


### PR DESCRIPTION
…n pattern file.