### PR TITLE
Issue 1081 hzn exchange node update verify userinput

### DIFF
--- a/cli/exchange/node.go
+++ b/cli/exchange/node.go
@@ -2,24 +2,26 @@ package exchange
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 
 	"github.com/open-horizon/anax/cli/cliconfig"
 	"github.com/open-horizon/anax/cli/cliutils"
+	"github.com/open-horizon/anax/cutil"
 	"github.com/open-horizon/anax/exchange"
 	"github.com/open-horizon/anax/externalpolicy"
 	_ "github.com/open-horizon/anax/externalpolicy/text_language"
 	"github.com/open-horizon/anax/i18n"
 	"github.com/open-horizon/anax/persistence"
 	"github.com/open-horizon/anax/policy"
+	"github.com/open-horizon/anax/semanticversion"
 )
 
-// We only care about handling the node names, so the rest is left as interface{} and will be passed from the exchange to the display
 type ExchangeNodes struct {
-	LastIndex int                    `json:"lastIndex"`
-	Nodes     map[string]interface{} `json:"nodes"`
+	LastIndex int                        `json:"lastIndex"`
+	Nodes     map[string]exchange.Device `json:"nodes"`
 }
 
 func NodeList(org string, credToUse string, node string, namesOnly bool) {
@@ -155,6 +157,80 @@ func NodeUpdate(org string, credToUse string, node string, filePath string) {
 			if err := json.Unmarshal(bytes, &ui); err != nil {
 				cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to unmarshal attribute input %s: %v", v, err))
 			} else {
+				// validate userInput
+				// if node has a pattern, check the service is defined in top level services
+				nodes := nodeReq.Nodes
+				if len(nodes) != 1 {
+					cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Expecting 1 exchange node, but get %d nodes", len(nodes)))
+				}
+
+				nodePatternString := ""
+				for _, node := range nodes {
+					nodePatternString = node.Pattern
+				}
+				var topLevelServices []ServiceReference
+				patternUserInputsMap := make(map[string]policy.UserInput)
+				userInputWithEmptyDefaultValueMap := make(map[string][]exchange.UserInput)
+
+				if nodePatternString != "" {
+					patOrg, patternName := cliutils.TrimOrg(org, nodePatternString)
+					var patternsResp ExchangePatterns
+					// Get exchange pattern
+					httpCode := cliutils.ExchangeGet("Exchange", cliutils.GetExchangeUrl(), "orgs/"+patOrg+"/patterns"+cliutils.AddSlash(patternName), cliutils.OrgAndCreds(org, credToUse), []int{200, 404}, &patternsResp)
+					if httpCode == 404 {
+						cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Pattern %v of the node does not exist for org: %v \n", nodePatternString, patOrg))
+					}
+
+					patterns := patternsResp.Patterns
+					if len(patterns) != 1 {
+						cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Expecting 1 pattern with name %v, but get %d patterns", nodePatternString, len(nodes)))
+					}
+
+					pattern, _ := patterns[nodePatternString]
+					topLevelServices = pattern.Services
+					patternUserInputs := pattern.UserInput
+
+					for _, u := range patternUserInputs {
+						mapKey := fmt.Sprintf("%v/%v", u.ServiceOrgid, u.ServiceUrl)
+						patternUserInputsMap[mapKey] = u
+					}
+
+
+					// if there are userinput with no default value, and value is not defined in pattern userinput, userinput from command line cannot be empty
+					_, err := getUserInputWithEmptyDefaultValue(cliutils.OrgAndCreds(org, credToUse), topLevelServices, patternUserInputsMap, userInputWithEmptyDefaultValueMap)
+					if err == nil && len(userInputWithEmptyDefaultValueMap) != 0 {
+						if len(ui) == 0 {
+							cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Userinput cannot be set to empty list because some userinputs have no default value from service and pattern "))
+						}
+					} else if err != nil {
+						cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("%v", err))
+					}
+				}
+
+
+				if len(ui) != 0 {
+					// make a map
+					userInputsMap := make(map[string]policy.UserInput)
+					for _, u := range ui {
+						// validate u has serviceOrg and serviceUrl
+						if u.ServiceOrgid == "" || u.ServiceUrl == "" {
+							cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("ServiceOrgid and ServiceUrl need to be set in userinput"))
+						}
+						mapKey := fmt.Sprintf("%v/%v", u.ServiceOrgid, u.ServiceUrl)
+						userInputsMap[mapKey] = u
+					}
+
+					for _, u := range ui {
+						uInput := u
+						validated, warningMessage, err := ValidateUserInput(org, credToUse, uInput, nodePatternString, topLevelServices, userInputsMap, patternUserInputsMap, userInputWithEmptyDefaultValueMap)
+						if !validated {
+							cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Unable to validate exchange node userInput, error: %v", err))
+						} else if warningMessage != "" { // validate == true, but give back warning error message
+							cliutils.Warning(msgPrinter.Sprintf("validate exchange node/userinput %v ", warningMessage))
+						}
+
+					}
+				}
 				patch[k] = ui
 			}
 		} else if k == "pattern" {
@@ -464,4 +540,482 @@ func NodeListErrors(org string, credToUse string, node string, long bool) {
 		}
 		fmt.Printf("%s\n", jsonBytes)
 	}
+}
+
+func ValidateUserInput(org string, credToUse string, userInput policy.UserInput, nodePattern string, topLevelServices []ServiceReference, userInputsMap map[string]policy.UserInput, patternUserInputsMap map[string]policy.UserInput, userInputWithEmptyDefaultValueMap map[string][]exchange.UserInput) (bool, string, error) {
+	msgPrinter := i18n.GetMessagePrinter()
+	warningMessage := ""
+
+	serviceOrg := userInput.ServiceOrgid
+	serviceUrl := userInput.ServiceUrl
+	serviceVersionRange := userInput.ServiceVersionRange
+	serviceArch := userInput.ServiceArch
+
+	msgPrinter.Printf("Start validating userinput %v, %v, %v, %v", serviceOrg, serviceUrl, serviceVersionRange, serviceArch)
+	msgPrinter.Println()
+
+	var errorString string
+	if &userInput.ServiceVersionRange == nil || userInput.ServiceVersionRange == "" {
+		def := "0.0.0"
+		serviceVersionRange = def
+	}
+
+	// Convert the version to a version expression.
+	vExp, err := semanticversion.Version_Expression_Factory(serviceVersionRange)
+	if err != nil {
+		errorString = msgPrinter.Sprintf("versionRange %v cannot be converted to a version expression, error %v", userInput.ServiceVersionRange, err)
+		return false, warningMessage, errors.New(errorString)
+	}
+	serviceVersion := vExp.Get_expression()
+
+	// service exist
+	var sdef *exchange.ServiceDefinition
+
+	searchVersion, err := getSearchVersion(serviceVersion)
+	if err != nil {
+		return false, warningMessage, err
+	}
+
+	sdef, err = getService(cliutils.OrgAndCreds(org, credToUse), serviceOrg, serviceUrl, serviceArch, serviceVersion, searchVersion)
+	if sdef == nil || err != nil {
+		return false, warningMessage, err
+	}
+
+	// compare ServiceDefinition.UserInput(array) with userInput.Inputs(array)
+	var compareResult bool
+	compareResult, err = compareUserInput(sdef.UserInputs, userInput.Inputs)
+	if !compareResult {
+		errorString = msgPrinter.Sprintf("Failed to compare given userInput with service userInput, error: %v", err)
+		return false, warningMessage, errors.New(errorString)
+	} else if err != nil {
+		// give back a warning
+		warningMessage = msgPrinter.Sprintf("For service %v %v %v, got warning message: %v", serviceOrg, serviceUrl, serviceArch, err.Error())
+	}
+
+	// Need to check:
+	// 1) if service is top level service
+	// 2) or recursively check if service defined in dependent service
+	// 3) if service range of the dependent service has intersection with versionRange of service from userInput
+	// 4) For services (toplevel service and required services) that have userinput without default value, it should be set in userinput from user
+	foundService := false
+
+	if &topLevelServices != nil && len(topLevelServices) != 0 {
+		for _, topLevelService := range topLevelServices {
+			topLevelServiceVersionNumber := topLevelService.ServiceVersions[0].Version
+			sdef, err = getService(cliutils.OrgAndCreds(org, credToUse), topLevelService.ServiceOrg, topLevelService.ServiceURL, topLevelService.ServiceArch, topLevelServiceVersionNumber, "")
+			if sdef == nil || err != nil {
+				return false, warningMessage, errors.New(msgPrinter.Sprintf("toplevel service does not exist %v, %v, %v, %v", topLevelService.ServiceOrg, topLevelService.ServiceURL, topLevelService.ServiceArch, topLevelServiceVersionNumber))
+			}
+
+			mapKey := fmt.Sprintf("%v/%v", topLevelService.ServiceOrg, topLevelService.ServiceURL)
+			emptyDefaultValueUserInput, ok := userInputWithEmptyDefaultValueMap[mapKey]
+
+			// if !ok, means all the default value are set either from service or pattern userinput
+			if ok {
+				u, inCmdUserInput := userInputsMap[mapKey]
+				if !inCmdUserInput {
+					return false, warningMessage, errors.New(msgPrinter.Sprintf("%v %v has userInput that need to be set because they have no default value.", topLevelService.ServiceOrg, topLevelService.ServiceURL))
+				} else {
+					for _, emptyDefaultValue := range emptyDefaultValueUserInput {
+						if definedInCmdUserInput, err := cmdInputsContains(u.Inputs, emptyDefaultValue.Name); !definedInCmdUserInput {
+							return false, warningMessage, errors.New(msgPrinter.Sprintf("%v", err))
+						}
+					}
+				}
+			}
+
+			var topLevelServiceVersion ServiceChoice
+			if serviceOrg == topLevelService.ServiceOrg && serviceUrl == topLevelService.ServiceURL {
+				for _, topLevelServiceVersion = range topLevelService.ServiceVersions {
+					if withinRange, _ := vExp.Is_within_range(topLevelServiceVersion.Version); withinRange == true {
+						sdef, err = getService(cliutils.OrgAndCreds(org, credToUse), topLevelService.ServiceOrg, topLevelService.ServiceURL, topLevelService.ServiceArch, topLevelServiceVersion.Version, "")
+						if sdef == nil || err != nil {
+							return false, warningMessage, errors.New(msgPrinter.Sprintf("toplevel service does not exist %v, %v, %v, %v", topLevelService.ServiceOrg, topLevelService.ServiceURL, topLevelService.ServiceArch, topLevelServiceVersion.Version))
+						}
+						foundService = true
+						//return true, warningMessage, nil
+					}
+				}
+			}
+
+			// recursively check required services/dependent services
+			foundMatchService := make([]bool, 1)
+			findMatchInDepService, defaultValueCheck, err := checkDependentServices(cliutils.OrgAndCreds(org, credToUse), serviceOrg, serviceUrl, vExp, sdef, userInputsMap, patternUserInputsMap, userInputWithEmptyDefaultValueMap, foundMatchService)
+			if !defaultValueCheck {
+				return false, warningMessage, err
+			}
+
+			if !foundService && findMatchInDepService {
+				foundService = true
+			}
+
+		}
+		if !foundService {
+			errorString = msgPrinter.Sprintf("Service %v %v %v %v in userInput is not defined in pattern %v or its dependent services", serviceOrg, serviceUrl, serviceArch, vExp.Get_expression(), nodePattern)
+			return false, warningMessage, errors.New(errorString)
+		}
+	} else {
+		if checkDefaultValueInServiceUserInput, err := checkDefaultValueInServiceUserInput(sdef.UserInputs, userInput.Inputs); !checkDefaultValueInServiceUserInput {
+			warningMessage = msgPrinter.Sprintf("%vWarning: %v", warningMessage, err)
+		}
+	}
+
+
+	return true, warningMessage, nil
+
+}
+
+// return bool, bool, err.
+// first bool return - indicate if service is defined in the dependent service by recursively check
+// second bool return - indicate if required service has userinputs without default values
+func checkDependentServices(creds string, serviceOrg string, serviceUrl string, serviceVersionExp *semanticversion.Version_Expression, servToCheckDependentService *exchange.ServiceDefinition, userInputsMap map[string]policy.UserInput, patternUserInputsMap map[string]policy.UserInput, userInputWithEmptyDefaultValueMap map[string][]exchange.UserInput, foundMatchService []bool) (bool, bool, error) {
+	msgPrinter := i18n.GetMessagePrinter()
+	// versionRange is "" for the 1st interation
+
+	dependentServices := servToCheckDependentService.RequiredServices
+	if len(dependentServices) == 0 {
+		if foundMatchService[0] {
+			return true, true, nil
+		} else {
+			return false, true, errors.New(msgPrinter.Sprintf("No dependent service for service %v, %v, %v, %v", servToCheckDependentService.Owner, servToCheckDependentService.URL, servToCheckDependentService.Arch, servToCheckDependentService.Version))
+		}
+
+	}
+	for _, dependentService := range dependentServices {
+		dependentServiceVersionRange := dependentService.VersionRange
+		if &dependentService.VersionRange == nil || dependentService.VersionRange == "" {
+			def := "0.0.0"
+			dependentServiceVersionRange = def
+		}
+		dependentServiceVersionExp, _ := semanticversion.Version_Expression_Factory(dependentServiceVersionRange)
+		dependentServiceVersion := dependentServiceVersionExp.Get_expression()
+		dependentServiceSearchVersion, _ := getSearchVersion(dependentServiceVersion)
+		
+		dsdef, err := getService(creds, dependentService.Org, dependentService.URL, dependentService.Arch, dependentServiceVersion, dependentServiceSearchVersion)
+		if dsdef == nil || err != nil {
+			return false, true, errors.New(msgPrinter.Sprintf("service does not exist %v, %v, %v, %v, %v", dependentService.Org, dependentService.URL, dependentService.Arch, dependentServiceVersion, dependentServiceSearchVersion))
+		}
+
+		mapKey := fmt.Sprintf("%v/%v", dependentService.Org, dependentService.URL)
+		emptyDefaultValueUserInput, ok := userInputWithEmptyDefaultValueMap[mapKey]
+
+		if ok {
+			u, inCmdUserInput := userInputsMap[mapKey]
+			if !inCmdUserInput {
+				return foundMatchService[0], false, errors.New(msgPrinter.Sprintf("%v %v has userInput that need to be set because they have no default value.", dependentService.Org, dependentService.URL))
+			} else {
+				for _, emptyDefaultValue := range emptyDefaultValueUserInput {
+					if definedInCmdUserInput, err := cmdInputsContains(u.Inputs, emptyDefaultValue.Name); !definedInCmdUserInput {
+						return foundMatchService[0], false, errors.New(msgPrinter.Sprintf("%v", err))
+					}
+				}
+			}
+		}
+
+		if serviceOrg == dependentService.Org && serviceUrl == dependentService.URL {
+			// true if versionRange of the dependent service has intersection with versionRange of service from user input
+			if err = serviceVersionExp.IntersectsWith(dependentServiceVersionExp); err == nil {
+				foundMatchService[0] = true
+			}
+
+		}
+
+		// recursive call
+		_, defaultValueCheck, err := checkDependentServices(creds, serviceOrg, serviceUrl, serviceVersionExp, dsdef, userInputsMap, patternUserInputsMap, userInputWithEmptyDefaultValueMap, foundMatchService)
+		if !defaultValueCheck {
+			return foundMatchService[0], false, err
+		}
+	}
+
+	if foundMatchService[0] {
+		return true, true, nil
+	}
+	return false, true, errors.New(msgPrinter.Sprintf("Service %v, %v, %v does not define a dependent service", serviceOrg, serviceUrl, serviceVersionExp.Get_expression()))
+
+}
+
+func getSearchVersion(version string) (string, error) {
+	msgPrinter := i18n.GetMessagePrinter()
+	// The caller could pass a specific version or a version range, in the version parameter. If it's a version range
+	// then it must be a full expression. That is, it must be expanded into the full syntax. For example; 1.2.3 is a specific
+	// version, and [4.5.6, INFINITY) is the full expression corresponding to the shorthand form of "4.5.6".
+	searchVersion := ""
+	if version == "" || semanticversion.IsVersionExpression(version) {
+		// search for all versions
+	} else if semanticversion.IsVersionString(version) {
+		// search for a specific version
+		searchVersion = version
+	} else {
+		return "", errors.New(msgPrinter.Sprintf("input version %v is not a valid version string", version))
+	}
+	return searchVersion, nil
+}
+
+func getService(creds string, serviceOrg string, serviceUrl string, serviceArch string, serviceVersion string, searchVersion string) (*exchange.ServiceDefinition, error) {
+	msgPrinter := i18n.GetMessagePrinter()
+	var servicesResp exchange.GetServicesResponse
+	targetURL := fmt.Sprintf("orgs/%v/services?url=%v", serviceOrg, serviceUrl)
+	if searchVersion != "" {
+		targetURL = fmt.Sprintf("%v&version=%v", targetURL, searchVersion)
+	}
+
+	if serviceArch != "" {
+		targetURL = fmt.Sprintf("%v&arch=%v", targetURL, serviceArch)
+	}
+
+	httpCode := cliutils.ExchangeGet("Exchange", cliutils.GetExchangeUrl(), targetURL, creds, []int{200, 404}, &servicesResp)
+	if httpCode == 404 {
+		errorString := msgPrinter.Sprintf("Service does not exist for org: %v, url: %v, version: %v, arch: %v \n", serviceOrg, serviceUrl, serviceVersion, serviceArch)
+		return nil, errors.New(errorString)
+	}
+
+	// processGetServiceResponse to get the service with highest version
+	return processGetServiceResponse(servicesResp, serviceUrl, serviceArch, serviceVersion, searchVersion)
+}
+
+func processGetServiceResponse(servicesResp exchange.GetServicesResponse, serviceUrl string, serviceArch string, serviceVersion string, searchVersion string) (*exchange.ServiceDefinition, error) {
+	msgPrinter := i18n.GetMessagePrinter()
+	services := servicesResp.Services
+
+	var errorString string
+	if searchVersion != "" {
+		if serviceArch != "" {
+			// return the given version, expecting 1 service
+			if len(services) != 1 {
+				errorString = msgPrinter.Sprintf("expecting 1 service for %v %v %v, but get %d services", serviceUrl, serviceVersion, searchVersion, len(services))
+				return nil, errors.New(errorString)
+			}
+		}
+
+		for _, serviceDef := range services {
+			return &serviceDef, nil
+		}
+
+		return nil, errors.New("should not get here")
+
+	} else {
+		// get the hightest
+		if len(services) == 0 {
+			errorString = msgPrinter.Sprintf("expecting at least 1 service for %v %v %v, but get 0 service", serviceUrl, serviceVersion, searchVersion)
+			return nil, errors.New(errorString)
+		}
+
+		vRange, _ := semanticversion.Version_Expression_Factory("0.0.0")
+		var err error
+		if serviceVersion != "" {
+			if vRange, err = semanticversion.Version_Expression_Factory(serviceVersion); err != nil {
+				errorString = msgPrinter.Sprintf("version range %v in error: %v", serviceVersion, err)
+				return nil, errors.New(errorString)
+			}
+		}
+
+		highest, serviceDef, _, err := exchange.GetHighestVersion(services, vRange)
+		if err != nil {
+			return nil, err
+		}
+
+		if highest == "" {
+			errorString = msgPrinter.Sprintf("Cannot find service given version range: %v", serviceVersion)
+			return nil, errors.New(errorString)
+		}
+		return &serviceDef, nil
+
+	}
+}
+
+func compareUserInput(sdefUserInputs []exchange.UserInput, cmdUserInputs []policy.Input) (bool, error) {
+	msgPrinter := i18n.GetMessagePrinter()
+	serviceUserInputsMap := make(map[string]exchange.UserInput)
+	var serviceInputName string
+	var serviceInput exchange.UserInput
+	var errorString string
+
+
+	for _, serviceInput = range sdefUserInputs {
+		serviceInputName = serviceInput.Name
+		serviceUserInputsMap[serviceInputName] = serviceInput
+	}
+
+	// return true with warning message if the variables in userInput.Inputs are not defined in service, also check values are correct types
+	var policyInputName string
+	var policyInputValue interface{}
+	var ok bool
+	var inputNameNotDefinedInService []string
+
+	for _, policyInput := range cmdUserInputs {
+		policyInputName = policyInput.Name
+		policyInputValue = policyInput.Value
+
+		serviceInput, ok = serviceUserInputsMap[policyInputName]
+		if !ok {
+			// give back a warning
+			inputNameNotDefinedInService = append(inputNameNotDefinedInService, policyInputName)
+		} else {
+			if err := cutil.VerifyWorkloadVarTypes(policyInputValue, serviceInput.Type); err != nil {
+				errorString = msgPrinter.Sprintf("Error validating the type of userInput variable %v. error: %v", policyInputName, err)
+				return false, errors.New(errorString)
+			}
+		}
+	}
+
+	if len(inputNameNotDefinedInService) != 0 {
+		errorString = msgPrinter.Sprintf("The following variables are not defined in userInput for service in its highest version: %v \n", inputNameNotDefinedInService)
+		return true, errors.New(errorString)
+	}
+	return true, nil
+
+}
+
+func sliceContains(sliceToCheck []string, elem string) bool {
+	for _, e := range sliceToCheck {
+		if e == elem {
+			return true
+		}
+	}
+
+	return false
+}
+
+// if service has a userinput with no default value AND userInput is not set in input body, return err
+func checkDefaultValueInServiceUserInput(sdefUserInputs []exchange.UserInput, cmdUserInputs []policy.Input) (bool, error) {
+	msgPrinter := i18n.GetMessagePrinter()
+	var cmdUserInputNames []string
+	var serviceInputName string
+	var serviceInput exchange.UserInput
+
+	for _, u := range cmdUserInputs {
+		cmdUserInputNames = append(cmdUserInputNames, u.Name)
+	}
+
+	for _, serviceInput = range sdefUserInputs {
+		serviceInputName = serviceInput.Name
+
+		if serviceInput.DefaultValue == "" {
+			valueDefined := sliceContains(cmdUserInputNames, serviceInputName)
+			if !valueDefined {
+				errorString := msgPrinter.Sprintf("%v needs to be set in userInput because it has no default value.", serviceInputName)
+				return false, errors.New(errorString)
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func checkUserInputDefaultValueNotEmpty(org string, sdef *exchange.ServiceDefinition, patternUserInput *policy.UserInput, userInputWithEmptyDefaultValueMap map[string][]exchange.UserInput) map[string][]exchange.UserInput {
+	if sdef != nil {
+		for _, u := range sdef.UserInputs {
+			contains := false
+			if u.DefaultValue == "" {
+				if patternUserInput != nil {
+					for _, patternInput := range patternUserInput.Inputs {
+						if patternInput.Name == u.Name {
+							contains = true
+							break
+						}
+					}
+				}
+				if !contains {
+					mapKey := fmt.Sprintf("%v/%v", org, sdef.URL)
+					emptyDefaultValueNames, exist := userInputWithEmptyDefaultValueMap[mapKey]
+					if exist {
+						emptyDefaultValueNames = append(emptyDefaultValueNames, u)
+					}
+
+					userInputWithEmptyDefaultValueMap[mapKey] = emptyDefaultValueNames
+				}
+			}
+		}
+	}
+
+	return userInputWithEmptyDefaultValueMap
+}
+
+func cmdInputsContains(cmdInputs []policy.Input, serviceInputName string) (bool, error) {
+	msgPrinter := i18n.GetMessagePrinter()
+	for _, input := range cmdInputs {
+		if input.Name == serviceInputName {
+			return true, nil
+		}
+	}
+
+	errorString := msgPrinter.Sprintf("%v needs to be set in userInput because it has no default value.", serviceInputName)
+	return false, errors.New(errorString)
+}
+
+func getUserInputWithEmptyDefaultValue(creds string, topLevelServices []ServiceReference, patternUserInputsMap map[string]policy.UserInput, userInputWithEmptyDefaultValueMap map[string][]exchange.UserInput) (*map[string][]exchange.UserInput, error) {
+	msgPrinter := i18n.GetMessagePrinter()
+	if &topLevelServices != nil && len(topLevelServices) != 0 {
+		for _, topLevelService := range topLevelServices {
+			topLevelServiceVersionNumber := topLevelService.ServiceVersions[0].Version
+			sdef, err := getService(creds, topLevelService.ServiceOrg, topLevelService.ServiceURL, topLevelService.ServiceArch, topLevelServiceVersionNumber, "")
+			if sdef == nil || err != nil {
+				return nil, errors.New(msgPrinter.Sprintf("toplevel service does not exist %v, %v, %v, %v", topLevelService.ServiceOrg, topLevelService.ServiceURL, topLevelService.ServiceArch, topLevelServiceVersionNumber))
+			}
+
+			pattenUserInputMapKey := fmt.Sprintf("%v/%v", topLevelService.ServiceOrg, topLevelService.ServiceURL)
+			patternUserInput, ok := patternUserInputsMap[pattenUserInputMapKey]
+			if !ok {
+				checkUserInputDefaultValueNotEmpty(topLevelService.ServiceOrg, sdef, nil, userInputWithEmptyDefaultValueMap)
+			} else {
+				checkUserInputDefaultValueNotEmpty(topLevelService.ServiceOrg, sdef, &patternUserInput, userInputWithEmptyDefaultValueMap)
+			}
+
+			// recursively check required services/dependent services
+			_, err = checkDependentServiceEmptyDefaultValue(creds, sdef, patternUserInputsMap, userInputWithEmptyDefaultValueMap)
+			if err != nil {
+				return nil, err
+			}
+
+		}
+
+	}
+
+	return &userInputWithEmptyDefaultValueMap, nil
+
+}
+
+func checkDependentServiceEmptyDefaultValue(creds string, servToCheckDependentService *exchange.ServiceDefinition, patternUserInputsMap map[string]policy.UserInput, userInputWithEmptyDefaultValueMap map[string][]exchange.UserInput) (*map[string][]exchange.UserInput, error) {
+	msgPrinter := i18n.GetMessagePrinter()
+	// versionRange is "" for the 1st interation
+
+	dependentServices := servToCheckDependentService.RequiredServices
+	if len(dependentServices) == 0 {
+		return &userInputWithEmptyDefaultValueMap, nil
+
+	}
+
+	for _, dependentService := range dependentServices {
+		dependentServiceVersionRange := dependentService.VersionRange
+		if &dependentService.VersionRange == nil || dependentService.VersionRange == "" {
+			def := "0.0.0"
+			dependentServiceVersionRange = def
+		}
+		dependentServiceVersionExp, _ := semanticversion.Version_Expression_Factory(dependentServiceVersionRange)
+		dependentServiceVersion := dependentServiceVersionExp.Get_expression()
+		dependentServiceSearchVersion, _ := getSearchVersion(dependentServiceVersion)
+
+		dsdef, err := getService(creds, dependentService.Org, dependentService.URL, dependentService.Arch, dependentServiceVersion, dependentServiceSearchVersion)
+		if dsdef == nil || err != nil {
+			return nil, errors.New(msgPrinter.Sprintf("service does not exist %v, %v, %v, %v, %v", dependentService.Org, dependentService.URL, dependentService.Arch, dependentServiceVersion, dependentServiceSearchVersion))
+		}
+		pattenUserInputMapKey := fmt.Sprintf("%v/%v", dependentService.Org, dependentService.URL)
+		patternUserInput, ok := patternUserInputsMap[pattenUserInputMapKey]
+
+		if !ok {
+			checkUserInputDefaultValueNotEmpty(dependentService.Org, dsdef, nil, userInputWithEmptyDefaultValueMap)
+		} else {
+			checkUserInputDefaultValueNotEmpty(dependentService.Org, dsdef, &patternUserInput, userInputWithEmptyDefaultValueMap)
+		}
+
+		// recursive call
+		_, err = checkDependentServiceEmptyDefaultValue(creds, dsdef, patternUserInputsMap, userInputWithEmptyDefaultValueMap)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+
+	return &userInputWithEmptyDefaultValueMap, nil
+
 }

--- a/test/gov/pattern_change.sh
+++ b/test/gov/pattern_change.sh
@@ -67,6 +67,10 @@ cat <<EOF > /tmp/userinput_for_sall.json
         {
           "name": "var3",
           "value": 20.2
+        },
+	{
+          "name": "var4",
+          "value": ["node_String1", "node_String2", "node_String3"]
         }
       ]
     },
@@ -87,6 +91,10 @@ cat <<EOF > /tmp/userinput_for_sall.json
         {
           "name": "var3",
           "value": 21.2
+        },
+	{
+          "name": "var4",
+          "value": ["node_String1", "node_String2", "node_String3"]
         }
       ]
     },
@@ -149,6 +157,7 @@ cat <<EOF > /tmp/userinput_for_sall.json
     {
       "serviceOrgid": "IBM",
       "serviceUrl": "https://bluehorizon.network/service-gps",
+      "serviceArch": "amd64",
       "serviceVersionRange": "2.0.3",
       "inputs": [
         {
@@ -172,6 +181,7 @@ cat <<EOF > /tmp/userinput_for_sall.json
     {
       "serviceOrgid": "e2edev@somecomp.com",
       "serviceUrl": "https://bluehorizon.network/services/weather",
+      "serviceArch": "amd64",
       "serviceVersionRange": "1.5.0",
       "inputs": [
         {


### PR DESCRIPTION
1. service does not exist
<img width="1414" alt="Screen Shot 2019-12-01 at 19 53 24" src="https://user-images.githubusercontent.com/49077510/69923627-500ccf00-1474-11ea-9ebe-9063fc20665d.png">
<img width="1186" alt="Screen Shot 2019-12-01 at 19 55 29" src="https://user-images.githubusercontent.com/49077510/69923660-8ba79900-1474-11ea-8c73-58d3772518e9.png">
2. the variables are defined in the service, otherwise return a warning message
<img width="1628" alt="Screen Shot 2019-12-01 at 20 01 47" src="https://user-images.githubusercontent.com/49077510/69923789-6e26ff00-1475-11ea-8e3f-07358cc4b306.png">

3. variables are correct type
<img width="1625" alt="Screen Shot 2019-12-01 at 20 01 06" src="https://user-images.githubusercontent.com/49077510/69923765-55b6e480-1475-11ea-9c6d-639a3a0d2e83.png">

4. the node is associated with a pattern `sall`, the service should be defined as top level service or as dependent service
<img width="1593" alt="Screen Shot 2019-12-01 at 19 59 54" src="https://user-images.githubusercontent.com/49077510/69923736-299b6380-1475-11ea-807d-75a2877691a2.png">

5. 
<img width="1357" alt="Screen Shot 2019-12-01 at 20 15 28" src="https://user-images.githubusercontent.com/49077510/69924072-66685a00-1477-11ea-9699-f8a79eb66799.png">
the userinputs need to be set in given userinput.json if no default value given in service userinput.

