### PR TITLE
Issue #1305 - add node built-in property 'openhorizon.hardwareId'

### DIFF
--- a/abstractprotocol/protocol.go
+++ b/abstractprotocol/protocol.go
@@ -575,7 +575,7 @@ func addNodeBuiltInProps(pol *policy.Policy) (*policy.Policy, error) {
 	// get built-in node properties and replace the ones in the policy,
 	// the memory will be the available memory instead of total memory -- not yet,
 	//still use total memory, change to true if you want available memory
-	builtinNodePol := externalpolicy.CreateNodeBuiltInPolicy(false)
+	builtinNodePol := externalpolicy.CreateNodeBuiltInPolicy(false, false)
 	for _, prop := range builtinNodePol.Properties {
 		if err := pol.Add_Property(&prop, true); err != nil {
 			return nil, err

--- a/api/path_service_config.go
+++ b/api/path_service_config.go
@@ -455,7 +455,7 @@ func CreateService(service *Service,
 	}
 
 	// add node built-in properties
-	externalPol := externalpolicy.CreateNodeBuiltInPolicy(false)
+	externalPol := externalpolicy.CreateNodeBuiltInPolicy(false, false)
 	if externalPol != nil {
 		for _, ele := range externalPol.Properties {
 			if ele.Name == externalpolicy.PROP_NODE_CPU {

--- a/cli/exchange/node.go
+++ b/cli/exchange/node.go
@@ -195,7 +195,6 @@ func NodeUpdate(org string, credToUse string, node string, filePath string) {
 						patternUserInputsMap[mapKey] = u
 					}
 
-
 					// if there are userinput with no default value, and value is not defined in pattern userinput, userinput from command line cannot be empty
 					_, err := getUserInputWithEmptyDefaultValue(cliutils.OrgAndCreds(org, credToUse), topLevelServices, patternUserInputsMap, userInputWithEmptyDefaultValueMap)
 					if err == nil && len(userInputWithEmptyDefaultValueMap) != 0 {
@@ -206,7 +205,6 @@ func NodeUpdate(org string, credToUse string, node string, filePath string) {
 						cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("%v", err))
 					}
 				}
-
 
 				if len(ui) != 0 {
 					// make a map
@@ -660,7 +658,6 @@ func ValidateUserInput(org string, credToUse string, userInput policy.UserInput,
 		}
 	}
 
-
 	return true, warningMessage, nil
 
 }
@@ -690,7 +687,7 @@ func checkDependentServices(creds string, serviceOrg string, serviceUrl string, 
 		dependentServiceVersionExp, _ := semanticversion.Version_Expression_Factory(dependentServiceVersionRange)
 		dependentServiceVersion := dependentServiceVersionExp.Get_expression()
 		dependentServiceSearchVersion, _ := getSearchVersion(dependentServiceVersion)
-		
+
 		dsdef, err := getService(creds, dependentService.Org, dependentService.URL, dependentService.Arch, dependentServiceVersion, dependentServiceSearchVersion)
 		if dsdef == nil || err != nil {
 			return false, true, errors.New(msgPrinter.Sprintf("service does not exist %v, %v, %v, %v, %v", dependentService.Org, dependentService.URL, dependentService.Arch, dependentServiceVersion, dependentServiceSearchVersion))
@@ -829,7 +826,6 @@ func compareUserInput(sdefUserInputs []exchange.UserInput, cmdUserInputs []polic
 	var serviceInputName string
 	var serviceInput exchange.UserInput
 	var errorString string
-
 
 	for _, serviceInput = range sdefUserInputs {
 		serviceInputName = serviceInput.Name

--- a/events/events.go
+++ b/events/events.go
@@ -810,7 +810,7 @@ func NewGovernanceWorkloadCancelationMessage(id EventId, cause EndContractCause,
 
 	return &GovernanceWorkloadCancelationMessage{
 		GovernanceMaintenanceMessage: *govMaint,
-		Cause:                        cause,
+		Cause: cause,
 	}
 }
 

--- a/exchangesync/node_policy.go
+++ b/exchangesync/node_policy.go
@@ -87,7 +87,9 @@ func GetProcessedExchangeNodePolicy(pDevice *persistence.ExchangeDevice, getExch
 		return nil, fmt.Errorf("Unable to retrieve the node policy from the exchange. Error: %v", err)
 	}
 
-	builtinPolicy := externalpolicy.CreateNodeBuiltInPolicy(false)
+	hasHwId := exchangeNodePolicy.Properties.HasProperty(externalpolicy.PROP_NODE_HARDWAREID)
+
+	builtinPolicy := externalpolicy.CreateNodeBuiltInPolicy(false, !hasHwId)
 
 	var mergedPol *externalpolicy.ExternalPolicy
 	if exchangeNodePolicy == nil {
@@ -148,7 +150,7 @@ func SetDefaultNodePolicy(config *config.HorizonConfig, pDevice *persistence.Exc
 	glog.V(3).Infof("Setting up the default node policy.")
 
 	nodePolicy := new(externalpolicy.ExternalPolicy)
-	builtinNodePol := externalpolicy.CreateNodeBuiltInPolicy(false)
+	builtinNodePol := externalpolicy.CreateNodeBuiltInPolicy(false, true)
 
 	// get the default node policy file name from the config and set it up in local and exchange
 	policyFile := config.Edge.DefaultNodePolicyFile
@@ -330,8 +332,10 @@ func UpdateNodePolicy(pDevice *persistence.ExchangeDevice, db *bolt.DB, nodePoli
 		return fmt.Errorf("Node policy does not validate. %v", err)
 	}
 
+	hasHwId := nodePolicy.Properties.HasProperty(externalpolicy.PROP_NODE_HARDWAREID)
+
 	// add node's built-in properties
-	builtinNodePol := externalpolicy.CreateNodeBuiltInPolicy(false)
+	builtinNodePol := externalpolicy.CreateNodeBuiltInPolicy(false, hasHwId)
 	if builtinNodePol != nil {
 		nodePolicy.MergeWith(builtinNodePol, true)
 	}

--- a/exchangesync/node_policy_test.go
+++ b/exchangesync/node_policy_test.go
@@ -21,7 +21,7 @@ import (
 var ExchangeNodePolicyLastUpdated = ""
 var ExchangeNodePolicy *externalpolicy.ExternalPolicy
 
-const NUM_BUILT_INS = 3
+const NUM_BUILT_INS = 4
 
 // Verify that a Node Policy Object can be created and saved the first time.
 func Test_UpdateNodePolicy(t *testing.T) {

--- a/imagefetch/image_process_int_test.go
+++ b/imagefetch/image_process_int_test.go
@@ -279,8 +279,8 @@ func Test_ImageFetch_Event_Suite(suite *testing.T) {
 	images := []string{
 		"summit.hovitos.engineering/amd64/neo4j:3.3.1",               // 189MB
 		"summit.hovitos.engineering/amd64/clojure:boot-2.7.2-alpine", // 147MB
-		"ubuntu:yakkety", // 107MB
-		"registry.ng.bluemix.net/glendarling/x86/cpu:1.2.1", // 9MB
+		"ubuntu:yakkety",                                             // 107MB
+		"registry.ng.bluemix.net/glendarling/x86/cpu:1.2.1",          // 9MB
 	}
 
 	var buf bytes.Buffer

--- a/microservice/microservice.go
+++ b/microservice/microservice.go
@@ -317,7 +317,7 @@ func GenMicroservicePolicy(msdef *persistence.MicroserviceDefinition, policyPath
 	}
 
 	// add node built-in properties
-	externalPol := externalpolicy.CreateNodeBuiltInPolicy(false)
+	externalPol := externalpolicy.CreateNodeBuiltInPolicy(false, false)
 	if externalPol != nil {
 		for _, ele := range externalPol.Properties {
 			if ele.Name == externalpolicy.PROP_NODE_CPU {

--- a/persistence/attributes.go
+++ b/persistence/attributes.go
@@ -336,7 +336,7 @@ func AttributesToEnvvarMap(attributes []Attribute, envvars map[string]string, pr
 	writePrefix("ARCH", cutil.ArchString())
 
 	// Override with the built-in properties
-	externalPol := externalpolicy.CreateNodeBuiltInPolicy(false)
+	externalPol := externalpolicy.CreateNodeBuiltInPolicy(false, false)
 	if externalPol != nil {
 		for _, ele := range externalPol.Properties {
 			if ele.Name == externalpolicy.PROP_NODE_CPU {


### PR DESCRIPTION
The added parameter on CreateNodeBuiltInPolicy is a boolean to indicate if a generated hardwareId should be included. This is only true when creating a new default policy or when updating a policy that does not already have a hardwareId defined.