### PR TITLE
Fixes for 2 small cli bugs

### DIFF
--- a/cli/deploycheck/allcomp.go
+++ b/cli/deploycheck/allcomp.go
@@ -38,6 +38,11 @@ func AllCompatible(org string, userPw string, nodeId string, nodeArch string,
 	compCheckInput.PatternId = patternId
 	compCheckInput.Pattern = pattern
 
+	// use the user org for the patternId if it does not include an org id
+	if compCheckInput.PatternId != "" {
+		compCheckInput.PatternId = cliutils.AddOrg(userOrg, compCheckInput.PatternId)
+	}
+
 	if useNodeId {
 		// add credentials'org to node id if the node id does not have an org
 		nId = cliutils.AddOrg(userOrg, nId)
@@ -251,7 +256,7 @@ func verifyCompCheckParamters(org string, userPw string, nodeId string, nodePolF
 		// Other parts will be checked later by the compcheck package.
 		checkServiceDefsForBPol(bp, serviceDefs, svcDefFiles)
 
-		return orgToUse, *credToUse, nodeId, useNodeId, bp, nil, serviceDefs
+		return orgToUse, *credToUse, nodeIdToUse, useNodeId, bp, nil, serviceDefs
 	} else {
 		// get pattern from file or exchange
 		pattern, pf := getPattern(orgToUse, *credToUse, patternId, patternFile)
@@ -261,7 +266,7 @@ func verifyCompCheckParamters(org string, userPw string, nodeId string, nodePolF
 		// Not checking the missing ones becaused it will be checked by the compcheck package.
 		checkServiceDefsForPattern(pattern, serviceDefs, svcDefFiles)
 
-		return orgToUse, *credToUse, nodeId, useNodeId, nil, pf, serviceDefs
+		return orgToUse, *credToUse, nodeIdToUse, useNodeId, nil, pf, serviceDefs
 	}
 }
 

--- a/cli/deploycheck/policy.go
+++ b/cli/deploycheck/policy.go
@@ -169,5 +169,5 @@ func verifyPolicyCompatibleParamters(org string, userPw string, nodeId string, n
 		}
 	}
 
-	return orgToUse, *credToUse, nodeId, useNodeId
+	return orgToUse, *credToUse, nodeIdToUse, useNodeId
 }

--- a/cli/deploycheck/userinput.go
+++ b/cli/deploycheck/userinput.go
@@ -49,6 +49,11 @@ func UserInputCompatible(org string, userPw string, nodeId string, nodeArch stri
 	uiCheckInput.PatternId = patternId
 	uiCheckInput.Pattern = pattern
 
+	// use the user org for the patternId if it does not include an org id
+	if uiCheckInput.PatternId != "" {
+		uiCheckInput.PatternId = cliutils.AddOrg(userOrg, uiCheckInput.PatternId)
+	}
+
 	// formalize node id or get node policy
 	bUseLocalNode := false
 	if useNodeId {
@@ -230,7 +235,7 @@ func verifyUserInputCompatibleParamters(org string, userPw string, nodeId string
 		// Other parts will be checked later by the compcheck package.
 		checkServiceDefsForBPol(bp, serviceDefs, svcDefFiles)
 
-		return orgToUse, *credToUse, nodeId, useNodeId, bp, nil, serviceDefs
+		return orgToUse, *credToUse, nodeIdToUse, useNodeId, bp, nil, serviceDefs
 	} else {
 		// get pattern from file or exchange
 		pattern, pf := getPattern(orgToUse, *credToUse, patternId, patternFile)
@@ -240,7 +245,7 @@ func verifyUserInputCompatibleParamters(org string, userPw string, nodeId string
 		// Not checking the missing ones becaused it will be checked by the compcheck package.
 		checkServiceDefsForPattern(pattern, serviceDefs, svcDefFiles)
 
-		return orgToUse, *credToUse, nodeId, useNodeId, nil, pf, serviceDefs
+		return orgToUse, *credToUse, nodeIdToUse, useNodeId, nil, pf, serviceDefs
 	}
 }
 


### PR DESCRIPTION
bug 1) error returned by deploycheck when pattern org not specified in pattern id. Help text says it will use the user org in this case.
bug 2) querying the exchange with an empty node id when node id is retrieved from the node causing an error