### PR TITLE
Add network=host to the documentation for deployment strings

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -706,15 +706,17 @@ func serviceStart(client *docker.Client,
 			return fail(container, serviceName, err)
 		}
 	}
-	for _, cfg := range sharedEndpoints {
-		glog.V(5).Infof("Connecting network: %v to container id: %v", cfg.NetworkID, container.ID)
-		err := client.ConnectNetwork(cfg.NetworkID, docker.NetworkConnectionOptions{
-			Container:      container.ID,
-			EndpointConfig: cfg,
-			Force:          true,
-		})
-		if err != nil {
-			return fail(container, serviceName, err)
+	if serviceConfig.HostConfig.NetworkMode != "host" {
+		for _, cfg := range sharedEndpoints {
+			glog.V(5).Infof("Connecting network: %v to container id: %v", cfg.NetworkID, container.ID)
+			err := client.ConnectNetwork(cfg.NetworkID, docker.NetworkConnectionOptions{
+				Container:      container.ID,
+				EndpointConfig: cfg,
+				Force:          true,
+			})
+			if err != nil {
+				return fail(container, serviceName, err)
+			}
 		}
 	}
 

--- a/doc/deployment_string.md
+++ b/doc/deployment_string.md
@@ -7,7 +7,7 @@ When defining services in the Horizon Exchange, one of the fields that needs to 
 The deployment string is JSON which has been "stringified" (double quotes escaped, new lines removed, etc.). It should look like this:
 
 ```
-  "deployment": "{\"services\":{\"gps\":{\"image\":\"openhorizon/x86/gps:2.0.3\",\"privileged\":true,\"devices\":[\"/dev/bus/usb/001/001:/dev/bus/usb/001/001\"]}}}",
+  "deployment": "{\"services\":{\"gps\":{\"image\":\"openhorizon/x86/gps:2.0.3\",\"privileged\":true,\"devices\":[\"/dev/bus/usb/001/001:/dev/bus/usb/001/001\"],\"network\":\"host\"}}}",
  ```
 
  **Note**: You do not need to stringify the `deployent` string if you use `hzn` command to create the service in the exchange. However if you use `curl` command to create the service, you must stringify it.
@@ -19,7 +19,7 @@ Because Horizon uses the Docker API to start the containers, many of the fields 
 - `services`: a list of docker images that are part of this service
   - `<container-name>`: the name docker should give the container. Equivalent to the `docker run --name` flag. Horizon will also define this as the hostname for the container on the docker network, so other containers in the same network can connect to it using this name.
     - `image`: the docker image to be downloaded from the Horizon image server. The same name:tag format as used for `docker pull`.
-    - `privileged`: `{true|false}` - set to true if the container needs privileged mode.
+    - `privileged`: `{true|false}` - set to true if the container needs privileged mode. When set to true, the service can only be deployed to nodes with property openhorizon.allowPrivileged set to true.
     - `cap_add`: `["SYS_ADMIN"]` - grant an individual authority to the container. See https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities for a list of capabilities that can be added.
     - `environment`: `["FOO=bar","FOO2=bar2"]` - environment variables that should be set in the container.
     - `devices`: `["/dev/bus/usb/001/001:/dev/bus/usb/001/001",...]` - device files that should be made available to the container.
@@ -28,6 +28,7 @@ Because Horizon uses the Docker API to start the containers, many of the fields 
     - `ports`: `[{"HostPort":"5555:7777/udp","HostIP":"1.2.3.4"},{"HostPort":"8888/udp","HostIP":"1.2.3.4"}...]` -  container ports that should be mapped to the host. "5555" is the host port number, if omitted, the same container port number ("7777") will be used. If the protocol is not specified after the port number, it defaults to `tcp`. The `HostIP` identifies what host network interfaces this port should listen on. Use `0.0.0.0` to specify all interfaces.
     - `ephemeral_ports`: `[{"localhost_only":true, "port_and_protocol":"7777/udp"}, {"port_and_protocol":"8888"}...]` - publish a container port to an ephemeral host port. If `localhost_only` is set to true, the localhost ip address (`127.0.0.1`) will be used as the host network interface this port should listen on. Otherwise, all the host network interfaces on the host will be listened by this port. If the protocol is not specified after the port number for `port_and_protocol`, it defaults to `tcp`.
     - `command`: `["--myfirstarg","argvalue",...]` - override the start CMD specified the dockerfile, or append to the ENTRYPOINT specified in the dockerfile.
+    - `network`: `"host"` - start the container with host network mode. When network is set to host, the service can only be deployed to nodes with property openhorizon.allowPrivileged set to true.
 
 ## Deployment String Examples
 
@@ -57,7 +58,8 @@ A deployment string JSON would look like this:
           "HostPort":"5200:6414/tcp",
           "HostIP": "0.0.0.0"
         }
-      ]
+      ],
+      "network": "host"
     }
   }
 }


### PR DESCRIPTION
Fixed an issue causing dependent services of services with network=host to fail on start up 