### PR TITLE
Added note of the go dependency to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Related Projects:
 
 ### Preconditions
 
+* Go version >=1.11 is a required dependency, download it [here](https://golang.org/dl/)
 * To execute the lint and other code checkers (`make lint` or `make check`), you must install: `go vet`, `golint`, and `jshint`
 
 ### Operations


### PR DESCRIPTION
Go dependency not explicitly stated in readme

running the make as the current master branch version requires go 1.10 or higher.