### PR TITLE
Issue 1631 - anax/Makefile failure if $GOPATH/bin does not already exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ promote-mac-pkg-and-docker: promote-mac-pkg promote-docker promote-agbot
 anax-k8s-image:
 	rm -rf $(ANAX_K8S_CONTAINER_DIR)/anax
 	rm -rf $(ANAX_K8S_CONTAINER_DIR)/hzn
-	cp $(EXECUTABLE) $(ANAX_K8S_CONTAINER_DIR) 
+	cp $(EXECUTABLE) $(ANAX_K8S_CONTAINER_DIR)
 	cp $(CLI_EXECUTABLE) $(ANAX_K8S_CONTAINER_DIR)
 	@echo "Producing ANAX K8S docker image $(ANAX_K8S_IMAGE_STG) and also tag with $(ANAX_K8S_IMAGE_E2E)"
 	cd $(ANAX_K8S_CONTAINER_DIR) && docker build $(DOCKER_MAYBE_CACHE) -t $(ANAX_K8S_IMAGE_STG) -f Dockerfile .
@@ -525,6 +525,9 @@ i18n-translation: deps i18n-catalog all-nodeps
 
 
 $(TMPGOPATH)/bin/gotext: gopathlinks
+	if [ ! -e $(GOPATH)/bin ]; then \
+		mkdir $(GOPATH)/bin; \
+	fi
 	if [ ! -e "$(TMPGOPATH)/bin/gotext" ]; then \
 		echo "Fetching gotext"; \
 		export GOPATH=$(TMPGOPATH); export PATH=$(TMPGOPATH)/bin:$$PATH; \

--- a/test/README.md
+++ b/test/README.md
@@ -19,13 +19,12 @@ And depending on which PATTERN is chosen, a series of workload containers
 - Install docker
   - `curl https://get.docker.com/ | sh`
 - Install make and jq
-  - `apt update && apt install -y make jq`
+  - `apt update && apt install -y make jq build-essential`
 - Install golang version 1.14.* ...
   - `curl https://dl.google.com/go/go1.14.linux-amd64.tar.gz | tar -xzf- -C /usr/local/`
   - `export PATH=$PATH:/usr/local/go/bin` (and modify your ~/.bashrc file with the same)
-- If you are developing/making changes to anax, install govendor (you can skip this step if you're just building/running tests)
+- GOPATH cannot be set to the same path as GOROOT
   - `export GOPATH=</your/go/path>`
-  - `go get -u github.com/kardianos/govendor`
   - `export ANAX_SOURCE=</path/to/anax>`
 - Set up a single node k8s for testing, follow the instructions here:
   - https://microk8s.io/docs/
@@ -70,7 +69,7 @@ Here is a full description of all the variables you can use to setup the test th
 - NOGPS=1 - dont register the gpstest service.
 - NOLOC=1 - dont register the location service.
 - NOPWS=1 - dont register the weather service. This is a good workload to run when iterating code because it is simple and reliable, it wont get in your way.
-- NOK8S=1 - dont register the k8s-service1. 
+- NOK8S=1 - dont register the k8s-service1.
 - NOANAX=1 - anax is started for API tests but is then stopped and is NOT restarted to run workloads.
 - NOAGBOT=1 - the agbot is never started.
 - HA=1 - register 2 devices (and the workload services) as an HA pair. You will get 2 anax device processes in the container.


### PR DESCRIPTION
- make deps in the main anax file fails if $GOPATH/bin doesn't exist

Also

- remove go get govendor from anax/test readme

- add apt install build-essential to prereqs in anax/test readme to prevent issue on ubuntu where go cannot find gcc