### PR TITLE
Some agent-install.sh user experience improvements

### DIFF
--- a/agent-install/README.md
+++ b/agent-install/README.md
@@ -92,7 +92,7 @@ Command line flags override the corresponding environment variables or config fi
 
 `-v` - show version
 
-`-l` - logging verbosity level (0-5, 5 is verbose; default is 3.)
+`-l` - logging verbosity level (0: silent, 1: critical, 2: error, 3: warning, 4: info, 5: debug), the default is (3: warning)
 
 ## Package Tree
 
@@ -151,3 +151,4 @@ The script relies on an installation packages tree with the following directory 
         ├── horizon-cli-2.24.17.pkg
         └── horizon-cli.crt
 ```
+

--- a/agent-install/README.md
+++ b/agent-install/README.md
@@ -1,4 +1,4 @@
-# Edge node agent-install
+# Edge node agent-install 
 
 ## Overview
 

--- a/agent-install/agent-install.sh
+++ b/agent-install/agent-install.sh
@@ -189,7 +189,7 @@ function validate_mutual_ex() {
 
 	log_debug "validate_mutual_ex() begin"
 
-	if [[ ! -z "${!1}" && ! -z "${!2}" ]]; then
+	if [[ -n "${!1}" && -n "${!2}" ]]; then
 		echo "Both ${1}=${!1} and ${2}=${!2} mutually exlusive parameters are defined, exiting..."
 		exit 1
 	fi
@@ -327,13 +327,13 @@ function validate_args(){
 	validate_mutual_ex "HZN_NODE_POLICY" "HZN_EXCHANGE_PATTERN"
 
 	# if a node policy is non-empty, check if the file exists
-	if [[ ! -z  $HZN_NODE_POLICY ]]; then
+	if [[ -n  $HZN_NODE_POLICY ]]; then
 		check_exist f "$HZN_NODE_POLICY" "The node policy"
         elif [[ "$HZN_EXCHANGE_PATTERN" == "" ]] ; then
                 set_policy_from_exchange
 	fi
 
-    if [[ -z "$WAIT_FOR_SERVICE_ORG" ]] && [[ ! -z "$WAIT_FOR_SERVICE" ]]; then
+    if [[ -z "$WAIT_FOR_SERVICE_ORG" ]] && [[ -n "$WAIT_FOR_SERVICE" ]]; then
     	log_error "Must specify service with -w to use with -o organization. Ignoring -o flag."
 	unset WAIT_FOR_SERVICE_ORG
     fi
@@ -394,7 +394,7 @@ function version_gt() {
 
 # create /etc/default/horizon file for mac or linux
 function create_config() {
-    if [[ ! -z "${HZN_EXCHANGE_URL}" ]] && [[ ! -z "${HZN_FSS_CSSURL}" ]]; then
+    if [[ -n "${HZN_EXCHANGE_URL}" ]] && [[ -n "${HZN_FSS_CSSURL}" ]]; then
             log_info "Found environment variables HZN_EXCHANGE_URL and HZN_FSS_CSSURL, updating horizon config..."
             set -x
 		if [ -z "$CERTIFICATE" ]; then
@@ -578,7 +578,7 @@ function install_linux(){
     fi
 
 	log_info "Checking if the agent port ${ANAX_PORT} is free..."
-	if [ ! -z "$(netstat -nlp | grep \":$ANAX_PORT \")" ]; then
+	if [ -n "$(netstat -nlp | grep \":$ANAX_PORT \")" ]; then
 		log_info "Something is running on ${ANAX_PORT}..."
 		if [ -z "$(netstat -nlp | grep \":$ANAX_PORT \" | grep anax)" ]; then
 			log_notify "It's not anax, please free the port in order to install horizon, exiting..."
@@ -617,8 +617,8 @@ function install_linux(){
         log_info "jq installed"
 	fi
 
-    if [[ ! -z "$PKG_APT_REPO" ]]; then
-	    if [[ ! -z "$PKG_APT_KEY" ]]; then
+    if [[ -n "$PKG_APT_REPO" ]]; then
+	    if [[ -n "$PKG_APT_KEY" ]]; then
 		    log_info "Adding key $PKG_APT_KEY"
 		    set -x
 		    apt-key add "$PKG_APT_KEY"
@@ -856,11 +856,11 @@ function process_node(){
 			if [[ -z "$HZN_EXCHANGE_PATTERN" ]] && [[ -z "$HZN_NODE_POLICY" ]]; then
 				log_info "Neither a pattern nor node policy has not been specified, skipping registration..."
 		 	else
-				if [[ ! -z "$HZN_EXCHANGE_PATTERN" ]]; then
+				if [[ -n "$HZN_EXCHANGE_PATTERN" ]]; then
 					log_info "There's no workloads running, but ${HZN_EXCHANGE_PATTERN} pattern has been specified"
 					log_info "Unregistering the node and register it again with the new ${HZN_EXCHANGE_PATTERN} pattern..."
 				fi
-				if [[ ! -z "$HZN_NODE_POLICY" ]]; then
+				if [[ -n "$HZN_NODE_POLICY" ]]; then
 					log_info "There's no workloads running, but ${HZN_NODE_POLICY} node policy has been specified"
 					log_info "Unregistering the node and register it again with the new ${HZN_NODE_POLICY} node policy..."
 				fi
@@ -887,17 +887,17 @@ function process_node(){
 				fi
 				log_notify "Unregistering the node and register it again without pattern or node policy..."
 			else
-				if [[ ! -z "$HZN_EXCHANGE_PATTERN" ]]; then
+				if [[ -n "$HZN_EXCHANGE_PATTERN" ]]; then
 					log_notify "${HZN_EXCHANGE_PATTERN} pattern has been specified"
 				fi
-				if [[ ! -z "$HZN_NODE_POLICY" ]]; then
+				if [[ -n "$HZN_NODE_POLICY" ]]; then
 					log_notify "${HZN_NODE_POLICY} node policy has been specified"
 				fi
 				if [[ "$OVERWRITE_NODE" != "true" ]] && [ $BATCH_INSTALL -eq 0 ] ; then
-					if [[ ! -z "$HZN_EXCHANGE_PATTERN" ]]; then
+					if [[ -n "$HZN_EXCHANGE_PATTERN" ]]; then
 						echo "Do you want to unregister and register it with a new ${HZN_EXCHANGE_PATTERN} pattern, continue?[y/N]:"
 					fi
-					if [[ ! -z "$HZN_NODE_POLICY" ]]; then
+					if [[ -n "$HZN_NODE_POLICY" ]]; then
 						echo "Do you want to unregister and register it with a new ${HZN_NODE_POLICY} node policy, continue?[y/N]:"
 					fi
 					read RESPONSE
@@ -906,10 +906,10 @@ function process_node(){
 						exit
 					fi
 				fi
-				if [[ ! -z "$HZN_EXCHANGE_PATTERN" ]]; then
+				if [[ -n "$HZN_EXCHANGE_PATTERN" ]]; then
 					log_notify "Unregistering the node and register it again with the new ${HZN_EXCHANGE_PATTERN} pattern..."
 				fi
-				if [[ ! -z "$HZN_NODE_POLICY" ]]; then
+				if [[ -n "$HZN_NODE_POLICY" ]]; then
 					log_notify "Unregistering the node and register it again with the new ${HZN_NODE_POLICY} node policy..."
 				fi
 			fi
@@ -1094,7 +1094,7 @@ function add_autocomplete() {
         AUTOCOMPLETE="/usr/local/share/horizon/hzn_bash_autocomplete.sh"
     fi
 
-    if [[ ! -z "$AUTOCOMPLETE" ]]; then
+    if [[ -n "$AUTOCOMPLETE" ]]; then
     	if [ -f ~/.${SHELL_FILE}rc ]; then
             grep -q "^source ${AUTOCOMPLETE}" ~/.${SHELL_FILE}rc || \
             echo "source ${AUTOCOMPLETE}" >> ~/.${SHELL_FILE}rc
@@ -1125,7 +1125,7 @@ function detect_os() {
     log_debug "detect_os() end"
 }
 
-# detects linux distributive name, version, and codename
+# detects linux distribution name, version, and codename
 function detect_distro() {
     log_debug "detect_distro() begin"
 
@@ -1153,7 +1153,7 @@ function detect_distro() {
         CODENAME=$(echo ${VERSION} | sed -e 's/.*(\(.*\))/\1/')
     fi
 
-    log_info "Detected distributive is ${DISTRO}, verison is ${VER}, codename is ${CODENAME}"
+    log_info "Detected distribution is ${DISTRO}, verison is ${VER}, codename is ${CODENAME}"
 
     log_debug "detect_distro() end"
 }
@@ -1182,7 +1182,7 @@ function detect_arch() {
     log_debug "detect_arch() end"
 }
 
-# checks if OS/distributive/codename/arch is supported
+# checks if OS/distribution/codename/arch is supported
 function check_support() {
     log_debug "check_support() begin"
 
@@ -1212,7 +1212,7 @@ function check_requirements() {
 
     if [ "$OS" = "linux" ]; then
         detect_distro
-        log_info "Checking support of detected Linux distributive..."
+        log_info "Checking support of detected Linux distribution..."
         check_support "${SUPPORTED_LINUX_DISTRO[*]}" "$DISTRO"
         log_info "Checking support of detected Linux version/codename..."
         check_support "${SUPPORTED_LINUX_VERSION[*]}" "$CODENAME"
@@ -1271,7 +1271,7 @@ function check_node_state() {
 		if [ $BATCH_INSTALL -eq 0 ] && [[ "$NODE_STATE" = "configured" ]] && [[ ! $OVERWRITE = "true" ]]; then
 			# node is configured need to ask what to do
 			log_notify "Your node is registered"
-			VERWRITE_NODE=true
+			OVERWRITE_NODE=true
 			log_notify "The configuration will be overwritten..."
 		elif [[ "$NODE_STATE" = "unconfigured" ]]; then
 			# node is unconfigured
@@ -1395,7 +1395,7 @@ check_requirements
 check_node_state
 
 if [[ "$OS" == "linux" ]]; then
-	echo `now` "Detection results: OS is ${OS}, distributive is ${DISTRO}, release is ${CODENAME}, architecture is ${ARCH}"
+	echo `now` "Detection results: OS is ${OS}, distribution is ${DISTRO}, release is ${CODENAME}, architecture is ${ARCH}"
 	install_${OS} ${OS} ${DISTRO} ${CODENAME} ${ARCH}
 elif [[ "$OS" == "macos" ]]; then
 	echo `now` "Detection results: OS is ${OS}"


### PR DESCRIPTION
Updates in this PR are the checked boxes in this issue:
https://app.zenhub.com/workspaces/open-horizon-5877f2c6a8ad090f31c73853/issues/open-horizon/anax/1502

- removed creation of `~/.hzn/hzn.json` for Mac around line 542 
- added usage description of `-l`
- moved agent-install.crt to `/etc/horizon` ...this had to be `/private/etc/horizon` for Mac because docker on Mac does not have access to `/etc` by default, but it does have access to `/private` which is a symbolic link to `/etc` 
- removed ` Do you want to overwrite the current node configuration?[y/N]: `
- when rerunning agent-install.sh with the same install pkgs, it won't install them, unless a force flag is specified
- /agent-install.sh -h will exit code of 0 (if the usage is shown as a result of invalid args, then the exit code should be 1)
- getting node IP address with `ipconfig getifaddr en0` on Mac
- added the -z flag to the usage msg
- changed all occurrences of set +x to { set +x; } 2>/dev/null so it doesn't get printed