### PR TITLE
Issue 1635 - makefile failure on 'make all-nodeps'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,9 +166,9 @@ ifndef verbose
 endif
 
 all: deps all-nodeps
-all-nodeps: gopathlinks $(EXECUTABLE) $(CLI_EXECUTABLE) $(CSS_EXECUTABLE) $(ESS_EXECUTABLE)
+all-nodeps: gopathlinks gofolders $(EXECUTABLE) $(CLI_EXECUTABLE) $(CSS_EXECUTABLE) $(ESS_EXECUTABLE)
 
-deps: pkgdeps i18n-catalog
+deps: gofolders pkgdeps i18n-catalog
 
 noi18n: pkgdeps all-nodeps
 
@@ -511,6 +511,9 @@ pkgdeps:
 	@echo "Fetching dependencies"
 	go mod tidy
 
+gofolders:
+	mkdir -p $(GOPATH)/pkg $(GOPATH)/bin
+
 i18n-catalog: pkgdeps $(TMPGOPATH)/bin/gotext
 	@echo "Creating message catalogs"
 	cd $(PKGPATH) && \
@@ -525,9 +528,6 @@ i18n-translation: deps i18n-catalog all-nodeps
 
 
 $(TMPGOPATH)/bin/gotext: gopathlinks
-	if [ ! -e $(GOPATH)/bin ]; then \
-		mkdir $(GOPATH)/bin; \
-	fi
 	if [ ! -e "$(TMPGOPATH)/bin/gotext" ]; then \
 		echo "Fetching gotext"; \
 		export GOPATH=$(TMPGOPATH); export PATH=$(TMPGOPATH)/bin:$$PATH; \

--- a/go.mod
+++ b/go.mod
@@ -37,9 +37,11 @@ require (
 	github.com/vbatts/tar-split v0.11.1 // indirect
 	go.etcd.io/bbolt v1.3.3 // indirect
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
-	golang.org/x/net v0.0.0-20190606173856-1492cefac77f // indirect
+	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20191115151921-52ab43148777
 	golang.org/x/text v0.3.3-0.20191031172631-4b67af870c6f
+	golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gotest.tools/v3 v3.0.2 // indirect


### PR DESCRIPTION
$GOPATH/pkg doesn't exist on a new environment when pkgdeps is skipped. This causes 'make all-nodeps' to fail