### PR TITLE
Issue 1635 - horizon-deb-packager failing on mkdir /home/max/go/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,7 +510,7 @@ anax-k8s-clean:
 
 gofolders:
 ifneq ($(GOPATH),$(TMPGOPATH))
-	if [ ! -z $(GOPATH) ]; then \
+	if [ ! -z $(GOPATH) ] && [ -w $(GOPATH) ] && [ -d $(GOPATH) ]; then \
 		mkdir -p $(GOPATH)/pkg $(GOPATH)/bin; \
 	fi
 endif


### PR DESCRIPTION
Check that $GOPATH is writable and a directory