### PR TITLE
Issue 1589 - part2: Stop ImageFetcher and Container workers for clust…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -620,10 +620,7 @@ test-ci: gopathlinks
 		GOPATH=$(TMPGOPATH) $(COMPILE_ARGS) go test -cover -tags=ci $(PKGS)
 
 # N.B. this doesn't run ci tests, the ones that require CI system setup
-check: deps lint test test-integration
-
-check-noi18n: lint test test-integration
-
+check: lint test test-integration
 
 # build sequence diagrams
 diagrams:

--- a/anax-in-k8s/config/anax.json
+++ b/anax-in-k8s/config/anax.json
@@ -2,7 +2,6 @@
   "Edge": {
     "APIListen": "127.0.0.1:8510",
     "DBPath": "/var/horizon/",
-    "DockerEndpoint": "unix:///var/run/docker.sock",
     "StaticWebContent": "/usr/horizon/web/",
     "PublicKeyPath": "/etc/horizon/trust/mtn-publicKey.pem",
     "TrustSystemCACerts": true,
@@ -19,7 +18,7 @@
     "TrustCertUpdatesFromOrg": true,
     "TrustDockerAuthFromOrg": true,
     "ServiceUpgradeCheckIntervalS": 300,
-    "MultipleAnaxInstances": true,
+    "MultipleAnaxInstances": false,
     "FileSyncService": {}
   },
   "ArchSynonyms": {

--- a/api/api_node.go
+++ b/api/api_node.go
@@ -81,7 +81,7 @@ func (a *API) node(w http.ResponseWriter, r *http.Request) {
 
 		a.EC = worker.NewExchangeContext(fmt.Sprintf("%v/%v", *device.Org, *device.Id), *device.Token, a.Config.Edge.ExchangeURL, a.Config.GetCSSURL(), a.Config.Collaborators.HTTPClientFactory)
 
-		a.Messages() <- events.NewEdgeRegisteredExchangeMessage(events.NEW_DEVICE_REG, *device.Id, *device.Token, *device.Org, *device.Pattern)
+		a.Messages() <- events.NewEdgeRegisteredExchangeMessage(events.NEW_DEVICE_REG, *device.Id, *device.Token, *device.Org, *device.Pattern, *device.NodeType)
 
 		writeResponse(w, exDev, http.StatusCreated)
 

--- a/events/events.go
+++ b/events/events.go
@@ -632,15 +632,16 @@ func NewServicePolicyDeletedMessage(id EventId, bPolOrg, bPolName, svcId string)
 
 // This event indicates that the edge device has been registered in the exchange
 type EdgeRegisteredExchangeMessage struct {
-	event     Event
-	device_id string
-	token     string
-	org       string
-	pattern   string
+	event      Event
+	device_id  string
+	token      string
+	org        string
+	pattern    string
+	deviceType string
 }
 
 func (e EdgeRegisteredExchangeMessage) String() string {
-	return fmt.Sprintf("event: %v, device_id: %v, token: %v, org: %v, pattern: %v", e.event, e.device_id, "********", e.org, e.pattern)
+	return fmt.Sprintf("event: %v, device_id: %v, token: %v, org: %v, pattern: %v, deviceType: %v", e.event, e.device_id, "********", e.org, e.pattern, e.deviceType)
 }
 
 func (e EdgeRegisteredExchangeMessage) ShortString() string {
@@ -667,16 +668,21 @@ func (e *EdgeRegisteredExchangeMessage) Pattern() string {
 	return e.pattern
 }
 
-func NewEdgeRegisteredExchangeMessage(evId EventId, device_id string, token string, org string, pattern string) *EdgeRegisteredExchangeMessage {
+func (e *EdgeRegisteredExchangeMessage) DeviceType() string {
+	return e.deviceType
+}
+
+func NewEdgeRegisteredExchangeMessage(evId EventId, device_id string, token string, org string, pattern string, deviceType string) *EdgeRegisteredExchangeMessage {
 
 	return &EdgeRegisteredExchangeMessage{
 		event: Event{
 			Id: evId,
 		},
-		device_id: device_id,
-		token:     token,
-		org:       org,
-		pattern:   pattern,
+		device_id:  device_id,
+		token:      token,
+		org:        org,
+		pattern:    pattern,
+		deviceType: deviceType,
 	}
 }
 

--- a/governance/status.go
+++ b/governance/status.go
@@ -76,8 +76,19 @@ func (w *GovernanceWorker) ReportDeviceStatus() {
 		return
 	}
 
-	glog.Info("started the status report to the exchange.")
+	// TODO: not reporting the cluster node status for now. will be added later.
+	if w.deviceType == persistence.DEVICE_TYPE_CLUSTER {
+		return
+	}
 
+	// for 'device' node type, it has to have DockerEndpoint set
+	if w.Config.Edge.DockerEndpoint == "" && w.deviceType == persistence.DEVICE_TYPE_DEVICE {
+		glog.Infof("Skip reporting the status to the exchange because DockerEndpoint is not set in the configuration.")
+		return
+	}
+
+	glog.Info("started the status report to the exchange.")
+	
 	w.deviceStatus = nil
 	var device_status DeviceStatus
 

--- a/main.go
+++ b/main.go
@@ -166,8 +166,12 @@ func main() {
 		workers.Add(agreement.NewAgreementWorker("Agreement", cfg, db, pm))
 		workers.Add(governance.NewGovernanceWorker("Governance", cfg, db, pm))
 		workers.Add(exchange.NewExchangeMessageWorker("ExchangeMessages", cfg, db))
-		workers.Add(container.NewContainerWorker("Container", cfg, db, authm))
-		workers.Add(imagefetch.NewImageFetchWorker("ImageFetch", cfg, db))
+		if containerWorker := container.NewContainerWorker("Container", cfg, db, authm); containerWorker != nil {
+			workers.Add(containerWorker)
+		}
+		if imageWorker := imagefetch.NewImageFetchWorker("ImageFetch", cfg, db); imageWorker != nil {
+			workers.Add(imageWorker)
+		}
 		workers.Add(kube_operator.NewKubeWorker("Kube", cfg, db))
 		workers.Add(resource.NewResourceWorker("Resource", cfg, db, authm))
 		workers.Add(changes.NewChangesWorker("ExchangeChanges", cfg, db))


### PR DESCRIPTION
…er node
1  The container worker and Image Fetch workers might be able to terminate themselves when running on an edge cluster agent.
2  Fix agent so that MultipleAnaxInstances can be set to false in the agent k8s container config file.
3  Fix agent to ensure that it never creates a go-docker client when running in k8s, then remove "DockerEndpoint" from the agent k8s container config file.