### PR TITLE
Added device_cleanup_agent_files() to agent-install.sh

### DIFF
--- a/agent-install/agent-install.sh
+++ b/agent-install/agent-install.sh
@@ -1352,6 +1352,21 @@ function check_node_state() {
 	log_debug "check_node_state() end"
 }
 
+# removes agent-install files and deb packages after successful install
+function device_cleanup_agent_files() {
+    log_notify "device_cleanup_agent_files() begin"
+
+    files_to_remove=( 'agent-install.cfg' *'horizon'* )
+
+    set +e
+    for file in "${files_to_remove[@]}"; do
+        rm -fv $file
+    done
+    set -e
+
+    log_notify "device_cleanup_agent_files() end"
+}
+
 function unzip_install_files() {
 	if [ -f $AGENT_INSTALL_ZIP ]; then
 		tar -zxf $AGENT_INSTALL_ZIP
@@ -1800,6 +1815,7 @@ if [[ $NODE_ID =~ : && -n ${NODE_ID#*:} ]]; then   # tests if NODE_ID contains a
 fi
 
 if [ -f "$AGENT_INSTALL_ZIP" ]; then
+    device_cleanup_agent_files
 	unzip_install_files
 	find_node_id
 	NODE_ID=$(echo "$NODE_ID" | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]]*$//' )
@@ -1829,6 +1845,7 @@ if [ "${DEPLOY_TYPE}" == "device" ]; then
 	fi
 
 	add_autocomplete
+
 elif [ "${DEPLOY_TYPE}" == "cluster" ]; then
 	echo `now` "Install agent on edge cluster"
 	set +e

--- a/agent-install/agent-install.sh
+++ b/agent-install/agent-install.sh
@@ -1352,7 +1352,7 @@ function check_node_state() {
 	log_debug "check_node_state() end"
 }
 
-# removes agent-install files and deb packages after successful install
+# removes agent-install files and deb packages before bulk install
 function device_cleanup_agent_files() {
     log_notify "device_cleanup_agent_files() begin"
 


### PR DESCRIPTION
added device_cleanup_agent_files() to remove leftover deb packages and agent-install files when using bulk install method

**Output of the function with the following directory contents**
```
root@adonis1:~# ls
agent-install.cfg                             Dockerfile.arm    horizon_2.26.0~ppa~ubuntu.bionic_amd64.deb      release4.0
agent-install.sh                              Dockerfile.arm64  horizon-cli_2.26.0~ppa~ubuntu.bionic_amd64.deb  script.sh
bluehorizon_2.26.0~ppa~ubuntu.bionic_all.deb  examples          icpcreds                                        service.sh
creds                                         files             Makefile                                        squid
Dockerfile.amd64                              horizon           node-id-mapping.csv                             testSDO


agent-install.cfg agent-install.sh bluehorizon_2.26.0~ppa~ubuntu.bionic_all.deb creds Dockerfile.amd64 Dockerfile.arm Dockerfile.arm64 examples files horizon horizon_2.26.0~ppa~ubuntu.bionic_amd64.deb horizon-cli_2.26.0~ppa~ubuntu.bionic_amd64.deb icpcreds Makefile node-id-mapping.csv release4.0 script.sh service.sh squid testSDO

removed 'agent-install.cfg'
0
removed 'bluehorizon_2.26.0~ppa~ubuntu.bionic_all.deb'
0
1                <-------- this was when it tried to delete a directory called horizon 
removed 'horizon_2.26.0~ppa~ubuntu.bionic_amd64.deb'
0
removed 'horizon-cli_2.26.0~ppa~ubuntu.bionic_amd64.deb'
0

agent-install.sh creds Dockerfile.amd64 Dockerfile.arm Dockerfile.arm64 examples files horizon icpcreds Makefile node-id-mapping.csv release4.0 script.sh service.sh squid testSDO
```