### PR TITLE
Fix Issue 1780 - agent-install.sh does not check for docker pre-requi…

### DIFF
--- a/agent-install/agent-install.sh
+++ b/agent-install/agent-install.sh
@@ -267,12 +267,7 @@ function validate_args(){
                 log_notify "$KUBECTL is not available, please install $KUBECTL and ensure that it is found on your \$PATH. Exiting..."
       fi
 
-    # check docker is available
-    docker --help > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
-            log_notify "docker is not available, please install docker. Exiting..."
-    fi
-
+      check_installed "docker" "Docker"
     fi
 
     check_empty "$SKIP_REGISTRATION" "registration flag"


### PR DESCRIPTION
When verifying issue 1780, I uninstall docker from my machine, I found the agent install script will exit without printing out the expected message "Docker not found, please install it. Exiting...". `docker --help > /dev/null 2>&1` will exit the script since before printing out the message, since have `set -e` at the beginning. Change to use an existing method `check_installed()` for the checking.