### PR TITLE
Minor fix: removed blank like in hzn register output

### DIFF
--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -265,7 +265,6 @@ func DoIt(org, pattern, nodeIdTok, userPw, inputFile string, nodeOrgFromFlag str
 			}
 			break
 		}
-		msgPrinter.Println()
 	}
 
 	// Use the exchange node pattern if any


### PR DESCRIPTION
The output of `hzn register ...` looks like this when the node already exists:

```
Horizon Exchange base URL: https://icp-console.apps.rested-squid.purple-chesterfield.com/edge-exchange/v1
Node mycluster/bp-edge-cluster-3 exists in the Exchange

No pattern or node policy is specified. Will proceeed with the existing node policy.
Initializing the Horizon node with node type 'cluster'...
Warning: no input file was specified. This is only valid if none of the services need variables set (including GPS coordinates).
However, if there is 'userInput' specified in the node already in the Exchange, the userInput will be used.
Changing Horizon state to configured to register this node with Horizon...
Horizon node is registered. Workload agreement negotiation should begin shortly. Run 'hzn agreement list' to view.
```

This PR removes that blank like.