### PR TITLE
add more info in agent-install.sh usage and Issue 1846

### DIFF
--- a/agent-install/agent-install.sh
+++ b/agent-install/agent-install.sh
@@ -1668,8 +1668,9 @@ function create_namespace() {
             log_notify "Failed to create namespace ${AGENT_NAMESPACE}, exiting..."
             exit 1
         fi
+	log_notify "namespace ${AGENT_NAMESPACE} created"
     else
-        log_info "namespace ${AGENT_NAMESPACE} exists, skip creating namespace"
+        log_notify "namespace ${AGENT_NAMESPACE} exists, skip creating namespace"
     fi
 
     log_debug "create_namespace() end"
@@ -1678,21 +1679,36 @@ function create_namespace() {
 # Cluster only: to create service account for agent namespace and binding to cluster-admin clusterrole
 function create_service_account() {
 	log_debug "create_service_account() begin"
-	$KUBECTL create serviceaccount ${SERVICE_ACCOUNT_NAME} -n ${AGENT_NAMESPACE}
-	if [ $? -ne 0 ]; then
-        log_notify "Failed to create service account ${SERVICE_ACCOUNT_NAME}, exiting..."
-        exit 1
-    fi
-	log_info "serviceaccount ${SERVICE_ACCOUNT_NAME} created"
 
-	log_info "Binding ${SERVICE_ACCOUNT_NAME} to cluster admin..."
-	$KUBECTL create clusterrolebinding ${CLUSTER_ROLE_BINDING_NAME} --serviceaccount=${AGENT_NAMESPACE}:${SERVICE_ACCOUNT_NAME} --clusterrole=cluster-admin
+	log_info "checking if serviceaccont exist..."
+	$KUBECTL get serviceaccount ${SERVICE_ACCOUNT_NAME} -n ${AGENT_NAMESPACE} 2>/dev/null
+	
 	if [ $? -ne 0 ]; then
-        log_notify "Failed to create clusterrolebinding for ${AGENT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}, exiting..."
-        exit 1
-    fi
-	log_info "clusterrolebinding ${CLUSTER_ROLE_BINDING_NAME} created"
+		log_info "serviceaccount ${SERVICE_ACCOUNT_NAME} does not exist, creating..."
+		$KUBECTL create serviceaccount ${SERVICE_ACCOUNT_NAME} -n ${AGENT_NAMESPACE}
+		if [ $? -ne 0 ]; then
+        		log_notify "Failed to create service account ${SERVICE_ACCOUNT_NAME}, exiting..."
+        		exit 1
+    		fi
+		log_notify "serviceaccount ${SERVICE_ACCOUNT_NAME} created"
 
+	else
+		log_notify "serviceaccount ${SERVICE_ACCOUNT_NAME} exists, skip creating serviceaccount"
+	fi
+
+	log_info "checking if clusterrolebinding exist..."
+	$KUBECTL get clusterrolebinding ${CLUSTER_ROLE_BINDING_NAME} 2>/dev/null
+	if [ $? -ne 0 ]; then
+		log_info "Binding ${SERVICE_ACCOUNT_NAME} to cluster admin..."
+		$KUBECTL create clusterrolebinding ${CLUSTER_ROLE_BINDING_NAME} --serviceaccount=${AGENT_NAMESPACE}:${SERVICE_ACCOUNT_NAME} --clusterrole=cluster-admin
+		if [ $? -ne 0 ]; then
+        		log_notify "Failed to create clusterrolebinding for ${AGENT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}, exiting..."
+        		exit 1
+    		fi
+		log_notify "clusterrolebinding ${CLUSTER_ROLE_BINDING_NAME} created"
+	else
+		log_notify "clusterrolebinding ${CLUSTER_ROLE_BINDING_NAME} exists, skip creating clusterrolebinding"
+	fi
 	log_debug "create_service_account() end"
 }
 
@@ -1700,13 +1716,19 @@ function create_service_account() {
 function create_secret() {
     log_debug "create_secrets() begin"
 
-    log_info "creating secret for cert file..."
-    $KUBECTL create secret generic ${SECRET_NAME} --from-file=${CERTIFICATE} -n ${AGENT_NAMESPACE}
+    log_info "checking if secret ${SECRET_NAME} exist..."
+    $KUBECTL get secret ${SECRET_NAME} -n ${AGENT_NAMESPACE} 2>/dev/null
     if [ $? -ne 0 ]; then
-        log_notify "Failed to create secret ${SECRET_NAME} from cert file ${CERTIFICATE}, exiting..."
-        exit 1
+    	log_info "creating secret for cert file..."
+    	$KUBECTL create secret generic ${SECRET_NAME} --from-file=${CERTIFICATE} -n ${AGENT_NAMESPACE}
+    	if [ $? -ne 0 ]; then
+        	log_notify "Failed to create secret ${SECRET_NAME} from cert file ${CERTIFICATE}, exiting..."
+        	exit 1
+    	fi
+    	log_notify "secret ${SECRET_NAME} created"
+    else
+        log_notify "secret ${SECRET_NAME} exists, skip creating secret"
     fi
-    log_info "secret ${SECRET_NAME} created"
 
     log_debug "create_secrets() end"
 }
@@ -1714,13 +1736,20 @@ function create_secret() {
 # Cluster only: to create configmap based on /tmp/agent-install-horizon-env for agent deployment
 function create_configmap() {
     log_debug "create_configmap() begin"
-    log_info "create configmap from ${HZN_ENV_FILE}..."
-    $KUBECTL create configmap ${CONFIGMAP_NAME} --from-file=horizon=${HZN_ENV_FILE} -n ${AGENT_NAMESPACE}
+
+    log_info "checking if configmap ${CONFIGMAP_NAME} exist..."
+    $KUBECTL get configmap ${CONFIGMAP_NAME} -n ${AGENT_NAMESPACE} 2>/dev/null
     if [ $? -ne 0 ]; then
-        log_notify "Failed to create configmap ${CONFIGMAP_NAME} from ${HZN_ENV_FILE}, exiting..."
-        exit 1
+    	log_info "create configmap from ${HZN_ENV_FILE}..."
+    	$KUBECTL create configmap ${CONFIGMAP_NAME} --from-file=horizon=${HZN_ENV_FILE} -n ${AGENT_NAMESPACE}
+    	if [ $? -ne 0 ]; then
+        	log_notify "Failed to create configmap ${CONFIGMAP_NAME} from ${HZN_ENV_FILE}, exiting..."
+        	exit 1
+    	fi
+    	log_notify "configmap ${CONFIGMAP_NAME} created."
+    else
+        log_notify "configmap ${CONFIGMAP_NAME} exists, skip creating configmap"
     fi
-    log_info "configmap ${CONFIGMAP_NAME} created."
 
     log_debug "create_configmap() end"
 }
@@ -1729,13 +1758,19 @@ function create_configmap() {
 function create_persistent_volume() {
     log_debug "create_persistent_volume() begin"
 
-    log_info "creating persistent volume claim..."
-    $KUBECTL apply -f persistentClaim.yml -n ${AGENT_NAMESPACE}
+    log_info "checking if persistent volume claim ${PVC_NAME} exist..."
+    $KUBECTL get pvc ${PVC_NAME} -n ${AGENT_NAMESPACE} 2>/dev/null
     if [ $? -ne 0 ]; then
-        log_notify "Failed to create persistent volume claim, exiting..."
-        exit 1
+    	log_info "creating persistent volume claim..."
+    	$KUBECTL apply -f persistentClaim.yml -n ${AGENT_NAMESPACE}
+    	if [ $? -ne 0 ]; then
+        	log_notify "Failed to create persistent volume claim, exiting..."
+        	exit 1
+    	fi
+    	log_notify "persistent volume claim created"
+    else
+        log_notify "persistent volume claim ${PVC_NAME} exists, skip creating persistent volume claim"
     fi
-    log_info "persistent volume claim created"
 
     log_debug "create_persistent_volume() end"
 }

--- a/agent-install/agent-install.sh
+++ b/agent-install/agent-install.sh
@@ -57,8 +57,12 @@ function help() {
 $(basename "$0") <options> -- installing Horizon software
 where:
     \$HZN_EXCHANGE_URL, \$HZN_FSS_CSSURL, \$HZN_ORG_ID, either \$HZN_EXCHANGE_USER_AUTH or \$HZN_EXCHANGE_NODE_AUTH, variables must be defined either in a config file or environment,
-    \$IMAGE_ON_EDGE_CLUSTER_REGISTRY must be defined in a config file or environment if deploy type is "Cluster", format: <registry-host>/<ocp-project>/amd64_agent (without tag), for microsk8s: localhost:32000/agent-repo/amd64_agent
+    
+For agent install on edge cluster:
+    \$IMAGE_ON_EDGE_CLUSTER_REGISTRY must be defined in a config file or environment if deploy type is "cluster", format: <registry-host>/<ocp-project>/amd64_agent (without tag), for microsk8s: localhost:32000/agent-repo/amd64_agent
+    if set \$EDGE_CLUSTER_STORAGE_CLASS in environement, the value of "EDGE_CLUSTER_STORAGE_CLASS" in configuration file will not be used
 
+Parameters:
     -c          - path to a certificate file
     -k          - path to a configuration file (if not specified, uses agent-install.cfg in current directory, if present)
     -p          - pattern name to register with (if not specified, registers node w/o pattern)


### PR DESCRIPTION
agent-install usage information:

```javascript
$ ./agent-install.sh -h
agent-install.sh <options> -- installing Horizon software
where:
    $HZN_EXCHANGE_URL, $HZN_FSS_CSSURL, $HZN_ORG_ID, either $HZN_EXCHANGE_USER_AUTH or $HZN_EXCHANGE_NODE_AUTH, variables must be defined either in a config file or environment,
    
For agent install on edge cluster:
    $IMAGE_ON_EDGE_CLUSTER_REGISTRY must be defined in a config file or environment if deploy type is "cluster", format: <registry-host>/<ocp-project>/amd64_agent (without tag), for microsk8s: localhost:32000/agent-repo/amd64_agent
    if set $EDGE_CLUSTER_STORAGE_CLASS in environement, the value of "EDGE_CLUSTER_STORAGE_CLASS" in configuration file will not be used

Parameters:
    -c          - path to a certificate file
    -k          - path to a configuration file (if not specified, uses agent-install.cfg in current directory, if present)
    -p          - pattern name to register with (if not specified, registers node w/o pattern)
    -i          - installation packages location (if not specified, uses current directory). if the argument begins with 'http' or 'https', will use as an apt repository
    -j          - file location for the public key for an apt repository specified with '-i'
    -t          - set a branch to use in the apt repo specified with -i. default is 'updates'
    -n          - path to a node policy file
    -s          - skip registration
    -v          - show version
    -l          - logging verbosity level (0: silent, 1: critical, 2: error, 3: warning, 4: info, 5: debug), the default is (3: warning)
    -u          - exchange user authorization credentials
    -a 		- exchange node authorization credentials
    -d          - the id to register this node with
    -f          - install older version without prompt. overwrite configured node without prompt.
    -b 			- skip any prompts for user input
    -w          - wait for the named service to start executing on this node
    -o          - specify an org id for the service specified with '-w'
    -z 		- specify the name of your agent installation tar file. Default is ./agent-install-files.tar.gz
    -D		- specify deploy type (device, cluster. If not specifed, uses device by default).
    -U		- specify internal url for edge cluster registry (If not specified, this script will detect if cluster is local. Use "image-registry.openshift-image-registry.svc:5000" by default for ocp image registry)

Example: ./agent-install.sh -i <path_to_package(s)>
```

Second commit is to handle issue #1846 