### PR TITLE
Issue 1888 - agbot failed to cache the new patterns if the there are …

### DIFF
--- a/agreementbot/agreementbot.go
+++ b/agreementbot/agreementbot.go
@@ -1423,7 +1423,7 @@ func (w *AgreementBotWorker) generatePolicyFromPatterns(msg *events.ExchangeChan
 	glog.V(5).Infof(AWlogString(fmt.Sprintf("scanning patterns for updates")))
 
 	// Iterate over each org in the PatternManager and process all the patterns in that org
-	for org, _ := range w.PatternManager.OrgPatterns {
+	for _, org := range w.PatternManager.GetAllPatternOrgs() {
 
 		var exchangePatternMetadata map[string]exchange.Pattern
 		var err error

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash
 
 #Versioning
-DOCKER_EXCH_TAG := 2.23.0
+DOCKER_EXCH_TAG ?= 2.23.0
 PKG_URL_BASE := http://169.45.88.181/linux/ubuntu
 PKGS_URL := $(PKG_URL_BASE)/dists/xenial-testing/main/binary-amd64/Packages
 DEB_PKGS_URL := $(PKG_URL_BASE)/pool/main/h/horizon


### PR DESCRIPTION
…no patterns in a org at the start up
I tested the code with the following cases:

1. start agbot when pattern orgs and policy orgs are added added for the agbot. Add first pattern for the org. Then register a node with the pattern, agreements formed.
2. same as above except that it is for the policy case. The agreements formed.
3. start agbot when there are no pattern orgs for the agbot. Add pattern orgs for the agbot. Add first pattern for the org. Then register a node with the pattern, agreements formed.
4. same as above except that it is for the policy case. The agreements formed.
5. start agbot when pattern orgs are added for the agbot and there are patterns in the org. Delete all the patterns from the org. Then add a pattern in the org. Register a node, agreements formed.
6. same as above except that it is for the policy case. The agreements formed.