### PR TITLE
Fixed RPM build on Linux hosts

### DIFF
--- a/pkg/rpm/horizon-cli/Makefile
+++ b/pkg/rpm/horizon-cli/Makefile
@@ -42,23 +42,23 @@ rpmbuild: require-version
 	@# If you add files copied, add them to .gitignore too
 	cp ../../../cli/hzn fs/usr/horizon/bin
 	cp ../../../anax-in-container/horizon-container fs/usr/horizon/bin
-	cp ../../../agent-install/agent-install.sh fs/usr/horizon/bin
-	cp ../../../agent-install/agent-uninstall.sh fs/usr/horizon/bin
-	cp ../../../agent-install/edgeNodeFiles.sh fs/usr/horizon/bin
+	cp ../../../agent-install/{agent-install.sh,agent-uninstall.sh,edgeNodeFiles.sh} fs/usr/horizon/bin
 	cp ../../../cli/bash_completion/hzn_bash_autocomplete.sh fs/etc/bash_completion.d
 	mkdir -p fs/usr/share/man/man1
 	gzip --stdout ../../../cli/man1/hzn.1 > fs/usr/share/man/man1/hzn.1.gz
 	for m in ../../../cli/man1/hzn.1.*; do \
-	  if [[ ! -f $$m ]]; then continue; fi; \
+	  test -f $$m || continue; \
 	  d="fs/usr/share/man/$${m##../../../cli/man1/hzn.1.}/man1"; \
 	  mkdir -p $$d; \
 	  gzip --stdout $$m > "$$d/hzn.1.gz"; \
 	done
-	mkdir -p $(RPMROOT)/{SOURCES,SRPMS,SRPMS}
-	rm -f $(RPMNAME)-$(VERSION); ln -s . $(RPMNAME)-$(VERSION)  # so the tar file files can have this prefix
+	mkdir -p $(RPMROOT)/SOURCES
+	mkdir -p $(RPMROOT)/RPMS
+	mkdir -p $(RPMROOT)/SRPMS
+	rm -f $(RPMNAME)-$(VERSION)
 	rm -f $(RPMROOT)/SOURCES/$(RPMNAME)-*.tar.gz
 	#tar --exclude '.git*' -X .tarignore -H -czf $(RPMROOT)/SOURCES/$(RPMNAME)-$(VERSION).tar.gz $(RPMNAME)-$(VERSION)
-	tar -H -czf $(RPMROOT)/SOURCES/$(RPMNAME)-$(VERSION).tar.gz $(RPMNAME)-$(VERSION)
+	tar -czf $(RPMROOT)/SOURCES/$(RPMNAME)-$(VERSION).tar.gz .
 	rm -rf $(RPMROOT)/BUILD/horizon-cli-*
 	rm -f $(RPMROOT)/SRPMS/$(RPMNAME)*rpm $(RPMROOT)/RPMS/$(rpm_arch)/$(RPMNAME)*rpm $(RPMROOT)/RPMS/$(rpm_arch)/$(RPMNAME)*rpm.gz
 	rpmbuild --target $(rpm_arch)-linux -ba $(RPMNAME).spec

--- a/pkg/rpm/horizon-cli/Makefile
+++ b/pkg/rpm/horizon-cli/Makefile
@@ -42,7 +42,9 @@ rpmbuild: require-version
 	@# If you add files copied, add them to .gitignore too
 	cp ../../../cli/hzn fs/usr/horizon/bin
 	cp ../../../anax-in-container/horizon-container fs/usr/horizon/bin
-	cp ../../../agent-install/{agent-install.sh,agent-uninstall.sh,edgeNodeFiles.sh} fs/usr/horizon/bin
+	cp ../../../agent-install/agent-install.sh fs/usr/horizon/bin
+	cp ../../../agent-install/agent-uninstall.sh fs/usr/horizon/bin
+	cp ../../../agent-install/edgeNodeFiles.sh fs/usr/horizon/bin
 	cp ../../../cli/bash_completion/hzn_bash_autocomplete.sh fs/etc/bash_completion.d
 	mkdir -p fs/usr/share/man/man1
 	gzip --stdout ../../../cli/man1/hzn.1 > fs/usr/share/man/man1/hzn.1.gz

--- a/pkg/rpm/horizon-cli/horizon-cli.spec
+++ b/pkg/rpm/horizon-cli/horizon-cli.spec
@@ -23,7 +23,7 @@ Provides: horizon-cli = %{version}
 Open-horizon command line interface
 
 %prep
-%setup -q
+%setup -c
 
 %build
 # This phase is done in ~/rpmbuild/BUILD/horizon-cli-<version> . All of the tarball source has been unpacked there and

--- a/pkg/rpm/horizon/Makefile
+++ b/pkg/rpm/horizon/Makefile
@@ -43,11 +43,13 @@ rpmbuild: require-version
 	cp ../../../anax fs/usr/horizon/bin
 	cp -a ../../../cli/samples fs/usr/horizon
 	cp -a ../../../LICENSE.txt fs/usr/horizon
-	mkdir -p $(RPMROOT)/{SOURCES,SRPMS,SRPMS}
-	rm -f $(RPMNAME)-$(VERSION); ln -s . $(RPMNAME)-$(VERSION)  # so the tar file files can have this prefix
+	mkdir -p $(RPMROOT)/SOURCES
+	mkdir -p $(RPMROOT)/RPMS
+	mkdir -p $(RPMROOT)/SRPMS
+	rm -f $(RPMNAME)-$(VERSION)
 	rm -f $(RPMROOT)/SOURCES/$(RPMNAME)-*.tar.gz
 	#tar --exclude '.git*' -X .tarignore -H -czf $(RPMROOT)/SOURCES/$(RPMNAME)-$(VERSION).tar.gz $(RPMNAME)-$(VERSION)
-	tar -H -czf $(RPMROOT)/SOURCES/$(RPMNAME)-$(VERSION).tar.gz $(RPMNAME)-$(VERSION)
+	tar -czf $(RPMROOT)/SOURCES/$(RPMNAME)-$(VERSION).tar.gz .
 	rm -rf $(RPMROOT)/BUILD/horizon-*
 	rm -f $(RPMROOT)/SRPMS/$(RPMNAME)-$${VERSION%%.*}*rpm $(RPMROOT)/RPMS/$(rpm_arch)/$(RPMNAME)-$${VERSION%%.*}*rpm $(RPMROOT)/RPMS/$(rpm_arch)/$(RPMNAME)-$${VERSION%%.*}*rpm.gz
 	rpmbuild --target $(rpm_arch)-linux -ba $(RPMNAME).spec

--- a/pkg/rpm/horizon/horizon.spec
+++ b/pkg/rpm/horizon/horizon.spec
@@ -26,7 +26,7 @@ Requires: horizon-cli docker-ce iptables jq
 Open-horizon edge node agent
 
 %prep
-%setup -q
+%setup -c
 
 %build
 # This phase is done in ~/rpmbuild/BUILD/horizon-<version> . All of the tarball source has been unpacked there and


### PR DESCRIPTION
Removed usage of symlink to prefix source files with package name and instead used %setup -c in spec file to accomplish the same for horizon and horizon-cli. 