### PR TITLE
Change EXECUTABLE to anax instead of dirname 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifdef BUILD_NUMBER
 BUILD_NUMBER := -$(BUILD_NUMBER:-%=%)
 endif
 
-EXECUTABLE := $(shell basename $$PWD)
+EXECUTABLE := anax
 export CLI_EXECUTABLE := cli/hzn
 export CLI_CONFIG_FILE := cli/hzn.json
 CLI_HORIZON_CONTAINER := anax-in-container/horizon-container


### PR DESCRIPTION
Made EXECUTABLE static and equal to 'anax' to prevent the binary name from changing when the directory Anax is built in changes. If the binary name is supposed to change for some reason, then obviously this won't work and you can reject the PR. But I didn't see anywhere in the code where that would happen. 