### PR TITLE
Fixed missing bash completion script throwing error

### DIFF
--- a/pkg/deb/Makefile
+++ b/pkg/deb/Makefile
@@ -55,7 +55,7 @@ horizon-cli-deb: require-version
 	cp ../../agent-install/edgeNodeFiles.sh horizon-cli/usr/horizon/bin
 	if [ -e ../../cli/bash_completion/hzn_bash_autocomplete.sh ]; then \
           cp ../../cli/bash_completion/hzn_bash_autocomplete.sh horizon-cli/etc/bash_completion.d; \
-        fi
+	fi
 	mkdir -p horizon-cli/usr/share/man/man1
 	gzip --stdout ../../cli/man1/hzn.1 > horizon-cli/usr/share/man/man1/hzn.1.gz
 	for m in ../../cli/man1/hzn.1.*; do \

--- a/pkg/deb/Makefile
+++ b/pkg/deb/Makefile
@@ -53,7 +53,9 @@ horizon-cli-deb: require-version
 	cp ../../agent-install/agent-install.sh horizon-cli/usr/horizon/bin
 	cp ../../agent-install/agent-uninstall.sh horizon-cli/usr/horizon/bin
 	cp ../../agent-install/edgeNodeFiles.sh horizon-cli/usr/horizon/bin
-	cp ../../cli/bash_completion/hzn_bash_autocomplete.sh horizon-cli/etc/bash_completion.d
+	if [ -e ../../cli/bash_completion/hzn_bash_autocomplete.sh ]; then \
+          cp ../../cli/bash_completion/hzn_bash_autocomplete.sh horizon-cli/etc/bash_completion.d; \
+        fi
 	mkdir -p horizon-cli/usr/share/man/man1
 	gzip --stdout ../../cli/man1/hzn.1 > horizon-cli/usr/share/man/man1/hzn.1.gz
 	for m in ../../cli/man1/hzn.1.*; do \


### PR DESCRIPTION
This is a workaround so that deb packaging will work for non-amd64 architectures. Since the build occurs on amd64 hosts (for all architectures), the main Anax Makefile will not generate the hzn_bash_autocomplete.sh script because the binary won't work on that system. When we get to the debpkgs target, this cp command will will fail since the script doesn't exist. This means that arm64, armhf, and ppc64el architectures **will not have hzn_bash_autocomplete capabilities**.