### PR TITLE
Updates to e2edev test scripts

### DIFF
--- a/doc/service_def.md
+++ b/doc/service_def.md
@@ -1,0 +1,31 @@
+# Service Definition
+
+OpenHorizon deploys services to edge nodes, where those services are comprised of at least one container image and a configuration that conditions how the service executes.
+Services are defined by a service definition, encoded in JSON. The attributes of a service definition are defined in this document.
+
+## Structure
+
+Service defintions come in 2 forms;
+- `source`: A service definition file that is part of the source code in a service project, e.g. https://github.com/open-horizon/examples/blob/master/edge/services/helloworld/horizon/service.definition.json.
+In this case, the service definition is used to create or update a service definition in the OpenHorizon Exchange.
+- `display`: A service definition displayed by `hzn exchange service list`.
+In this case, the service definition has extra fields and some fields have a different datatype as compared to the source form version of a service definition.
+The differences are noted below.
+
+- `owner`: This is only part of the `display` form, reflecting the user that created the definition in the Exchange.
+- `org`: The organization where the service is defined. OpenHorizon supports multi-tenancy through the concept of an organization (org).
+- `label`: A short textual label assigned to the service definition which could be displayed in a UI.
+- `description`: A long textual description describing the service.
+- `documentation`: A text field used to describe where to find formal documentation for a service. Usually this in the form of a URL.
+- `public`: A boolean describing whether (true) or not (false) this service is available to be used by orgs other than the org where the service resides. This field should only be set to true if the service is truly reusable and the container image(s) contain publicly available information.
+- `url`: The name of the service. The service does not have to be in form of a URL, but it does have to be unique. A best practice is to adhere to conventions that enable the owner of the service to provide a unique name, e.g. including your domain name, my-service.me.com.
+- `version`: A 3 part, dotted decimal version string. In OpenHorizon, versions have semantic meaning. Version `1.0.0` is known to be older than `1.0.1`. The last 2 decimal parts are optional. Version `1` is valid and semantically equivalent to `1.0` and `1.0.0`.
+- `arch`: The hardware architecture of the service implementation in the container image. Valid values are those returned from the GOARCH constant in https://golang.org/pkg/runtime/. The anax agent can be configured to define aliases for these values, see https://github.com/open-horizon/anax/blob/master/test/docker/fs/etc/colonus/anax-combined.config.tmpl for an example. A service is deployed to edge nodes with the same hardware architecture.
+- `sharable`: Can be one of 2 values; `singleton` or `multiple`. Services should be defined as multiple in most cases. The value of this field determines how many instances of the service's containers will be running on a node when the service is deployed more than once to the same node. Use `singleton` when the service is going to be used as a dependency by more than one service, AND those services all run together on a single node, AND the service implementation cannot tolerate multiple instances OR there are not enough resources to support multiple instances.
+- `matchHardware`: Unused
+- `requiredServices`: The list of services on which this service directly depends. A service in this list might have it's own required services. When deploying a serivce to a node, the full dependency tree is analyzed so that leaf services are started first, working recursively up the tree until the top level service is reached, and is started last. However, just because a service's dependencies are started first, does NOT guarantee that the dependencies are ready to process requests when the parent service is started. Parent services should always be prepared to tolerate unavailable dependent services.
+- `userInputs`: The list of variables that condition the behavior of the service implementation in the container image(s). These variables are typed; `string`, `int`, `float`, `boolean`, `list of strings` and MAY have a default value. Userinputs that DO NOT have a default value must be set in the `pattern` or `policy` that deploys the service. In some cases, userInputs need to be set on a per node basis, and therefore can be set on a node definition in the exchange `hzn exchange node update -f <userinput-settings-file>`.
+- `deployment`: The list of container images and container specific config for this service. See [deployment structure](./deployment_string.md) for more information on this field. In `display` form, this field is shown as stringified JSON. This field MAY be omitted if `clusterDeployment` is provided.
+- `deploymentSignature`: The digital signature of the deployment field, created using an RSA key pair provided to `hzn exchange service publish`. It is a best practice to ALWAYS use the -K option when publishing a service, to ensure that the public key used to verify this signature is available for the agent to verify the signature.
+- `clusterDeployment`: The Kubernetes Operator yaml for this service. See [deployment structure](./deployment_string.md) for more information on this field. In `display` form, this field is shown as stringified bytes and truncated. This field MAY be omitted if `deployment` is provided. The yaml files of a published service can be retrieved from the exchange using `hzn exchange service list -f <downloaded-yaml-file>`.
+- `clusterDeploymentSignature`: The digital signature of the clusterDeployment field, created using an RSA key pair provided to `hzn exchange service publish`. It is a best practice to ALWAYS use the -K option when publishing a service, to ensure that the public key used to verify this signature is available for the agent to verify the signature.

--- a/test/Makefile
+++ b/test/Makefile
@@ -54,6 +54,12 @@ E2EDEV_HOST_IP := $(shell hostname -I | awk '{print $$1}')
 AGBOT_SAPI_URL ?= https://localhost:8083
 ICP_HOST_IP ?= 0
 
+export PREBUILT_DOCKER_REG_URL ?= ""
+export PREBUILT_DOCKER_REG_USER ?= ""
+export PREBUILT_DOCKER_REG_PW ?= ""
+export PREBUILT_ANAX_VERSION ?= nightly
+export PREBUILT_ESS_VERSION ?= nightly
+
 ifndef verbose
 .SILENT:
 endif
@@ -241,11 +247,24 @@ $(ANAX_SOURCE)/anax:
 	@echo "Building anax"
 	cd $(ANAX_SOURCE) && make clean && make && make ess-docker-image && make css-docker-image
 
-agbot-docker-prereqs: $(ANAX_SOURCE)/anax
+get-anax:
+
+ifeq ($(MAKECMDGOALS),test-remote-prebuilt)
+get-anax: agbot-prereq-download-anax
+else
+get-anax: agbot-prereq-build-anax
+endif
+
+agbot-prereq-build-anax: $(ANAX_SOURCE)/anax
 	@echo "Configuring agbot prerequisites"
 	if [[ "$(shell docker images -q $(DOCKER_ANAX_K8S_INAME) 2>/dev/null)" == "" ]]; then \
 		cd $(ANAX_SOURCE) && make anax-k8s-image; \
 	fi
+
+agbot-prereq-download-anax: 
+	gov/setup_agbot.sh
+
+agbot-docker-prereqs: get-anax
 	mkdir -p /tmp/ess-store/ /tmp/ess-auth/ /tmp/service_storage/ /tmp/hzndev/
 	mkdir -p $(AGBOT_TEMPFS)/usr/local/bin $(AGBOT_TEMPFS)/root/.colonus
 	cp $(ANAX_SOURCE)/anax $(ANAX_SOURCE)/cli/hzn $(AGBOT_TEMPFS)/usr/local/bin
@@ -288,6 +307,12 @@ test: clean $(ANAX_SOURCE)/anax run-dockerreg run-exchange run-css run-agbot
 	docker exec $(DOCKER_AGBOT_CNAME) bash -c "export $(TEST_VARS); export $(MSGHUB_VARS); /root/gov-combined.sh"
 
 test-remote: clean $(ANAX_SOURCE)/anax run-dockerreg run-agbot copy-cert
+	@echo -e  "\nBootstrapping the exchange"
+	docker exec $(DOCKER_AGBOT_CNAME) bash -c "export $(TEST_VARS); /root/init_exchange.sh"
+	@echo -e  "\nStarting tests"
+	docker exec $(DOCKER_AGBOT_CNAME) bash -c "export $(TEST_VARS); export $(MSGHUB_VARS); /root/gov-combined.sh"
+
+test-remote-prebuilt: clean run-dockerreg run-agbot copy-cert
 	@echo -e  "\nBootstrapping the exchange"
 	docker exec $(DOCKER_AGBOT_CNAME) bash -c "export $(TEST_VARS); /root/init_exchange.sh"
 	@echo -e  "\nStarting tests"

--- a/test/README.md
+++ b/test/README.md
@@ -108,7 +108,7 @@ Here is a full description of all the variables you can use to setup the test th
   - Does all the above, plus removes the agbot and exchange base images, our docker test network, and all dangling docker images
   - NOTE: This is the only 'clean' command which requires re-running `make`
 
-### Remote environment testing
+### Remote Environment Testing
 
 - `export DOCKER_EXCH="Exchange's URL"`
 - `export CSS_URL="CSS's URL"`
@@ -124,3 +124,17 @@ Here is a full description of all the variables you can use to setup the test th
 - `make build-remote`
 - `make test-remote`
 - `make stop` # used between runs
+
+### Remote Environment - Continuous Integration (CI) Testing
+The e2edev tests can be run against pre-built anax and hzn binaries and against a remote management hub. This is useful in a CI environment where we want to utilize binaries that have already been built instead of always rebuilding them. This is to remove the chance of any build environment inconsistencies from the time a binary was built to the time it was deployed to the time it was tested. 
+
+Execute the following target. All other existing options are valid.
+```
+make test-remote-prebuilt
+```
+The following environment variables are needed in addition ot the Remote Environment Testing variables specified in the previous section.
+- `export PREBUILT_DOCKER_REG_URL=<Docker Registry URL>`
+- `export PREBUILT_DOCKER_REG_USER=<Docker User>`
+- `export PREBUILT_DOCKER_REG_PW=<Docker Password`
+- `export PREBUILT_ANAX_VERSION=<Version of Anax (defaults to nightly)>`
+- `export PREBUILT_ESS_VERSION=<Version of ESS (defaults to nightly)>`

--- a/test/gov/setup_agbot.sh
+++ b/test/gov/setup_agbot.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+echo "setup_agbot.sh start"
+
+if [ -z $PREBUILT_DOCKER_REG_USER ]; then
+    echo "You must specify the Docker Registry User ID"
+    exit 1
+elif [ -z $PREBUILT_DOCKER_REG_PW ]; then
+    echo "You must specify the Docker Registry User Password/Token"
+    exit 1
+elif [ -z $PREBUILT_DOCKER_REG_URL ]; then
+    echo "You must specify the Docker Registry URL"
+    exit 1
+fi
+
+echo "Docker Registry login"
+echo ${PREBUILT_DOCKER_REG_PW} | docker login -u=${PREBUILT_DOCKER_REG_USER} --password-stdin ${PREBUILT_DOCKER_REG_URL}
+
+echo "Pulling anax_k8s and ESS from Docker Registry..."
+docker pull ${PREBUILT_DOCKER_REG_URL}/amd64_anax_k8s:${PREBUILT_ANAX_VERSION}
+docker pull ${PREBUILT_DOCKER_REG_URL}/amd64_edge-sync-service:${PREBUILT_ESS_VERSION}
+
+echo "Tagging ESS to openhorizon/amd64_edge-sync-service:latest"
+docker tag ${PREBUILT_DOCKER_REG_URL}/amd64_edge-sync-service:${PREBUILT_ESS_VERSION} openhorizon/amd64_edge-sync-service:testing
+
+echo "Creating (but not starting/running) anax container..."
+id=$(docker create ${PREBUILT_DOCKER_REG_URL}/amd64_anax_k8s:${PREBUILT_ANAX_VERSION})
+
+echo "Doing container copy out of binaries from anax container: $id"
+docker cp $id:/usr/bin/hzn $ANAX_SOURCE/cli/.
+docker cp $id:/usr/horizon/bin/anax $ANAX_SOURCE/.
+
+echo "Removing anax container"
+docker rm -v ${id}
+
+echo "setup_agbot.sh finished"


### PR DESCRIPTION
Modifications to allow e2edev test scripts to use prebuilt binaries instead of building Anax for every run. This will help in CI pipelines where we've already built the binaries, deployed to a test environment, and want to run the e2edev tests against that test environment. 