### PR TITLE
Issue 1958 - Add the --add-host flag to the Docker run command in e2edev remote testing

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -53,6 +53,7 @@ DOCKER_DEV_OPTS :=  --rm --no-cache
 E2EDEV_HOST_IP := $(shell hostname -I | awk '{print $$1}')
 AGBOT_SAPI_URL ?= https://localhost:8083
 ICP_HOST_IP ?= 0
+DOCKER_AGBOT_ADD_HOST ?= "localhost:127.0.0.1"
 
 export PREBUILT_DOCKER_REG_URL ?= ""
 export PREBUILT_DOCKER_REG_USER ?= ""
@@ -99,6 +100,7 @@ run-agbot: agbot-docker-prereqs test-network
 		-p 127.0.0.1:8085:8085 \
 		--name "$(DOCKER_AGBOT_CNAME)" \
 		--network "$(DOCKER_TEST_NETWORK)" \
+		--add-host "$(DOCKER_AGBOT_ADD_HOST)" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(UDS):$(UDS):rw \
 		-v ~/.docker:/home/agbotuser/.docker \

--- a/test/README.md
+++ b/test/README.md
@@ -138,3 +138,5 @@ The following environment variables are needed in addition ot the Remote Environ
 - `export PREBUILT_DOCKER_REG_PW=<Docker Password`
 - `export PREBUILT_ANAX_VERSION=<Version of Anax (defaults to nightly)>`
 - `export PREBUILT_ESS_VERSION=<Version of ESS (defaults to nightly)>`
+
+Occasionally you may need to test against a remote environment that is not recognizable by the existing DNS settings. You can add a host override setting as a flag to the Make command. Add `DOCKER_AGBOT_ADD_HOST=<hostname>:<ip>`.


### PR DESCRIPTION
Fixes 'no such host' errors for hosts not in existing DNS when doing e2edev testing against remote hosts. Fixes #1958.