### PR TITLE
Issue 2038 - Dockerfile performance improvements

### DIFF
--- a/anax-in-container/Dockerfile.amd64
+++ b/anax-in-container/Dockerfile.amd64
@@ -6,16 +6,16 @@ ENV ANAX_LOG_LEVEL 3
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install pre-reqs for getting the horizon pkgs
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl vim jq wget apt-transport-https software-properties-common gettext-base psmisc gnupg
+RUN apt-get update && apt-get install -y curl vim jq wget apt-transport-https software-properties-common gettext-base psmisc gnupg --no-install-recommends
 
 # Set up the apt repos for docker and horizon
 RUN wget -qO- https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-RUN wget -qO- http://pkg.bluehorizon.network/bluehorizon.network-public.key | apt-key add - && \
+    add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    wget -qO- http://pkg.bluehorizon.network/bluehorizon.network-public.key | apt-key add - && \
     add-apt-repository "deb [arch=$(dpkg --print-architecture)] http://pkg.bluehorizon.network/linux/ubuntu $(lsb_release -cs)$HORIZON_REPO_CHANNEL main"
 
 # Install bluehorizon
-RUN apt-get update && apt-get install -y bluehorizon mosquitto-clients
+RUN apt-get update && apt-get install -y bluehorizon mosquitto-clients --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 #RUN systemctl restart horizon.service  # <- systemd not available in a container w/o hacks
 WORKDIR /root

--- a/anax-in-container/Dockerfile.ubi.amd64
+++ b/anax-in-container/Dockerfile.ubi.amd64
@@ -22,12 +22,11 @@ RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${
   	&& tar xzvf docker-${DOCKER_VER}.tgz --strip 1 -C /usr/bin docker/docker \
   	&& rm docker-${DOCKER_VER}.tgz
 
-# add license file
-RUN mkdir -p /licenses
-COPY LICENSE.txt /licenses
-
-RUN mkdir -p /usr/horizon/bin /usr/horizon/web /var/horizon \
+RUN mkdir -p /licenses /usr/horizon/bin /usr/horizon/web /var/horizon \
     && mkdir -p /etc/horizon/agbot/policy.d /etc/horizon/policy.d /etc/horizon/trust
+
+# add license file
+COPY LICENSE.txt /licenses
 
 # copy the horizon configurations
 COPY config/anax.json /etc/horizon/

--- a/anax-in-container/Dockerfile_agbot.amd64
+++ b/anax-in-container/Dockerfile_agbot.amd64
@@ -6,16 +6,16 @@ ENV ANAX_LOG_LEVEL 3
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install pre-reqs for getting the horizon pkgs
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl vim jq wget apt-transport-https software-properties-common gettext-base psmisc gnupg
+RUN apt-get update && apt-get install -y curl vim jq wget apt-transport-https software-properties-common gettext-base psmisc gnupg --no-install-recommends
 
 # Set up the apt repos for docker and horizon
 RUN wget -qO- https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-RUN wget -qO- http://pkg.bluehorizon.network/bluehorizon.network-public.key | apt-key add - && \
+    add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    wget -qO- http://pkg.bluehorizon.network/bluehorizon.network-public.key | apt-key add - && \
     add-apt-repository "deb [arch=$(dpkg --print-architecture)] http://pkg.bluehorizon.network/linux/ubuntu $(lsb_release -cs)$HORIZON_REPO_CHANNEL main"
 
 # Install bluehorizon
-RUN apt-get update && apt-get install -y bluehorizon mosquitto-clients
+RUN apt-get update && apt-get install -y bluehorizon mosquitto-clients --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 # Add user
 RUN adduser agbotuser --disabled-password --gecos "agbot user,1,2,3" 

--- a/anax-in-container/Dockerfile_agbot.ubi
+++ b/anax-in-container/Dockerfile_agbot.ubi
@@ -17,15 +17,13 @@ RUN microdnf install --nodocs -y shadow-utils \
     && chmod +x ./jq \
     && mv jq /usr/bin
 
+# create dirs and add agbotuser
+RUN mkdir -p /licenses /usr/horizon/bin /usr/horizon/web /var/horizon/msgKey \
+    && mkdir -p /etc/horizon/agbot/policy.d /etc/horizon/policy.d /etc/horizon/trust \
+    && adduser agbotuser -f -1 -c "agbot user,1,2,3"
+
 # add license file
-RUN mkdir -p /licenses
 COPY LICENSE.txt /licenses
-
-RUN mkdir -p /usr/horizon/bin /usr/horizon/web /var/horizon/msgKey \
-    && mkdir -p /etc/horizon/agbot/policy.d /etc/horizon/policy.d /etc/horizon/trust
-
-# add agbotuser 
-RUN adduser agbotuser -f -1 -c "agbot user,1,2,3"
 
 # copy the horizon configurations and binaries
 COPY config/agbot.json.tmpl /etc/horizon/anax.json.tmpl
@@ -34,8 +32,7 @@ COPY script/agbot_start.sh /usr/horizon/bin
 ADD anax /usr/horizon/bin/
 ADD hzn /usr/bin/
 
-RUN chown -R agbotuser /etc/horizon
-RUN chown -R agbotuser /var/horizon
+RUN chown -R agbotuser /etc/horizon /var/horizon
 
 USER agbotuser
 WORKDIR /home/agbotuser

--- a/anax-in-k8s/Dockerfile.ubi
+++ b/anax-in-k8s/Dockerfile.ubi
@@ -15,14 +15,12 @@ RUN microdnf install --nodocs -y shadow-utils \
     && chmod +x ./jq \
     && mv jq /usr/bin
 
+RUN mkdir -p /licenses /usr/horizon/bin /usr/horizon/web /var/horizon \
+    && mkdir -p /etc/horizon/agbot/policy.d /etc/horizon/policy.d /etc/horizon/trust \
+    && adduser agentuser -u 1000 -U -f -1 -c "agent user,1,2,3"
+
 # add license file
-RUN mkdir -p /licenses
 COPY LICENSE.txt /licenses
-
-RUN mkdir -p /usr/horizon/bin /usr/horizon/web /var/horizon \
-    && mkdir -p /etc/horizon/agbot/policy.d /etc/horizon/policy.d /etc/horizon/trust
-
-RUN adduser agentuser -u 1000 -U -f -1 -c "agent user,1,2,3"
 
 COPY script/* /home/agentuser/
 COPY config/* /etc/horizon/

--- a/css/image/cloud-sync-service-amd64/Dockerfile.ubi
+++ b/css/image/cloud-sync-service-amd64/Dockerfile.ubi
@@ -10,16 +10,14 @@ RUN microdnf update -y --nodocs && microdnf clean all
 # shadow-utils contains groupadd and adduser commands
 RUN microdnf install --nodocs -y shadow-utils \
 	&& groupadd -g 1000 cssuser && adduser -u 1000 -g cssuser cssuser \
-    && microdnf install --nodocs -y openssl ca-certificates gettext \
-    && microdnf clean all
+  && microdnf install --nodocs -y openssl ca-certificates gettext \
+  && microdnf clean all
 
-# add license file
-RUN mkdir -p /licenses
+# create dirs and add license file
+RUN mkdir -p /licenses /var/edge-sync-service /etc/edge-sync-service /usr/edge-sync-service/bin
 COPY LICENSE.txt /licenses
 
 ADD cloud-sync-service /home/cssuser/cloud-sync-service
-
-RUN mkdir -p /var/edge-sync-service /etc/edge-sync-service /usr/edge-sync-service/bin
 
 COPY config/sync.conf.tmpl /etc/edge-sync-service
 COPY script/css_start.sh /usr/edge-sync-service/bin

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
-RUN apt-get update
-RUN apt-get -y install vim iptables build-essential wget git iputils-ping net-tools curl jq kafkacat apt-transport-https socat
+RUN apt-get update \
+    && apt-get -y install vim iptables build-essential wget git iputils-ping net-tools curl jq kafkacat apt-transport-https socat --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL get.docker.com | sh
 RUN curl https://dl.google.com/go/go1.14.linux-amd64.tar.gz | tar -xzf- -C /usr/local/
 


### PR DESCRIPTION
Reduced the number of layers by combining RUN commands.
Reduced the size of Go binaries by removing debugging information - flags-ldflags="-s -w".
Reduced the size of Go binaries by using Ultimate Packer for eXecutables (UPX). 
Added commands --no-install-recommends and rm -rf /var/lib/apt/lists/* to reduce image size.

Signed-off-by: Igor Kolinko <ikolin@softserveinc.com>