### PR TITLE
overhaul for new agent-install.sh tests and general test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ go.sum
 /anax-in-container/hzn
 /anax-in-container/anax
 /anax-in-container/LICENSE.txt
+/agent-install/test/config/agent-install.cfg                                                                                                                               /agent-install/test/config/agent-install.crt                                                                                                                               /agent-install/test/config/switch/agent-install.cfg                                                                                                                        /agent-install/test/config/switch/agent-install.crt
+/agent-install/test/config/switch/agent-install-test-results.log

--- a/agent-install/test/assertions.sh
+++ b/agent-install/test/assertions.sh
@@ -15,7 +15,7 @@ MESSAGE_DOCKER_NOT_FOUND="docker not found"
 MESSAGE_JQ_NOT_FOUND="jq not found"
 MESSAGE_CURL_NOT_FOUND="curl not found"
 
-WORKLOAD_EXECUTION_TIMEOUT=90
+WORKLOAD_EXECUTION_TIMEOUT=60
 
 isCLIInstalled() {
     if command -v hzn >/dev/null 2>&1; then


### PR DESCRIPTION
Updated test suite that works with new changes to agent-install.sh. Includes the following:

- Updated to pull packages from artifactory instead of pkg-bluehorizon
- Removed 2 test cases for no longer supported cases (down-level agent installation support removed from agent-install.sh)
- Removed redundant assertions that could cause failures and test inconsistency (waiting for services to start when not necessary).
- Added support for local package use for tests that require only one version (all but test 6)
- Added support for only downloading a current version and skipping the agent-upgrade test (test 6). This test will run if a current version and previous version are provided to download.
- Added help menu to give some help context outside of git
- Fixed several test cases that failed or were inconsistent
- Fixed issue where terminal output would break due to some other functions in use
- Updated gitignore to ignore agent-install.crt/.cfg config files in agent-install/test/config & ../config/switch