### PR TITLE
Issue 2096 - Fix no-debug-pkg versions issue

### DIFF
--- a/tools/no-debug-pkg
+++ b/tools/no-debug-pkg
@@ -12,6 +12,9 @@ elif [ -f /etc/lsb-release ];then
 	DISTRO=$DISTRIB_ID;VER=$DISTRIB_RELEASE;
 fi
 
+# get rid of version's fraction (major releases make sense)
+VER=${VER%%.*}
+
 if [[ "$DISTRO" == fedora && $VER -ge 27 ]];then
 	echo true;
 elif [[ $DISTRO =~ ^(centos|rhel)$ && $VER -ge 7 ]];then


### PR DESCRIPTION
This PR fixes version ID matching at no-debug-pkg script. Affects external linking mode switch on RHEL platform builds, that omits debuginfo packages and the corresponding rpmbuild breakdown on RHEL.

Signed-off-by: Dmitry Gorbachev <dmitry.gorbachev@ru.ibm.com>

Resolves #2096 