### PR TITLE
Fix the reference link error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Related Projects:
 
 ## Documentation
 
-* [Anax APIs](doc/api.md)
-* [Managed Workloads](doc/managed_workloads.md)
+* [Anax APIs](docs/api.md)
+* [Managed Workloads](docs/managed_workloads.md)
 
 ## Development
 


### PR DESCRIPTION
The reference link of the `README` can't be accessed, because the files have been moved from the `doc` to `docs` 