### PR TITLE
Fix "hzn dev service new" command to publish services with "public":false

### DIFF
--- a/cli/dev/servicedefinition.go
+++ b/cli/dev/servicedefinition.go
@@ -44,7 +44,7 @@ func CreateServiceDefinition(directory string, specRef string, imageInfo map[str
 
 	res.Org = "$HZN_ORG_ID"
 	res.Label = msgPrinter.Sprintf("$SERVICE_NAME for $ARCH")
-	res.Public = true
+	res.Public = false
 	res.URL = "$SERVICE_NAME"
 	res.Version = "$SERVICE_VERSION"
 	res.Arch = "$ARCH"

--- a/cli/dev/utils_int_test.go
+++ b/cli/dev/utils_int_test.go
@@ -126,7 +126,7 @@ func createSkeletalServiceDef(serviceName string) *common.ServiceFile {
 	res := new(common.ServiceFile)
 	res.Label = ""
 	res.Description = ""
-	res.Public = true
+	res.Public = false
 	res.URL = DEFAULT_SDEF_URL
 	res.Version = "1.0.0"
 	res.Arch = cutil.ArchString()

--- a/test/gov/hzn_dev_services.sh
+++ b/test/gov/hzn_dev_services.sh
@@ -57,6 +57,7 @@ function createProject {
 
     sed -e 's|"label": "$SERVICE_NAME for $ARCH"|"label": "'$2'service"|' ${serviceDef} > ${serviceDef}.tmp && mv ${serviceDef}.tmp ${serviceDef}
     sed -e 's|"description": ""|"description": "'$2' service"|' ${serviceDef} > ${serviceDef}.tmp && mv ${serviceDef}.tmp ${serviceDef}
+    sed -e 's|"public": false|"public": true|' ${serviceDef} > ${serviceDef}.tmp && mv ${serviceDef}.tmp ${serviceDef}
     sed -e 's|"sharable": "multiple"|"sharable": "'$5'"|' ${serviceDef} > ${serviceDef}.tmp && mv ${serviceDef}.tmp ${serviceDef}
     sed -e 's|"name": ""|"name": "'$6'"|' ${serviceDef} > ${serviceDef}.tmp && mv ${serviceDef}.tmp ${serviceDef}
     sed -e 's|"type": ""|"type": "'$7'"|' ${serviceDef} > ${serviceDef}.tmp && mv ${serviceDef}.tmp ${serviceDef}


### PR DESCRIPTION
This commit partially addresses this [open-horizon/examples issue](https://github.com/open-horizon/examples/issues/356). Services should be created with `"public": false` so those outside the organizations can't see them by default.

Tested by locally building the hzn cli and making sure that the resulting horizon files have `"public": false` set on them.

Signed-off-by: Clement Ng <clementdng@gmail.com>