### PR TITLE
Issue 2211 - Add public flag to hzn exchange service publish

### DIFF
--- a/cli/exchange/service.go
+++ b/cli/exchange/service.go
@@ -120,7 +120,7 @@ func ServiceList(credOrg, userPw, service string, namesOnly bool, filePath strin
 }
 
 // ServicePublish signs the MS def and puts it in the exchange
-func ServicePublish(org, userPw, jsonFilePath, keyFilePath, pubKeyFilePath string, dontTouchImage bool, pullImage bool, registryTokens []string, overwrite bool, servicePolicyFilePath string) {
+func ServicePublish(org, userPw, jsonFilePath, keyFilePath, pubKeyFilePath string, dontTouchImage bool, pullImage bool, registryTokens []string, overwrite bool, servicePolicyFilePath string, public string) {
 	// get message printer
 	msgPrinter := i18n.GetMessagePrinter()
 
@@ -138,6 +138,19 @@ func ServicePublish(org, userPw, jsonFilePath, keyFilePath, pubKeyFilePath strin
 	}
 	if svcFile.Org != "" && svcFile.Org != org {
 		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("the org specified in the input file (%s) must match the org specified on the command line (%s)", svcFile.Org, org))
+	}
+	if public != "" {
+		public = strings.ToLower(public)
+		if public != "true" && public != "false" {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Need to set 'true' or 'false' when specifying flag --public."))
+		} else {
+			// Override public key with key set in the hzn command
+			svcFile.Public, err = strconv.ParseBool(public)
+			if err != nil {
+				cliutils.Fatal(cliutils.INTERNAL_ERROR, msgPrinter.Sprintf("failed to parse %s: %v", public, err))
+			}
+
+		}
 	}
 
 	// Compensate for old service definition files

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -281,6 +281,7 @@ Environment Variables:
 	exSvcRegistryTokens := exServicePublishCmd.Flag("registry-token", msgPrinter.Sprintf("Docker registry domain and auth that should be stored with the service, to enable the Horizon edge node to access the service's docker images. This flag can be repeated, and each flag should be in the format: registry:user:token")).Short('r').Strings()
 	exSvcOverwrite := exServicePublishCmd.Flag("overwrite", msgPrinter.Sprintf("Overwrite the existing version if the service exists in the Exchange. It will skip the 'do you want to overwrite' prompt.")).Short('O').Bool()
 	exSvcPolicyFile := exServicePublishCmd.Flag("service-policy-file", msgPrinter.Sprintf("The path of the service policy JSON file to be used for the service to be published. This flag is optional")).Short('p').String()
+	exSvcPublic := exServicePublishCmd.Flag("public", msgPrinter.Sprintf("Whether the service is visible to users outside of the organization. This flag is optional. If left unset, the service will default to whatever the metadata has set. If the service definition has also not set the public field, then the service will by default not be public.")).String()
 	exServiceVerifyCmd := exServiceCmd.Command("verify", msgPrinter.Sprintf("Verify the signatures of a service resource in the Horizon Exchange."))
 	exVerService := exServiceVerifyCmd.Arg("service", msgPrinter.Sprintf("The service to verify.")).Required().String()
 	exServiceVerifyNodeIdTok := exServiceVerifyCmd.Flag("node-id-tok", msgPrinter.Sprintf("The Horizon Exchange node ID and token to be used as credentials to query and modify the node resources if -u flag is not specified. HZN_EXCHANGE_NODE_AUTH will be used as a default for -n. If you don't prepend it with the node's org, it will automatically be prepended with the -o value.")).Short('n').PlaceHolder("ID:TOK").String()
@@ -930,7 +931,7 @@ Environment Variables:
 	case exServiceListCmd.FullCommand():
 		exchange.ServiceList(*exOrg, credToUse, *exService, !*exServiceLong, *exSvcOpYamlFilePath, *exSvcOpYamlForce)
 	case exServicePublishCmd.FullCommand():
-		exchange.ServicePublish(*exOrg, *exUserPw, *exSvcJsonFile, *exSvcPrivKeyFile, *exSvcPubPubKeyFile, *exSvcPubDontTouchImage, *exSvcPubPullImage, *exSvcRegistryTokens, *exSvcOverwrite, *exSvcPolicyFile)
+		exchange.ServicePublish(*exOrg, *exUserPw, *exSvcJsonFile, *exSvcPrivKeyFile, *exSvcPubPubKeyFile, *exSvcPubDontTouchImage, *exSvcPubPullImage, *exSvcRegistryTokens, *exSvcOverwrite, *exSvcPolicyFile, *exSvcPublic)
 	case exServiceVerifyCmd.FullCommand():
 		exchange.ServiceVerify(*exOrg, credToUse, *exVerService, *exSvcPubKeyFile)
 	case exSvcDelCmd.FullCommand():


### PR DESCRIPTION
This commit addresses #2211. This adds a flag to the `hzn exchange service publish` that sets the `public` field of the service to either be true or false based on the chart below. The rules are as follows.

1.  If the `hzn exchange service publish` has the flag set, then it takes precedence
2. Otherwise, `public` defaults to whatever is set in the metadata ie `horizon/service.definition.json`
3. If both are undefined, set to `public` to false

![image](https://user-images.githubusercontent.com/24197092/100194143-051c7080-2eaa-11eb-9a88-09191fe1ec9d.png)

Tested by locally building hzn cli and making sure that running `hzn exchange service publish` follows the results above.



Signed-off-by: Clement Ng <clementdng@gmail.com>