### PR TITLE
Issue 2272 - Fix to use authenticated Docker user for e2edev tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -105,6 +105,7 @@ run-agbot: agbot-docker-prereqs test-network
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(UDS):$(UDS):rw \
 		-v ~/.docker:/home/agbotuser/.docker \
+		-v ~/.docker:/root/.docker \
 		-v /etc/wiotp-edge/:/etc/wiotp-edge/ \
 		-v /var/wiotp-edge/persist/:/var/wiotp-edge/persist/ \
 		-v /tmp/ess-auth/:/tmp/ess-auth/:rw \


### PR DESCRIPTION
The e2edev-agbot container does not bind the local host's .docker to the container's /root directory. It does so for the /home/agbotuser. Added a volume bind to fix this. Will require rebuilding the e2edev-agbot container prior to running the tests.

Signed-off-by: Ben Courliss <bencourliss@ibm.com>