### PR TITLE
Issue 2344 - Add -c (container name) flag to hzn service log

### DIFF
--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -232,7 +232,8 @@ Environment Variables:
 
 	devServiceCmd := devCmd.Command("service", msgPrinter.Sprintf("For working with a service project."))
 	devServiceLogCmd := devServiceCmd.Command("log", msgPrinter.Sprintf("Show the container/system logs for a service."))
-	devServiceLogCmdServiceName := devServiceLogCmd.Flag("service", msgPrinter.Sprintf("The name of the service whose log records should be displayed. The service name is the same as the url field of a service definition.")).Short('s').String()
+	devServiceLogCmdServiceName := devServiceLogCmd.Flag("service", msgPrinter.Sprintf("(DEPRECATED) This flag is deprecated and is replaced by -c.")).Short('s').String()
+	devServiceLogCmdContainerName := devServiceLogCmd.Flag("container", msgPrinter.Sprintf("The name of the service container whose log records should be displayed. Can be omitted if the service definition has only one container in its deployment config.")).Default(*devServiceLogCmdServiceName).Short('c').String()
 	devServiceLogCmdTail := devServiceLogCmd.Flag("tail", msgPrinter.Sprintf("Continuously polls the service's logs to display the most recent records, similar to tail -F behavior.")).Short('f').Bool()
 	devServiceNewCmd := devServiceCmd.Command("new", msgPrinter.Sprintf("Create a new service project."))
 	devServiceNewCmdOrg := devServiceNewCmd.Flag("org", msgPrinter.Sprintf("The Org id that the service is defined within. If this flag is omitted, the HZN_ORG_ID environment variable is used.")).Short('o').String()
@@ -617,6 +618,7 @@ Environment Variables:
 	forceSuspendService := serviceConfigStateSuspendCmd.Flag("force", msgPrinter.Sprintf("Skip the 'are you sure?' prompt.")).Short('f').Bool()
 	serviceLogCmd := serviceCmd.Command("log", msgPrinter.Sprintf("Show the container logs for a service."))
 	logServiceName := serviceLogCmd.Arg("service", msgPrinter.Sprintf("The name of the service whose log records should be displayed. The service name is the same as the url field of a service definition. Displays log records similar to tail behavior and returns .")).Required().String()
+	logServiceContainerName := serviceLogCmd.Flag("container", msgPrinter.Sprintf("The name of the container within the service whose log records should be displayed.")).Short('c').String()
 	logTail := serviceLogCmd.Flag("tail", msgPrinter.Sprintf("Continuously polls the service's logs to display the most recent records, similar to tail -F behavior.")).Short('f').Bool()
 	serviceListCmd := serviceCmd.Command("list", msgPrinter.Sprintf("List the services variable configuration that has been done on this Horizon edge node."))
 	serviceRegisteredCmd := serviceCmd.Command("registered", msgPrinter.Sprintf("List the services that are currently registered on this Horizon edge node."))
@@ -1045,7 +1047,7 @@ Environment Variables:
 	case serviceListCmd.FullCommand():
 		service.List()
 	case serviceLogCmd.FullCommand():
-		service.Log(*logServiceName, *logTail)
+		service.Log(*logServiceName, *logServiceContainerName, *logTail)
 	case serviceRegisteredCmd.FullCommand():
 		service.Registered()
 	case serviceConfigStateListCmd.FullCommand():
@@ -1071,7 +1073,7 @@ Environment Variables:
 	case devServiceValidateCmd.FullCommand():
 		dev.ServiceValidate(*devHomeDirectory, *devServiceVerifyUserInputFile, []string{}, "", *devServiceValidateCmdUserPw)
 	case devServiceLogCmd.FullCommand():
-		dev.ServiceLog(*devHomeDirectory, *devServiceLogCmdServiceName, *devServiceLogCmdTail)
+		dev.ServiceLog(*devHomeDirectory, *devServiceLogCmdContainerName, *devServiceLogCmdTail)
 	case devDependencyFetchCmd.FullCommand():
 		dev.DependencyFetch(*devHomeDirectory, *devDependencyFetchCmdProject, *devDependencyCmdSpecRef, *devDependencyCmdURL, *devDependencyCmdOrg, *devDependencyCmdVersion, *devDependencyCmdArch, *devDependencyFetchCmdUserPw, *devDependencyFetchCmdUserInputFile)
 	case devDependencyListCmd.FullCommand():

--- a/test/gov/gov-combined.sh
+++ b/test/gov/gov-combined.sh
@@ -491,6 +491,14 @@ if [ "$NOHZNREG" != "1" ] && [ "$TESTFAIL" != "1" ]; then
   fi
 fi
 
+if [ "$TEST_PATTERNS" == "sall" ] && [ "$NOHZNLOG" != "1" ] && [ "$NOHZNREG" != "1" ] && [ "$TESTFAIL" != "1" ]; then
+  ./service_log_test.sh
+  if [ $? -ne 0 ]; then
+    echo "Failed hzn service log tests."
+    exit 1
+  fi
+fi
+
 if [ "$NOPATTERNCHANGE" != "1" ] && [ "$TESTFAIL" != "1" ]; then
   if [ "$TEST_PATTERNS" == "sall" ]; then
     ./pattern_change.sh

--- a/test/gov/service_log_test.sh
+++ b/test/gov/service_log_test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# This service log testing script requires the horizon node registration tests to be called before.
+
+# Still need to add tests which check logging for services with multiple containers deployed.
+PREFIX="hzn service log test:"
+
+export HZN_ORG_ID=e2edev@somecomp.com
+SERVICE_URL="$HZN_ORG_ID/https://bluehorizon.network/services/netspeed"
+SERVICE_CONTAINER_NAME="netspeed"
+
+echo ""
+echo -e "${PREFIX} Starting tests on service $SERVICE_URL with one service container"
+
+cmd="hzn service log $SERVICE_URL"
+echo -e "$cmd"
+ret=`$cmd 2>&1`
+if [ $? != 0 ]; then
+  echo -e "Error: hzn service log failed for $SERVICE_URL. $ret"
+  exit 1
+fi
+
+cmd="hzn service log $SERVICE_URL -c $SERVICE_CONTAINER_NAME"
+echo -e "$cmd"
+ret=`$cmd 2>&1`
+if [ $? != 0 ]; then
+  echo -e "Error: hzn service log failed for $SERVICE_URL with container $SERVICE_CONTAINER_NAME. $ret"
+  exit 1
+fi
+
+cmd="hzn service log ${SERVICE_URL} -c ${SERVICE_CONTAINER_NAME}_error"
+echo -e "$cmd"
+ret=`$cmd 2>&1`
+if [ $? == 0 ]; then
+  echo -e "Error: hzn service log should have failed for ${SERVICE_URL} with container ${SERVICE_CONTAINER_NAME}_error. $ret"
+  exit 1
+fi
+
+cmd="hzn service log ${SERVICE_URL}_error"
+echo -e "$cmd"
+ret=`$cmd 2>&1`
+if [ $? == 0 ]; then
+  echo -e "Error: hzn service log should have failed for ${SERVICE_URL}_error. $ret"
+  exit 1
+fi
+
+unset HZN_ORG_ID
+echo -e "${PREFIX} Done"


### PR DESCRIPTION
Signed-off-by: codejaeger <mandaldebabrata123@gmail.com>

This is a possible fix to #2344. A new (optional) flag `-c` is added to the `hzn service log` cli to take the service container name as input. This helps disambiguate between multiple containers for a service definition.

Updates made:
1. `-c` is an optional flag which needs to be specified if the current service definition has more than one running containers.
2. In a few cases the deployment name of the container is changed to `<service-name>@<repo-digest>`. This PR also accounts for this case.

Note :- There lacks a service in the e2edev tests with multiple containers in its `service.definition.json`. Such a service is needed to make a test to check service logging for individual containers in a deployed service.