### PR TITLE
Issue 2404 - Add hashicorp vault to e2edev environment

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -33,12 +33,15 @@ ANAX_SOURCE ?= $(shell dirname $(CURDIR))
 AGBOT_TEMPFS := $(CURDIR)/docker/tempfs/agbot
 EXCH_TEMPFS := $(CURDIR)/docker/tempfs/exchange
 CSS_CONFIG := $(CURDIR)/docker/fs/etc/edge-sync-service/
+VAULT_CONFIG := $(CURDIR)/docker/fs/etc/vault/config.json
 UDS := /var/run/horizon/
 EXCHDB_USER := admin
 EXCHDB_PORT := 5432
 EXCHDB_NAME := exchange
 EXCH_ROOTPW ?= Horizon-Rul3s
 AGBOT_NAME ?= ag12345
+VAULT_DEV_ROOT_TOKEN_ID := $(shell jq ".VAULT_DEV_ROOT_TOKEN_ID" $(VAULT_CONFIG))
+VAULT_DEV_LISTEN_ADDRESS := $(shell jq ".VAULT_DEV_LISTEN_ADDRESS" $(VAULT_CONFIG))
 DOCKER_TEST_NETWORK := e2edev_test_network
 DOCKER_AGBOT_INAME := openhorizon/e2edev-agbot
 DOCKER_EXCH_INAME := openhorizon/$(arch)_exchange-api
@@ -64,6 +67,8 @@ endif
 DOCKER_CPU_TAG := 1.2.2
 DOCKER_CSS_INAME := openhorizon/$(arch)_cloud-sync-service
 DOCKER_CSS_TAG := testing$(BRANCH_NAME)
+DOCKER_HASHICORP_VAULT_INAME := hashicorp/vault
+DOCKER_HASHICORP_VAULT_TAG := latest
 DOCKER_ANAX_K8S_INAME := openhorizon/$(arch)_anax_k8s:testing
 DOCKER_DEV_OPTS :=  --rm --no-cache --build-arg ARCH=$(arch)
 DOCKER_ANAX_INAME := openhorizon/$(arch)_anax:testing
@@ -86,7 +91,7 @@ endif
 all: default
 default: build
 stop: clean
-build: agbot-image exchange-db-image exchange-image css-mongo-db-image
+build: agbot-image exchange-db-image exchange-image css-mongo-db-image hashicorp-vault-image
 build-remote: agbot-image
 run: test
 distclean: realclean
@@ -94,6 +99,7 @@ distclean: realclean
 DOCKER_AGBOT_CNAME := agbot
 DOCKER_EXCH ?= http://exchange-api:8080/v1
 CSS_URL ?= https://css-api:9443
+VAULT_ADDR = http://vault:8200
 API_KEY ?= 0
 CERT_LOC ?= 1
 DOCKER_EXCH_CNAME = exchange-api
@@ -104,6 +110,7 @@ DOCKER_REG_USER := testuser
 DOCKER_REG_PW := testpassword
 DOCKER_CSS_CNAME := css-api
 DOCKER_CSSDB_CNAME := css-db
+DOCKER_HASHICORP_VAULT_CNAME := vault
 MUL_AGENTS ?= 0
 
 run-agbot: agbot-docker-prereqs test-network
@@ -160,6 +167,9 @@ run-agbot: agbot-docker-prereqs test-network
 		-e "DOCKER_CPU_INAME=$(DOCKER_CPU_INAME)" \
 		-e "DOCKER_CPU_TAG=$(DOCKER_CPU_TAG)" \
 		-e "ARCH=$(arch)" \
+		-e "HZN_VAULT"="$(HZN_VAULT)" \
+		-e "VAULT_TOKEN"="$(VAULT_DEV_ROOT_TOKEN_ID)" \
+		-e "VAULT_ADDR"="$(VAULT_ADDR)" \
 		-t $(DOCKER_AGBOT_INAME):$(DOCKER_DEV_TAG)
 	docker cp $(AGBOT_TEMPFS)/. $(DOCKER_AGBOT_CNAME):/
 
@@ -224,6 +234,22 @@ run-exchange-db: test-network
 		-e POSTGRES_HOST_AUTH_METHOD=trust \
 		-t $(DOCKER_EXCHDB_INAME):$(DOCKER_EXCHDB_TAG)
 
+run-vault: test-network 
+	if [[ "$(HZN_VAULT)" == "true" ]]; then \
+		echo "Handling $(DOCKER_HASHICORP_VAULT_CNAME)"; \
+		docker/docker_run.bash "$(DOCKER_HASHICORP_VAULT_CNAME)" \
+			docker run -d \
+			--name "$(DOCKER_HASHICORP_VAULT_CNAME)" \
+			--network "$(DOCKER_TEST_NETWORK)" \
+			-p 127.0.0.1:8200:8200 \
+			-e VAULT_DEV_LISTEN_ADDRESS=$(VAULT_DEV_LISTEN_ADDRESS) \
+			-e VAULT_DEV_ROOT_TOKEN_ID=$(VAULT_DEV_ROOT_TOKEN_ID) \
+			-e VAULT_LOG_LEVEL=$(shell jq ".VAULT_LOG_LEVEL" $(VAULT_CONFIG)) \
+			-t $(DOCKER_HASHICORP_VAULT_INAME):$(DOCKER_HASHICORP_VAULT_TAG); \
+	else \
+		echo "Skipping vault container $(DOCKER_HASHICORP_VAULT_CNAME)"; \
+	fi
+
 clean:
 	@echo -e "\nStarting cleanup"
 	@echo "Clean up kube environment"
@@ -254,9 +280,11 @@ clean:
 	-@docker rm -v -f "$(DOCKER_CSSDB_CNAME)" 2>/dev/null || true
 	@echo "Removing the $(DOCKER_CSS_CNAME) container"
 	-@docker rm -f "$(DOCKER_CSS_CNAME)" 2>/dev/null || true
+	@echo "Removing the $(DOCKER_HASHICORP_VAULT_CNAME) container"
+	-@docker rm -f "$(DOCKER_HASHICORP_VAULT_CNAME)" 2>/dev/null || true
 	@echo "Cleaning up any left over workloads"
-	-@docker stop $(docker ps -a | egrep "openhorizon/|wiotp-|localhost" | egrep -v "e2edev-agbot|$(arch)_exchange-api|$(arch)_cloud-sync-service|$(arch)_edge-sync-service|REPOSITORY" | awk '{print $$1}') 2>/dev/null || true
-	-@docker rm $(docker ps -a | egrep "openhorizon/|wiotp-|localhost" | egrep -v "e2edev-agbot|$(arch)_exchange-api|$(arch)_cloud-sync-service|$(arch)_edge-sync-service|REPOSITORY" | awk '{print $$1}') 2>/dev/null || true
+	-@docker stop $(docker ps -a | egrep "openhorizon/|wiotp-|localhost|hashicorp/" | egrep -v "e2edev-agbot|amd64_exchange-api|amd64_cloud-sync-service|amd64_edge-sync-service|vault|REPOSITORY" | awk '{print $$1}') 2>/dev/null || true
+	-@docker rm $(docker ps -a | egrep "openhorizon/|wiotp-|localhost|hashicorp/" | egrep -v "e2edev-agbot|amd64_exchange-api|amd64_cloud-sync-service|amd64_edge-sync-service|vault|REPOSITORY" | awk '{print $$1}') 2>/dev/null || true
 	@echo "Removing working directories"
 	-@rm -rf $(CURDIR)/docker/tempfs 2>/dev/null || true
 	-@sudo rm -fr $(UDS) 2>/dev/null || true
@@ -270,6 +298,7 @@ realclean: mostlyclean
 	-@docker rmi $(DOCKER_AGBOT_INAME):$(DOCKER_DEV_TAG) $(DOCKER_AGBOT_INAME):latest 2>/dev/null || true
 	-@docker rmi $(DOCKER_EXCH_INAME):$(DOCKER_EXCH_TAG) 2>/dev/null || true
 	-@docker rmi $(DOCKER_CSS_INAME):$(DOCKER_CSS_TAG) 2>/dev/null || true
+	-@docker rmi $(DOCKER_HASHICORP_VAULT_INAME):$(DOCKER_HASHICORP_VAULT_TAG) 2>/dev/null || true
 	-@docker network rm $(DOCKER_TEST_NETWORK) 2>/dev/null || true
 	-@docker rmi $$(docker images -qf "dangling=true") 2>/dev/null || true
 
@@ -308,6 +337,7 @@ agbot-docker-prereqs: get-anax
 	mkdir -p $(AGBOT_TEMPFS)/usr/local/bin $(AGBOT_TEMPFS)/root/.colonus
 	cp $(ANAX_SOURCE)/anax $(ANAX_SOURCE)/cli/hzn $(AGBOT_TEMPFS)/usr/local/bin
 	cp -r $(CURDIR)/docker/fs/etc $(AGBOT_TEMPFS)
+	rm -r $(AGBOT_TEMPFS)/etc/vault
 	cp -r $(CURDIR)/docker/fs/hzn $(CURDIR)/gov/* $(CURDIR)/docker/fs/helm $(CURDIR)/docker/fs/resources $(CURDIR)/docker/fs/objects $(AGBOT_TEMPFS)/root
 	for f in $$(find $(AGBOT_TEMPFS)/etc/agbot/ -maxdepth 1 -name '*.tmpl'); do EXCH_APP_HOST=$(DOCKER_EXCH) CSS_URL=$(CSS_URL) envsubst < $$f > "$$(echo $$f | sed 's/.tmpl//')"; done
 	for f in $$(find $(AGBOT_TEMPFS)/etc/colonus/ -maxdepth 1 -name '*.tmpl'); do EXCH_APP_HOST=$(DOCKER_EXCH) CSS_URL=$(CSS_URL) envsubst < $$f > "$$(echo $$f | sed 's/.tmpl//')"; done
@@ -329,7 +359,15 @@ exchange-db-image:
 exchange-image:
 	docker pull $(DOCKER_EXCH_INAME):$(DOCKER_EXCH_TAG)
 
-test: clean $(ANAX_SOURCE)/anax run-dockerreg run-exchange run-css run-agbot
+hashicorp-vault-image:
+	if [[ "$(HZN_VAULT)" == "true" ]]; then \
+		echo "\nPulling hashicorp vault image $(DOCKER_HASHICORP_VAULT_INAME)"; \
+		docker pull $(DOCKER_HASHICORP_VAULT_INAME):$(DOCKER_HASHICORP_VAULT_TAG); \
+	else \
+		echo "Skipping vault image $(DOCKER_HASHICORP_VAULT_INAME)"; \
+	fi
+
+test: clean $(ANAX_SOURCE)/anax run-dockerreg run-exchange run-css run-vault run-agbot
 	@echo -e  "\nBootstrapping the exchange"
 	docker exec $(DOCKER_AGBOT_CNAME) bash -c "export $(TEST_VARS); /root/init_exchange.sh"
 	@echo -e  "\nSetting up agent in kube"
@@ -387,5 +425,5 @@ run-css: run-mongo-db
 		-v $(AGBOT_TEMPFS)/certs/:/certs/ \
 		-t $(DOCKER_CSS_INAME):$(DOCKER_CSS_TAG)
 
-.PHONY: all default stop build run distclean clean mostlyclean realclean run-agbot run-dockerreg run-exchange run-exchange-db test-network test agbot-docker-prereqs agbot-image exchange-db-image exchange-image css-mongo-db-image run-mongo-db run-css copy-cert
+.PHONY: all default stop build run distclean clean mostlyclean realclean run-agbot run-dockerreg run-exchange run-exchange-db test-network test agbot-docker-prereqs agbot-image exchange-db-image exchange-image css-mongo-db-image run-mongo-db run-css copy-cert run-vault hashicorp-vault-image
 #.SILENT: clean

--- a/test/README.md
+++ b/test/README.md
@@ -65,7 +65,7 @@ make test TEST_VARS="NOLOOP=1 PATTERN=sloc"
 Light Test:
 
 ```sh
-make test TEST_VARS="NOLOOP=1 NOCANCEL=1 NOHZNREG=1 NORETRY=1 NOSVC_CONFIGSTATE=1 NOSURFERR=1 NOUPGRADE=1 NOPATTERNCHANGE=1 NOCOMPCHECK=1"
+make test TEST_VARS="NOLOOP=1 NOCANCEL=1 NOHZNREG=1 NORETRY=1 NOSVC_CONFIGSTATE=1 NOSURFERR=1 NOUPGRADE=1 NOPATTERNCHANGE=1 NOCOMPCHECK=1 NOVAULT=1"
 ```
 
 Here is a full description of all the variables you can use to setup the test the way you want it:
@@ -94,6 +94,7 @@ Here is a full description of all the variables you can use to setup the test th
 - OLDAGBOT=1 - run the agbot based on the current commit in github, i.e. the agbot before you made your changes. This is helpfiul for compatibility testing of new device with previous agbot.
 - MULTIAGBOT=1 - run two instances of agbot for testing pursposes.
 - NOKUBE=1 - Don't use Kubernetes cluster mode in testing.
+- NOVAULT=1 - the hashicorp vault tests are not executed.
 
 ### Debugging
 

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -3,9 +3,20 @@ FROM ubuntu:18.04
 ARG ARCH
 
 RUN apt-get update
-RUN apt-get -y install vim iptables build-essential wget git iputils-ping net-tools curl jq kafkacat apt-transport-https socat
-RUN curl -fsSL get.docker.com | sh
-RUN curl https://dl.google.com/go/go1.14.linux-${ARCH}.tar.gz | tar -xzf- -C /usr/local/
+RUN apt-get -y install vim iptables build-essential wget git iputils-ping net-tools curl jq kafkacat apt-transport-https socat software-properties-common lsb-release
+
+ARG DOCKER_VER=19.03.8
+
+# install docker cli
+RUN curl -4fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz \
+    && tar xzvf docker-${DOCKER_VER}.tgz --strip 1 -C /usr/bin docker/docker \
+    && rm docker-${DOCKER_VER}.tgz
+
+RUN curl https://dl.google.com/go/go1.14.linux-amd64.tar.gz | tar -xzf- -C /usr/local/
+
+RUN curl -4fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
+    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
+    apt-get update && apt-get -y install vault ;
 
 ENV GOROOT=/usr/local/go
 ENV PATH="${PATH}:${GOROOT}/bin"

--- a/test/docker/fs/etc/vault/config.json
+++ b/test/docker/fs/etc/vault/config.json
@@ -1,0 +1,10 @@
+{
+    "VAULT_DEV_LISTEN_ADDRESS": "0.0.0.0:8200",
+    "VAULT_DEV_ROOT_TOKEN_ID": "vault_dev_root_token_id",
+    "VAULT_LOG_LEVEL": "debug",
+    "VAULT_API_ADDR": "http://0.0.0.0:8200",
+    "VAULT_CLUSTER_ADDR": "http://0.0.0.0:8201",
+    "HTTP_PROXY": "",
+    "HTTPS_PROXY": "",
+    "NO_PROXY": ""
+}

--- a/test/gov/gov-combined.sh
+++ b/test/gov/gov-combined.sh
@@ -527,6 +527,19 @@ else
   echo -e "Edge cluster agreement verification skipped."
 fi
 
+#Starting vault tests.
+if [ "$HZN_VAULT" == "true" ] && [ "$NOVAULT" != "1" ] && [ "$TESTFAIL" != "1" ]
+then
+  echo -e "Checking hashicorp vault reachability"
+  ./vault_test.sh
+  if [ $? -ne 0 ]; then
+    echo -e "Failed hashicorp vault startup tests."
+    exit 1
+  fi
+else
+  echo -e "Vault reachability tests were skipped."
+fi
+
 # Clean up remote environment
 if [ "${EXCH_APP_HOST}" != "http://exchange-api:8080/v1" ]; then
   echo "Clean up remote environment"

--- a/test/gov/vault_test.sh
+++ b/test/gov/vault_test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Basic tests to check api reachability of hashicorp vault running as a docker instance.
+
+# Check vault status using API calls
+RES=$(curl --write-out "%{http_code}" --silent -o /dev/null ${VAULT_ADDR}/v1/sys/seal-status)
+
+if [ "$RES" != "200" ]
+then
+  echo -e "Error: Vault is unreachable at $VAULT_ADDR"
+  exit 1
+fi
+
+# Check success on aunthentication to vault server
+RES=$(curl --write-out "%{http_code}" --silent -o /dev/null -H "X-Vault-Token: $VAULT_TOKEN" -X GET ${VAULT_ADDR}/v1/auth/token/lookup-self)
+if [ "$RES" != "200" ]
+then
+  echo -e "Error: Cannot authenticate to vault at $VAULT_ADDR with vault token $VAULT_TOKEN"
+  exit 1
+fi
+
+# Check response on secret creation in vault
+RES=$(curl --write-out "%{http_code}" --silent -o /dev/null -H "X-Vault-Token: $VAULT_TOKEN" -X POST --data '{ "data": {"password": "my-long-password"} }' ${VAULT_ADDR}/v1/secret/data/creds)
+if [ "$RES" != "200" ]
+then
+  echo -e "Error: Cannot create secret in vault $VAULT_ADDR at secret/ with vault token $VAULT_TOKEN"
+  exit 1
+fi
+
+# Check vault cli, vault reachability has been checked earlier
+echo -e "Checking if the vault cli commands function properly"
+ret=$(vault status)
+if [ $? -ne 0 ]; then
+  echo -e "Error: vault cli not configured.\n $ret"
+  exit 1
+fi
+
+echo -e "Vault tests passed."


### PR DESCRIPTION
This PR will add a hashicorp vault instance inside the e2edev test environment. It will be reachable by the e2edev-agbot container.

Changes made :- 
1. `test/Makefile` - Updated targets `run-agbot`, `build` & `clean`. New targets `run-vault`, `hashicorp-vault-image`. Added config variables to run vault server (in dev mode) in a docker container.
2. `test/Dockerfile` - Updated docker cli install script & added vault-cli install script
3. `test/docker/fs/etc/vault/config.json` - Contains vault server configuration details
4. `test/gov/gov-combined.sh` - Add new section to execute vault reachability tests
5. `test/vault_test.sh` - Contains vault http API and cli tests
6. `test/README.md` - Update the lightweight test command

#### References

1. https://learn.hashicorp.com/collections/vault/getting-started
2.  https://www.vaultproject.io/api-docs
3. https://learn.hashicorp.com/tutorials/vault/configure-vault