### PR TITLE
Issue 2237 2324 - Added arm64 support to anax-in-container and to anax-in-k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ macpkginfo:
 
 anax-image:
 	@echo "Producing anax docker image $(ANAX_IMAGE)"
-	if [[ $(arch) == "amd64" || $(arch) == "ppc64el" || $(arch) == "s390x" ]]; then \
+	if [[ $(arch) == "amd64" || $(arch) == "ppc64el" || $(arch) == "s390x" || $(arch) == "arm64" ]]; then \
 	  rm -rf $(ANAX_CONTAINER_DIR)/anax; \
 	  rm -rf $(ANAX_CONTAINER_DIR)/hzn; \
 	  cp $(EXECUTABLE) $(ANAX_CONTAINER_DIR); \
@@ -370,7 +370,7 @@ anax-k8s-image: anax-k8s-clean
 	cp $(CLI_EXECUTABLE) $(ANAX_K8S_CONTAINER_DIR)
 	cp -f $(LICENSE_FILE) $(ANAX_K8S_CONTAINER_DIR)
 	@echo "Producing ANAX K8S docker image $(ANAX_K8S_IMAGE_STG)"
-	if [[ $(arch) == "amd64" || $(arch) == "ppc64el" ]]; then \
+	if [[ $(arch) == "amd64" || $(arch) == "ppc64el" || $(arch) == "arm64" ]]; then \
 		cd $(ANAX_K8S_CONTAINER_DIR) && docker build $(DOCKER_MAYBE_CACHE) $(ANAX_K8S_IMAGE_LABELS) -t $(ANAX_K8S_IMAGE_STG) -f Dockerfile.ubi.$(arch) .; \
 	fi
 	docker tag $(ANAX_K8S_IMAGE_STG) $(ANAX_K8S_IMAGE_BASE):$(ANAX_K8S_IMAGE_VERSION)

--- a/anax-in-container/Dockerfile.ubi.arm64
+++ b/anax-in-container/Dockerfile.ubi.arm64
@@ -1,0 +1,46 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
+
+LABEL vendor="IBM"
+LABEL summary="The agent in a general purpose container."
+LABEL description="A container which holds the edge node agent, to be used in environments where there is no operating system package that can install the agent natively."
+
+ARG DOCKER_VER=19.03.8
+
+# yum is not installed, use microdnf instead
+RUN microdnf update -y --nodocs && microdnf clean all
+
+# add EPEL repo with jq pkg and all deps
+#COPY EPEL.repo /etc/yum.repos.d
+
+# shadow-utils contains groupadd and adduser commands
+RUN microdnf install --nodocs -y shadow-utils \
+    && microdnf install --nodocs -y openssl ca-certificates \
+    && microdnf install -y wget iptables vim-minimal procps tar gzip \
+    && microdnf update -y --nodocs --nobest && microdnf clean all \
+    && microdnf install -y jq 
+
+# install docker cli
+RUN curl -fsSLO https://download.docker.com/linux/static/stable/aarch64/docker-${DOCKER_VER}.tgz \
+  	&& tar xzvf docker-${DOCKER_VER}.tgz --strip 1 -C /usr/bin docker/docker \
+  	&& rm docker-${DOCKER_VER}.tgz
+
+# add license file
+RUN mkdir -p /licenses
+COPY LICENSE.txt /licenses
+
+RUN mkdir -p /usr/horizon/bin /usr/horizon/web /var/horizon \
+    && mkdir -p /etc/horizon/agbot/policy.d /etc/horizon/policy.d /etc/horizon/trust
+
+# copy the horizon configurations
+COPY config/anax.json /etc/horizon/
+COPY config/hzn.json /etc/horizon/
+
+# copy anax and hzn binaries
+ADD anax /usr/horizon/bin/
+ADD hzn /usr/bin/
+
+WORKDIR /root
+COPY script/anax.service /root/
+
+# You can add a 2nd arg to this on the docker run cmd or the CMD statement in another dockerfile, to configure a specific environment
+ENTRYPOINT ["/root/anax.service", "start"]

--- a/anax-in-container/horizon-container
+++ b/anax-in-container/horizon-container
@@ -210,7 +210,14 @@ start() {
 	# Get the horizon image. The image version is the same as the hzn CLI version unless it is
 	# overwitten by $HC_DOCKER_IMAGE and $HC_DOCKER_TAG.
 	# $HC_DOCKER_IMAGE and $HC_DOCKER_TAG are intentionally undocumented env vars that allow us to test the staging version of the docker image
-	dockerImage='openhorizon/amd64_anax'
+
+	# get the architecture from hzn
+        arch=$(LANG=en_US hzn architecture)
+        if [ $? -ne 0 ]; then
+                arch="amd64"
+        fi
+
+	dockerImage='openhorizon/'$arch'_anax'
 	dockerTag='latest'
 	if [[ -n "$HC_DOCKER_IMAGE" ]]; then
 		dockerImage="$HC_DOCKER_IMAGE"

--- a/anax-in-k8s/Dockerfile.ubi.arm64
+++ b/anax-in-k8s/Dockerfile.ubi.arm64
@@ -1,0 +1,37 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
+
+LABEL vendor="IBM"
+LABEL summary="The agent for edge clusters."
+LABEL description="The agent in a container that is used solely for the purpose of running the agent in a kubernetes edge cluster."
+
+# yum is not installed, use microdnf instead
+RUN microdnf update -y --nodocs && microdnf clean all
+
+# shadow-utils contains groupadd and adduser commands
+RUN microdnf install --nodocs -y shadow-utils \
+    && microdnf install --nodocs -y openssl ca-certificates \
+    && microdnf install -y wget iptables vim-minimal procps tar \
+    && microdnf install -y jq
+
+# add license file
+RUN mkdir -p /licenses
+COPY LICENSE.txt /licenses
+
+RUN mkdir -p /usr/horizon/bin /usr/horizon/web /var/horizon \
+    && mkdir -p /etc/horizon/agbot/policy.d /etc/horizon/policy.d /etc/horizon/trust
+
+RUN adduser agentuser -u 1000 -U -f -1 -c "agent user,1,2,3"
+
+COPY script/* /home/agentuser/
+COPY config/* /etc/horizon/
+
+ADD anax /usr/horizon/bin/
+ADD hzn /usr/bin/
+
+RUN chown -R agentuser:agentuser /home/agentuser /etc/horizon
+
+USER agentuser
+WORKDIR /home/agentuser
+RUN mkdir -p /home/agentuser/policy.d
+
+ENTRYPOINT ["/home/agentuser/anax.service", "start"]


### PR DESCRIPTION
I added basic arm64 support to anax-in-container and to anax-in-k8s. See also #2337 and #2324

For a full arm64 anax-in-k8s support the file agent-install/agent-install.sh needs to be also modified. See also #2327 and #2326