### PR TITLE
Issue 2451 - Update the agbot config to include vault details

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,48 +19,54 @@ func Test_enrichFromEnvvars_success(t *testing.T) {
 		},
 		AgreementBot: AGConfig{
 			ExchangeURL: "zoo",
+			Vault: VaultConfig{
+				VaultURL: "http://vault/v1",
+			},
 		},
 	}
 
+	testVars := []string{ExchangeURLEnvvarName, FileSyncServiceCSSURLEnvvarName, VaultURLEnvvarName}
 	// Save the current env var value for restoration at the end.
-	saveEURL := os.Getenv(ExchangeURLEnvvarName)
-	saveCSSURL := os.Getenv(FileSyncServiceCSSURLEnvvarName)
+	currentVarValue := make(map[string]string)
+	for _, v := range testVars {
+		currentVarValue[v] = os.Getenv(v)
+	}
 
 	restore := func() {
 		// Restore the env var to what it was at the beginning of the test
-		if err := os.Setenv(ExchangeURLEnvvarName, saveEURL); err != nil {
-			t.Errorf("Failed to set envvar in test environment. Error: %v", err)
-		}
-		if err := os.Setenv(FileSyncServiceCSSURLEnvvarName, saveCSSURL); err != nil {
-			t.Errorf("Failed to set envvar in test environment. Error: %v", err)
+		for _, v := range testVars {
+			if err := os.Setenv(v, currentVarValue[v]); err != nil {
+				t.Errorf("Failed to set envvar in test environment. Error: %v", err)
+			}
 		}
 	}
 
 	defer restore()
 
 	// Clear it for the test
-	if err := os.Unsetenv(ExchangeURLEnvvarName); err != nil {
-		t.Errorf("Failed to clear %v for test environment. Error: %v", ExchangeURLEnvvarName, err)
-	}
-	if err := os.Unsetenv(FileSyncServiceCSSURLEnvvarName); err != nil {
-		t.Errorf("Failed to clear %v for test environment. Error: %v", FileSyncServiceCSSURLEnvvarName, err)
+	for _, v := range testVars {
+		if err := os.Unsetenv(v); err != nil {
+			t.Errorf("Failed to clear %v for test environment. Error: %v", v, err)
+		}
 	}
 
 	// test that there is no error produced by enriching w/ an unset exchange URL value until the time that we require it
-	if err := enrichFromEnvvars(&config); err != nil || config.Edge.ExchangeURL != "goo" || config.AgreementBot.ExchangeURL != "zoo" || config.Edge.FileSyncService.CSSURL != "https://mycomp/css/" {
+	if err := enrichFromEnvvars(&config); err != nil || config.Edge.ExchangeURL != "goo" || config.AgreementBot.ExchangeURL != "zoo" || config.Edge.FileSyncService.CSSURL != "https://mycomp/css/" || config.AgreementBot.Vault.VaultURL != "http://vault/v1" {
 		t.Errorf("Config enrichment failed passthrough test")
 	}
 
 	exVal := "fooozzzzz"
-	exCSSUTL := "edge.cssurl"
-	if err := os.Setenv(ExchangeURLEnvvarName, exVal); err != nil {
-		t.Errorf("Failed to set envvar in test environment. Error: %v", err)
-	}
-	if err := os.Setenv(FileSyncServiceCSSURLEnvvarName, exCSSUTL); err != nil {
-		t.Errorf("Failed to set envvar in test environment. Error: %v", err)
+	exCSSURL := "edge.cssurl"
+	exVaultURL := "https://vault/v1"
+	newVarValues := []string{exVal, exCSSURL, exVaultURL}
+
+	for i, v := range testVars {
+		if err := os.Setenv(v, newVarValues[i]); err != nil {
+			t.Errorf("Failed to set envvar in test environment. Error: %v", err)
+		}
 	}
 
-	if err := enrichFromEnvvars(&config); err != nil || config.Edge.ExchangeURL != exVal || config.AgreementBot.ExchangeURL != exVal || config.Edge.FileSyncService.CSSURL != exCSSUTL {
+	if err := enrichFromEnvvars(&config); err != nil || config.Edge.ExchangeURL != exVal || config.AgreementBot.ExchangeURL != exVal || config.Edge.FileSyncService.CSSURL != exCSSURL || config.AgreementBot.Vault.VaultURL != exVaultURL {
 		t.Errorf("Config enrichment did not set exchange URL or File Sync Server css url from envvar as expected")
 	}
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -168,6 +168,7 @@ run-agbot: agbot-docker-prereqs test-network
 		-e "DOCKER_CPU_TAG=$(DOCKER_CPU_TAG)" \
 		-e "ARCH=$(arch)" \
 		-e "HZN_VAULT"="$(HZN_VAULT)" \
+		-e "HZN_VAULT_ADDR"="$(VAULT_ADDR)" \
 		-e "VAULT_TOKEN"="$(VAULT_DEV_ROOT_TOKEN_ID)" \
 		-e "VAULT_ADDR"="$(VAULT_ADDR)" \
 		-t $(DOCKER_AGBOT_INAME):$(DOCKER_DEV_TAG)
@@ -339,8 +340,8 @@ agbot-docker-prereqs: get-anax
 	cp -r $(CURDIR)/docker/fs/etc $(AGBOT_TEMPFS)
 	rm -r $(AGBOT_TEMPFS)/etc/vault
 	cp -r $(CURDIR)/docker/fs/hzn $(CURDIR)/gov/* $(CURDIR)/docker/fs/helm $(CURDIR)/docker/fs/resources $(CURDIR)/docker/fs/objects $(AGBOT_TEMPFS)/root
-	for f in $$(find $(AGBOT_TEMPFS)/etc/agbot/ -maxdepth 1 -name '*.tmpl'); do EXCH_APP_HOST=$(DOCKER_EXCH) CSS_URL=$(CSS_URL) envsubst < $$f > "$$(echo $$f | sed 's/.tmpl//')"; done
-	for f in $$(find $(AGBOT_TEMPFS)/etc/colonus/ -maxdepth 1 -name '*.tmpl'); do EXCH_APP_HOST=$(DOCKER_EXCH) CSS_URL=$(CSS_URL) envsubst < $$f > "$$(echo $$f | sed 's/.tmpl//')"; done
+	for f in $$(find $(AGBOT_TEMPFS)/etc/agbot/ -maxdepth 1 -name '*.tmpl'); do EXCH_APP_HOST=$(DOCKER_EXCH) CSS_URL=$(CSS_URL) VAULT_ADDR=${VAULT_ADDR} envsubst < $$f > "$$(echo $$f | sed 's/.tmpl//')"; done
+	for f in $$(find $(AGBOT_TEMPFS)/etc/colonus/ -maxdepth 1 -name '*.tmpl'); do EXCH_APP_HOST=$(DOCKER_EXCH) CSS_URL=$(CSS_URL) VAULT_ADDR=${VAULT_ADDR} envsubst < $$f > "$$(echo $$f | sed 's/.tmpl//')"; done
 	cp $(ANAX_SOURCE)/pkg/deb/horizon/etc/horizon/trust/horizon.pem $(AGBOT_TEMPFS)/root/.colonus/.
 	cp $(ANAX_SOURCE)/pkg/deb/horizon/etc/horizon/trust/mtn-publicKey.pem $(AGBOT_TEMPFS)/root/.colonus/.
 

--- a/test/docker/fs/etc/agbot/agbot.config.tmpl
+++ b/test/docker/fs/etc/agbot/agbot.config.tmpl
@@ -37,6 +37,9 @@
         "CheckUpdatedPolicyS": 15,
         "CSSURL": "${CSS_URL}",
         "CSSSSLCert": "/certs/css.crt",
+        "Vault": {
+            "VaultURL": "${VAULT_ADDR}"
+        },
         "RetryLookBackWindow": 900,
         "MMSGarbageCollectionInterval": 20
     },

--- a/test/docker/fs/etc/agbot/agbot2.config.tmpl
+++ b/test/docker/fs/etc/agbot/agbot2.config.tmpl
@@ -37,6 +37,9 @@
         "CheckUpdatedPolicyS": 15,
         "CSSURL": "${CSS_URL}",
         "CSSSSLCert": "/certs/css.crt",
+        "Vault": {
+            "VaultURL": "${VAULT_ADDR}"
+        },
         "MMSGarbageCollectionInterval": 20
     },
     "ArchSynonyms": {


### PR DESCRIPTION
Signed-off-by: codejaeger <mandaldebabrata123@gmail.com>

Related to #2451 

- [x] Updated agbot config in `/config/config.go` to include vault details
- [x] Added tests to check vault variable enriching from the environment
- [x] Restructured `config_test.go`