### PR TITLE
Issue 2374 - AgBot panics if node policy has empty property

### DIFF
--- a/externalpolicy/counter_party_properties.go
+++ b/externalpolicy/counter_party_properties.go
@@ -494,7 +494,7 @@ func removeSpaces(value string) string {
 }
 func removeQuotes(value string) string {
 	quote := fmt.Sprint("\"")
-	if value[0:1] == quote && value[len(value)-1:len(value)] == quote {
+	if len(value) > 0 && value[0:1] == quote && value[len(value)-1:len(value)] == quote {
 		value = value[1 : len(value)-1]
 	}
 	return value


### PR DESCRIPTION
Signed-off-by: polber <jeff@thekinards.com>

AgBot would panic when parsing an empty string property because `externalpolicy/counter_party_properties.propertyInArray()` would try to remove quotations when they were not actually there causing an indexing issue in the string slice.