### PR TITLE
(Not ready) Agent add /secret et. al. APIs, document APIs

### DIFF
--- a/persistence/secrets.go
+++ b/persistence/secrets.go
@@ -1,0 +1,188 @@
+package persistence
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/boltdb/bolt"
+	"github.com/golang/glog"
+	"github.com/open-horizon/anax/policy"
+)
+
+const SECRETS = "secrets"
+
+const (
+	Initial  = "initial"
+	Received = "received"
+)
+
+type PersistedServiceSecret struct {
+	SvcOrgid        string
+	SvcUrl          string
+	SvcArch         string
+	SvcVersion      string
+	SvcSecretName   string
+	SvcSecretValue  string
+	SvcSecretStatus string
+}
+
+func persistedSecretFromPolicySecret(inputSecrets policy.ServiceSecret) []PersistedServiceSecret {
+	outputSecrets := []PersistedServiceSecret{}
+	for secName, secValue := range inputSecrets.ServiceSecrets {
+		outputSecrets = append(outputSecrets, PersistedServiceSecret{SvcOrgid: inputSecrets.ServiceOrgid, SvcUrl: inputSecrets.ServiceUrl, SvcArch: inputSecrets.ServiceArch, SvcVersion: inputSecrets.ServiceVersion, SvcSecretName: secName, SvcSecretValue: secValue})
+	}
+	return outputSecrets
+}
+
+func secretKey(svcName string, secretName string) string {
+	return fmt.Sprintf("%s/%s", svcName, secretName)
+}
+
+// Converts the policy form secrets to the persistent form and saves them in the db one by one. Can be used for a new agreement or for a change to an existing agreement.
+func PersistSecretsFromProposal(db *bolt.DB, secretsList []policy.ServiceSecret) error {
+	for _, secrets := range secretsList {
+		pSvcSecrets := persistedSecretFromPolicySecret(secrets)
+		for _, secToSave := range pSvcSecrets {
+			if db != nil {
+				secToSave.SvcSecretStatus = Initial
+				err := SaveSecrets(db, secToSave)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Saves the given secret to the agent db
+func SaveSecrets(db *bolt.DB, secretToSave PersistedServiceSecret) error {
+	writeErr := db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(SECRETS))
+		if err != nil {
+			return err
+		}
+
+		if serial, err := json.Marshal(secretToSave); err != nil {
+			return fmt.Errorf("Failed to serialize secrets: Error: %v", err)
+		} else {
+			return bucket.Put([]byte(secretKey(secretToSave.SvcUrl, secretToSave.SvcSecretName)), serial)
+		}
+	})
+
+	return writeErr
+}
+
+// Gets the secret from the database, no error returned if none is found in the db
+func FindSecrets(db *bolt.DB, secName string, svcName string) (*PersistedServiceSecret, error) {
+	psecret := &PersistedServiceSecret{}
+
+	readErr := db.View(func(tx *bolt.Tx) error {
+		if b := tx.Bucket([]byte(SECRETS)); b != nil {
+			s := b.Get([]byte(secretKey(svcName, secName)))
+			if s != nil {
+				if err := json.Unmarshal(s, psecret); err != nil {
+					glog.Errorf("Unable to deserialize service secret db record: %v. Error: %v", secretKey(svcName, secName), err)
+					return err
+				}
+			} else {
+				glog.Errorf("no entry found for %v", secretKey(svcName, secName))
+			}
+
+		}
+		return nil
+	})
+
+	if readErr != nil {
+		return nil, readErr
+	} else {
+		return psecret, nil
+	}
+}
+
+// Gets secrets which secret status is "initial"
+func FindUpdatedSecrets(db *bolt.DB, svcName string) ([]PersistedServiceSecret, error) {
+	result := make([]PersistedServiceSecret, 0)
+
+	function := func(secret PersistedServiceSecret) {
+		if svcName == secret.SvcUrl && Initial == secret.SvcSecretStatus {
+			result = append(result, secret)
+		}
+	}
+
+	readErr := db.View(func(tx *bolt.Tx) error {
+		if b := tx.Bucket([]byte(SECRETS)); b != nil {
+			cursor := b.Cursor()
+			for key, value := cursor.First(); key != nil; key, value = cursor.Next() {
+				var secret PersistedServiceSecret
+				if err := json.Unmarshal(value, &secret); err != nil {
+					return err
+				}
+				function(secret)
+			}
+		}
+		return nil
+	})
+
+	if readErr != nil {
+		return nil, readErr
+	} else {
+		return result, nil
+	}
+
+}
+
+// Updates the status of secret
+func UpdateSecretStatus(db *bolt.DB, secName string, svcName string, secStatus string) error {
+	psecret := PersistedServiceSecret{}
+	function := func(secret PersistedServiceSecret) (PersistedServiceSecret, error) {
+		secret.SvcSecretStatus = secStatus
+		return secret, nil
+	}
+
+	readErr := db.Update(func(tx *bolt.Tx) error {
+		if b := tx.Bucket([]byte(SECRETS)); b != nil {
+			id := []byte(secretKey(svcName, secName))
+			s := b.Get(id)
+			if s != nil {
+				if err := json.Unmarshal(s, &psecret); err != nil {
+					glog.Errorf("Unable to deserialize service secret db record: %v. Error: %v", secretKey(svcName, secName), err)
+					return err
+				} else if secret, err := function(psecret); err != nil {
+					glog.Errorf("Unable set secret status for db record: %v. Error: %v", secretKey(svcName, secName), err)
+					return err
+				} else if encodedSecret, err := json.Marshal(secret); err != nil {
+					glog.Errorf("Unable to serialize the updated secret db record: %v. Error: %v", secretKey(svcName, secName), err)
+					return err
+				} else if err = tx.Bucket([]byte(SECRETS)).Put([]byte(id), []byte(encodedSecret)); err != nil {
+					glog.Errorf("Unable to updated secret db record: %v. Error: %v", secretKey(svcName, secName), err)
+					return err
+				}
+			} else {
+				glog.Errorf("no entry found for %v", secretKey(svcName, secName))
+			}
+		}
+		return nil
+	})
+
+	return readErr
+
+}
+
+// Returns the secret from the db if it was there. No error returned if it is not in the db
+func DeleteSecrets(db *bolt.DB, secName string, svcName string) (*PersistedServiceSecret, error) {
+	if sec, err := FindSecrets(db, secName, svcName); err != nil {
+		return nil, err
+	} else {
+		return sec, db.Update(func(tx *bolt.Tx) error {
+			if b, err := tx.CreateBucketIfNotExists([]byte(MICROSERVICE_INSTANCES)); err != nil {
+				return err
+			} else if err := b.Delete([]byte(secretKey(svcName, secName))); err != nil {
+				return fmt.Errorf("Unable to delete service instance %v: %v", secretKey(svcName, secName), err)
+			} else {
+				return nil
+			}
+		})
+	}
+}
+

--- a/policy/secret.go
+++ b/policy/secret.go
@@ -1,0 +1,9 @@
+package policy
+
+type ServiceSecret struct {
+	ServiceOrgid   string            `json:"serviceOrgid"`
+	ServiceUrl     string            `json:"serviceUrl"`
+	ServiceArch    string            `json:"serviceArch,omitempty"`
+	ServiceVersion string            `json:"serviceVersion,omitempty"`
+	ServiceSecrets map[string]string `json:"serviceSecret"`
+}

--- a/resource/resource_manager.go
+++ b/resource/resource_manager.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"errors"
 	"fmt"
+	"github.com/boltdb/bolt"
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/config"
 	"github.com/open-horizon/anax/exchange"
@@ -58,7 +59,7 @@ func (r ResourceManager) String() string {
 		r.org, r.pattern, r.id, r.token)
 }
 
-func (r ResourceManager) StartFileSyncService(am *AuthenticationManager) error {
+func (r ResourceManager) setupFileSyncService(am *AuthenticationManager) error {
 
 	// Generate a self signed certificate to be used for TLS between a service and the embedded ESS API.
 	// The SSL private key is stored in a different location from the certificate so that the services
@@ -151,14 +152,32 @@ func (r ResourceManager) StartFileSyncService(am *AuthenticationManager) error {
 	// Set the authenticator that we're going to use.
 	security.SetAuthentication(&FSSAuthenticate{nodeOrg: r.org, nodeID: r.id, nodeToken: r.token, AuthMgr: am})
 
-	// Start the embedded ESS.
+	return nil
+
+}
+
+func (r ResourceManager) setupSecretsAPI(am *AuthenticationManager, db *bolt.DB) {
+	glog.V(5).Infof(rmLogString(fmt.Sprintf("Setup secret API")))
+	secretAPIs := NewSecretAPI(db, am)
+	secretAPIs.SetUpHttpHandler()
+}
+
+// StartFileSyncServiceAndSecretAPI will start embeded ESS and agent secrets API server
+func (r ResourceManager) StartFileSyncServiceAndSecretsAPI(am *AuthenticationManager, db *bolt.DB) error {
+	if err := r.setupFileSyncService(am); err != nil {
+		glog.Errorf(rmLogString(fmt.Sprintf("ESS Setup error: %v", err)))
+		os.Exit(98)
+	}
+
+	r.setupSecretsAPI(am, db)
+
+	// Start the embedded ESS and secret APIs
 	if err := base.Start("", true); err != nil {
 		glog.Errorf(rmLogString(fmt.Sprintf("ESS Start error: %v", err)))
 		os.Exit(98)
 	}
 
-	glog.V(3).Infof(rmLogString(fmt.Sprintf("ESS Started")))
-
+	glog.V(3).Infof(rmLogString(fmt.Sprintf("ESS and Secrets API Started")))
 	return nil
 
 }
@@ -232,3 +251,4 @@ func (r *ResourceManager) RemovePersistencePath() {
 var rmLogString = func(v interface{}) string {
 	return fmt.Sprintf("Resource Manager: %v", v)
 }
+

--- a/resource/resource_worker.go
+++ b/resource/resource_worker.go
@@ -59,8 +59,8 @@ func (w *ResourceWorker) Messages() chan events.Message {
 
 func (w *ResourceWorker) Initialize() bool {
 	if w.rm.Configured() {
-		if err := w.rm.StartFileSyncService(w.am); err != nil {
-			glog.Errorf(reslog(fmt.Sprintf("Error starting ESS: %v", err)))
+		if err := w.rm.StartFileSyncServiceAndSecretsAPI(w.am, w.db); err != nil {
+			glog.Errorf(reslog(fmt.Sprintf("Error starting ESS and Secrets API: %v", err)))
 			return false
 		}
 	}
@@ -151,7 +151,7 @@ func (w *ResourceWorker) handleNodeConfigCommand(cmd *NodeConfigCommand) error {
 		destinationType = "openhorizon/openhorizon.edgenode"
 	}
 	w.rm.NodeConfigUpdate(cmd.msg.Org(), destinationType, cmd.msg.DeviceId(), cmd.msg.Token())
-	return w.rm.StartFileSyncService(w.am)
+	return w.rm.StartFileSyncServiceAndSecretsAPI(w.am, w.db)
 }
 
 // The node has just been unconfigured so we can stop the file sync service.

--- a/resource/secret_api.go
+++ b/resource/secret_api.go
@@ -1,0 +1,227 @@
+package resource
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/boltdb/bolt"
+        "github.com/golang/glog"
+        "github.com/open-horizon/anax/persistence"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const (
+	getSecretsURL        = "/secrets"
+	secretsURL           = "/secrets/"
+	contentType          = "Content-Type"
+	applicationJSON      = "application/json"
+)
+
+type secretObject struct {
+	Details string `json:"details"`
+}
+
+var unauthorizedBytes = []byte("Unauthorized")
+
+type SecretAPI struct {
+	db *bolt.DB
+	authenticator *SecretsAPIAuthenticate
+}
+
+func NewSecretAPI(db *bolt.DB, am *AuthenticationManager) *SecretAPI {
+	auth := &SecretsAPIAuthenticate{
+		AuthMgr: am,
+	}
+	return &SecretAPI{
+		db: db,
+		authenticator: auth,
+	}
+}
+
+func (api *SecretAPI) SetUpHttpHandler() {
+	http.Handle(getSecretsURL, http.StripPrefix(getSecretsURL, http.HandlerFunc(api.handleGetSecrets)))
+	http.Handle(secretsURL, http.StripPrefix(secretsURL, http.HandlerFunc(api.handleSecrets)))
+
+}
+
+func (api *SecretAPI) SetupAuthenticator(auth *SecretsAPIAuthenticate) {
+	api.authenticator = auth
+}
+
+func (api *SecretAPI) handleGetSecrets(writer http.ResponseWriter, request *http.Request) {
+	setResponseHeaders(writer)
+
+	// GET /secrets
+        if request.Method != http.MethodGet {
+                writer.WriteHeader(http.StatusMethodNotAllowed)
+                return
+        }
+
+	glog.V(3).Infof(secLogString(fmt.Sprintf("Calling GET /secrets")))
+	authenticated, serviceName, err := api.authenticator.Authenticate(request)
+	if !authenticated {
+		glog.Errorf(secLogString(fmt.Sprintf("handleGetSecrets authenticate error: %v", err)))
+		writer.WriteHeader(http.StatusForbidden)
+		writer.Write(unauthorizedBytes)
+		return
+	} else if secs, err := persistence.FindUpdatedSecrets(api.db, serviceName); err != nil {
+		message := fmt.Sprintf("Failed to fetch the secret names.")
+		returnErrorResponse(writer, err, message, http.StatusInternalServerError)
+	} else if len(secs) == 0 {
+		writer.WriteHeader(http.StatusNotFound)
+		return
+	} else {
+		result := make([]string, 0)
+		for _, sec := range secs {
+			result = append(result, sec.SvcSecretName)
+		}
+
+		if data, err := json.MarshalIndent(result, "", "  "); err != nil {
+			returnErrorResponse(writer, err, "Failed to marshal the list of secret names.", http.StatusInternalServerError)
+		} else {
+			writer.Header().Add(contentType, applicationJSON)
+			writer.WriteHeader(http.StatusOK)
+			if _, err := writer.Write(data); err != nil {
+				glog.Errorf(secLogString(fmt.Sprintf("GET /secrets, failed to write to response body: %v", err)))
+			}
+			return
+		}
+	}
+
+}
+
+func (api *SecretAPI) handleSecrets(writer http.ResponseWriter, request *http.Request) {
+	setResponseHeaders(writer)
+
+	authenticated, serviceName, err := api.authenticator.Authenticate(request)
+	if !authenticated {
+		glog.Errorf(secLogString(fmt.Sprintf("handleSecrets authenticate error: %v", err)))
+                writer.WriteHeader(http.StatusForbidden)
+                writer.Write(unauthorizedBytes)
+                return
+        }
+
+	parts := strings.Split(request.URL.Path, "/")
+
+	if len(parts) == 0 {
+		api.handleGetSecrets(writer, request)
+		return
+	} else if len(parts) == 1 {
+		// GET /secrets/<secret-name>
+		// POST /secrets/<secret-name>?received=true
+		secretName := parts[0]
+		if secretName == "" {
+			writer.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		switch request.Method {
+		case http.MethodPost:
+			//POST /secrets/<secret-name>?received=true
+			receivedString := request.URL.Query().Get("received")
+
+			glog.V(3).Infof(secLogString(fmt.Sprintf("Calling POST /secrets/%s?received=%s", secretName, receivedString)))
+			received := false
+			if receivedString != "" {
+				var err error
+				if received, err = strconv.ParseBool(receivedString); err != nil {
+					writer.WriteHeader(http.StatusBadRequest)
+					return
+				} else if received {
+					// call persistent to find secret
+					if psecret, err := persistence.FindSecrets(api.db, secretName, serviceName); err != nil {
+						returnErrorResponse(writer, err, "Failed to find secret to mark received.", http.StatusInternalServerError)
+					} else if isEmptySecretObject(*psecret) {
+						returnErrorResponse(writer, err, "Secret not found to mark received.", http.StatusNotFound)
+					} else if psecret.SvcSecretStatus == persistence.Received {
+						writer.WriteHeader(http.StatusCreated)
+						return
+					}
+
+					// call persistent to update secret status
+					if err := persistence.UpdateSecretStatus(api.db, secretName, serviceName, persistence.Received); err != nil {
+						returnErrorResponse(writer, err, "Failed to mark secret received.", http.StatusInternalServerError)
+					}
+					writer.WriteHeader(http.StatusCreated)
+					return
+				} else {
+					// received == false
+					glog.V(3).Infof(secLogString(fmt.Sprintf("POST /secrets/%s?received=%s, return 201 directly", secretName, received)))
+					writer.WriteHeader(http.StatusCreated)
+					return
+				}
+			}
+
+		case http.MethodGet:
+			//GET /secrets/<secret-name>
+			glog.V(3).Infof(secLogString(fmt.Sprintf("Calling GET /secrets/%s", secretName)))
+
+			// call persistent to get secret object (key: serviceName/secretName)
+			// get secret value: secret.SvcSecretValue
+			if psecret, err := persistence.FindSecrets(api.db, secretName, serviceName); err != nil {
+				returnErrorResponse(writer, err, "Failed to find secret.", http.StatusInternalServerError)
+			} else if isEmptySecretObject(*psecret) {
+				returnErrorResponse(writer, err, "Secret not found.", http.StatusNotFound)
+			} else {
+				// return secret
+				m := make(map[string]*secretObject, 0)
+
+				secretName := psecret.SvcSecretName
+				secretObj := &secretObject{Details: psecret.SvcSecretValue}
+				m[secretName] = secretObj
+
+				if data, err := json.MarshalIndent(m, "", "  "); err != nil {
+					returnErrorResponse(writer, err, "Failed to marshal the secret.", http.StatusInternalServerError)
+				} else {
+					writer.Header().Add(contentType, applicationJSON)
+					writer.WriteHeader(http.StatusOK)
+					if _, err := writer.Write(data); err != nil {
+						glog.Errorf(secLogString(fmt.Sprintf("GET /secrets/<secretName>, failed to write to response body: %v", err)))
+					}
+					return
+				}
+
+			}
+		default:
+			writer.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	} else {
+		// error
+		writer.WriteHeader(http.StatusBadRequest)
+	}
+}
+
+func returnErrorResponse(writer http.ResponseWriter, err error, message string, statusCode int) {
+	writer.WriteHeader(statusCode)
+	if message != "" || err != nil {
+		writer.Header().Add("Content-Type", "Text/Plain")
+		buffer := bytes.NewBufferString(message)
+		if err != nil {
+			buffer.WriteString(fmt.Sprintf("Error: %s", err.Error()))
+		}
+		buffer.WriteString("\n")
+		writer.Write(buffer.Bytes())
+	}
+}
+
+func isEmptySecretObject(psecret persistence.PersistedServiceSecret) bool {
+	if psecret.SvcOrgid == "" && psecret.SvcUrl == "" && psecret.SvcSecretName == "" &&
+		psecret.SvcSecretValue == "" && psecret.SvcSecretStatus == "" {
+		return true
+	}
+	return false
+}
+
+// Set HTTP cache control headers for http 1.0 and 1.1 clients.
+func setResponseHeaders(writer http.ResponseWriter) {
+	// Set HTTP cache control headers for http 1.0 and 1.1 clients.
+	writer.Header().Set("Cache-Control", "no-store")
+	writer.Header().Set("Pragma", "no-cache")
+}
+
+// Logging function
+var secLogString = func(v interface{}) string {
+	return fmt.Sprintf("Secrets API: %v", v)
+}

--- a/resource/secret_api_authenticate.go
+++ b/resource/secret_api_authenticate.go
@@ -1,0 +1,55 @@
+package resource
+
+import (
+	"errors"
+	"fmt"
+	"github.com/golang/glog"
+	"net/http"
+	"strings"
+)
+
+type SecretsAPIAuthenticate struct {
+	AuthMgr *AuthenticationManager
+}
+
+// return bool, serviceURL, error
+func (auth *SecretsAPIAuthenticate) Authenticate(request *http.Request) (bool, string, error) {
+	if request == nil {
+		glog.Errorf(secretsALS(fmt.Sprintf("called with a nil HTTP request")))
+		return false, "", errors.New(fmt.Sprintf("Unable to authenticate nil request for secrets API"))
+	}
+
+	if appKey, appSecret, ok := request.BasicAuth(); !ok {
+		glog.Errorf(secretsALS(fmt.Sprintf("failed to extract basic auth for request")))
+		return false, "", errors.New(fmt.Sprintf("Unable to extract basic auth for request"))
+	} else if ok, _, err := auth.AuthMgr.Authenticate(appKey, appSecret); err != nil {
+		glog.Errorf(secretsALS(fmt.Sprintf("unable to verify %v, error %v", appKey, err)))
+		return false, "", errors.New(fmt.Sprintf("unable to verify %v, error %v", appKey, err))
+	} else if !ok {
+		glog.Errorf(secretsALS(fmt.Sprintf("credentials for %v are not valid", appKey)))
+		return false, "", errors.New(fmt.Sprintf("credentials for %v are not valid", appKey))
+	} else if _, serviceURL, err := extractAppKey(appKey); err != nil {
+		glog.Errorf(secretsALS(fmt.Sprintf("failed to extract serviceOrg and serviceURL from appKey Error: %v", err)))
+		return false, "", errors.New(fmt.Sprintf(err.Error()))
+	} else {
+		return true, serviceURL, nil
+	}
+
+}
+
+// returns serviceOrg, serviceURL, error from the appKey
+// appKey format: {serviceOrg}/{serviceURL}
+func extractAppKey(appKey string) (string, string, error) {
+	parts := strings.Split(appKey, "/")
+	if len(parts) != 2 {
+		return "", "", errors.New(fmt.Sprintf("appKey %s is not in the correct format {serviceOrg}/{serviceURL}", appKey))
+	}
+
+	return parts[0], parts[1], nil
+}
+
+// Logging function
+var secretsALS = func(v interface{}) string {
+	return fmt.Sprintf("Secrets API : Authenticator %v", v)
+}
+


### PR DESCRIPTION
Signed-off-by: zhangl <zhangl@us.ibm.com>

1. `GET /secrets`
<img width="1022" alt="Screen Shot 2021-06-17 at 4 44 01 PM" src="https://user-images.githubusercontent.com/49077510/122470325-ed165680-cf8b-11eb-951e-00b4e4576cb3.png">
<img width="1021" alt="Screen Shot 2021-06-17 at 4 43 33 PM" src="https://user-images.githubusercontent.com/49077510/122470346-f30c3780-cf8b-11eb-8785-c7aceb323fd9.png">

2. `GET /sercrets/<secretName>`
<img width="1115" alt="Screen Shot 2021-06-17 at 4 43 43 PM" src="https://user-images.githubusercontent.com/49077510/122470376-facbdc00-cf8b-11eb-81fc-09c3844e7fab.png">

3. `POST /secrets/<secretName>?receive=true`
<img width="1213" alt="Screen Shot 2021-06-17 at 4 43 50 PM" src="https://user-images.githubusercontent.com/49077510/122470407-04edda80-cf8c-11eb-8eb2-f88507a2c9a3.png">
