### PR TITLE
Issue2584 - Agent-install.sh: Error creating /etc/default/horizon fil…

### DIFF
--- a/agent-install/agent-install.sh
+++ b/agent-install/agent-install.sh
@@ -1058,6 +1058,7 @@ function create_or_update_horizon_defaults() {
 
     if [[ ! -f /etc/default/horizon ]]; then
         log_info "Creating /etc/default/horizon ..."
+        sudo mkdir -p /etc/default
         sudo bash -c "echo -e 'HZN_EXCHANGE_URL=${HZN_EXCHANGE_URL}\nHZN_FSS_CSSURL=${HZN_FSS_CSSURL}\nHZN_DEVICE_ID=${NODE_ID}\nHZN_NODE_ID=${NODE_ID}' > /etc/default/horizon"
         if [[ -n $HZN_AGBOT_URL ]]; then
             sudo sh -c "echo 'HZN_AGBOT_URL=$HZN_AGBOT_URL' >> /etc/default/horizon"


### PR DESCRIPTION
…e if /etc/default dir doesn't exist in MacOS

Signed-off-by: zhangl <zhangl@us.ibm.com>