### PR TITLE
Issue 2479 - 'hzn secretsmanager' commands that talk to the agbot secure APIs to list/add/remove secrets

### DIFF
--- a/agreementbot/secrets/vault/vault.go
+++ b/agreementbot/secrets/vault/vault.go
@@ -126,9 +126,30 @@ func (vs *AgbotVaultSecrets) ListOrgSecrets(user, password, org string) ([]strin
 		return nil, secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to parse response %v", string(respBytes)), Details: "", RespCode: http.StatusInternalServerError}
 	}
 
+	// filter out user/ and empty secret directories
+	secrets := []string{}
+	for _, secret := range respMsg.Data.Keys {
+		if secret == "user/" {
+			// filter out the user/ directory for user level secrets
+			continue
+		} else if secret[len(secret)-1] == '/' {
+			// filter out empty directories
+			res, listErr := vs.ListOrgSecrets(user, password, org+"/"+(secret[:len(secret)-1]))
+			if listErr != nil && len(res) == 0 {
+				continue
+			} else {
+				// non-empty secret directory
+				secrets = append(secrets, secret)
+			}
+		} else {
+			// secret
+			secrets = append(secrets, secret)
+		}
+	}
+
 	glog.V(3).Infof(vaultPluginLogString("done listing secrets."))
 
-	return respMsg.Data.Keys, nil
+	return secrets, nil
 }
 
 // Available to all users within the org
@@ -199,6 +220,15 @@ func (vs *AgbotVaultSecrets) deleteSecret(user, password, org, name, url string)
 	userVaultToken, err := vs.loginUser(user, password, org)
 	if err != nil {
 		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to login user %s, error %v", user, err), Details: "", RespCode: http.StatusUnauthorized}
+	}
+
+	// check if the secret exists before deleting (if the secret doesn't exist, return 404)
+	exists, listErr := vs.listSecret(user, password, org, name, url)
+	if listErr != nil {
+		return listErr
+	}
+	if exists["exists"] == "false" {
+		return secrets.ErrorResponse{Msg: fmt.Sprintf("Secret does not exist; there is nothing to delete."), Details: "", RespCode: http.StatusNotFound}
 	}
 
 	glog.V(3).Infof(vaultPluginLogString(fmt.Sprintf("deleting secret %s in org %s as user %s", name, org, user)))

--- a/cli/cliutils/cliutils.go
+++ b/cli/cliutils/cliutils.go
@@ -837,6 +837,64 @@ func HorizonPutPost(method string, urlSuffix string, goodHttpCodes []int, body i
 	return
 }
 
+// Runs a GET to the agbot secure API and fills in the specified json structure. if the structure is just a string, fill in the raw json.
+// If the list of goodHttpCodes is non-empty and none match the actual http code, it will exit with an error; otherwise, the actual code is returned
+func AgbotGet(urlSuffix, credentials string, goodHttpCodes []int, structure interface{}) (httpCode int) {
+	// get message printer
+	msgPrinter := i18n.GetMessagePrinter()
+
+	// check the agbot url
+	agbot_url := GetAgbotSecureAPIUrlBase()
+	if agbot_url == "" {
+		Fatal(HTTP_ERROR, msgPrinter.Sprintf("HZN_AGBOT_URL is not defined"))
+	}
+
+	// query the agbot secure api
+	httpCode = ExchangeGet("Agbot", agbot_url, urlSuffix, credentials, goodHttpCodes, structure)
+
+	// ExchangeGet checks the http code, so we can just directly return
+	return httpCode
+}
+
+// Runs a PUT, POST, or PATCH to the agbot secure API to create or update a resource. If body is a string, it will be given to the exhcnage
+// as json. Otherwise, the struct will be marshaled to json.
+// If the list of goodHttpCodes is non-empty and none match the actual http code, it will exit with an error; otherwise, the actual code is returned
+func AgbotPutPost(method, urlSuffix, credentials string, goodHttpCodes []int, body interface{}, structure interface{}) (httpCode int) {
+	// get message printer
+	msgPrinter := i18n.GetMessagePrinter()
+
+	// check the agbot url
+	agbot_url := GetAgbotSecureAPIUrlBase()
+	if agbot_url == "" {
+		Fatal(HTTP_ERROR, msgPrinter.Sprintf("HZN_AGBOT_URL is not defined"))
+	}
+
+	// query the agbot secure api
+	httpCode = ExchangePutPost("Agbot", method, agbot_url, urlSuffix, credentials, goodHttpCodes, body, structure)
+
+	// ExchangePutPost checks the http code, so we can just directly return
+	return httpCode
+}
+
+// Runs a DELETE to the agbot secure API to delete a resource.
+// If the list of goodHttpCodes is non-empty and none match the actual http code, it will exit with an error; otherwise, the actual code is returned
+func AgbotDelete(urlSuffix, credentials string, goodHttpCodes []int) (httpCode int) {
+	// get message printer
+	msgPrinter := i18n.GetMessagePrinter()
+
+	// check the agbot url
+	agbot_url := GetAgbotSecureAPIUrlBase()
+	if agbot_url == "" {
+		Fatal(HTTP_ERROR, msgPrinter.Sprintf("HZN_AGBOT_URL is not defined"))
+	}
+
+	// query the agbot secure api
+	httpCode = ExchangeDelete("Agbot", agbot_url, urlSuffix, credentials, goodHttpCodes)
+
+	// ExchangeDelete checks the http code, so we can just directly return
+	return httpCode
+}
+
 // get a value keyed by key in a file. The file contains key=value for each line.
 func GetEnvVarFromFile(filename string, key string) (string, error) {
 	fHandle, err := os.Open(filename)

--- a/cli/secrets_manager/secrets_manager.go
+++ b/cli/secrets_manager/secrets_manager.go
@@ -1,0 +1,203 @@
+package secrets_manager
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/open-horizon/anax/cli/cliutils"
+	"github.com/open-horizon/anax/i18n"
+)
+
+type SecretResponse struct {
+	Exists bool `json:"exists"`
+}
+
+// Parses the raw bytes into the given structure, then prints the parsed structure
+func printResponse(resp []byte, structure interface{}) {
+	// get message printer
+	msgPrinter := i18n.GetMessagePrinter()
+
+	// parse into the structure type
+	perr := json.Unmarshal(resp, &structure)
+	if perr != nil {
+		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to unmarshal REST API response: %v", perr))
+	}
+
+	// print the parsed structure
+	jsonBytes, jerr := json.MarshalIndent(structure, "", cliutils.JSON_INDENT)
+	if jerr != nil {
+		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to marshal 'exchange node list' output: %v", jerr))
+	}
+	fmt.Printf("%s\n", jsonBytes)
+}
+
+// Retries a query (in the form a function returning the http code) <retryCount> times with <retryInterval> second delays
+// as long as a 503 is returned. If a code other than 503 is returned, or the number of retries is reached, the code of the final
+// query will be returned.
+func queryWithRetry(query func() int, retryCount, retryInterval int) (httpCode int) {
+
+	// on a 503, we want to retry a small number of times
+	for i := 0; i < retryCount; i++ {
+		httpCode = query()
+		if httpCode != 503 {
+			return httpCode
+		}
+		cliutils.Verbose("Vault component not found in the management hub. Retrying...")
+		time.Sleep(time.Duration(retryInterval) * time.Second)
+	}
+
+	// maximum number of retries
+	return httpCode
+}
+
+// If secretName is empty, lists all the org level secrets and non-empty directories for the specified org in the secrets manager
+// If secretName is specified, prints a json object indicating whether the given secret exists or not in the secrets manager for the org
+func SecretList(org, credToUse, secretName string) {
+	// get message printer
+	msgPrinter := i18n.GetMessagePrinter()
+
+	// query the agbot secure api
+	var resp []byte
+	listQuery := func() int {
+		return cliutils.AgbotGet("org"+cliutils.AddSlash(org)+"/secrets"+cliutils.AddSlash(secretName), cliutils.OrgAndCreds(org, credToUse),
+			[]int{200, 401, 403, 404, 503}, &resp)
+	}
+	retCode := queryWithRetry(listQuery, 3, 1)
+
+	// parse and print the response
+	if retCode == 401 || retCode == 403 || retCode == 503 {
+		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, string(resp))
+	} else if secretName == "" { // no secret name provided, list secrets/no secrets found
+		if retCode == 200 {
+			// list secrets
+			var secrets []string
+			printResponse(resp, &secrets)
+		} else if retCode == 404 {
+			// no secrets found
+			fmt.Println("[]")
+		}
+	} else { // secret name provided, exists/does not exist
+		if retCode == 200 {
+			var secret SecretResponse
+			printResponse(resp, &secret)
+		} else if retCode == 404 {
+			// secret doesn't exist
+			secretDNE := SecretResponse{false}
+			jsonBytes, jerr := json.MarshalIndent(secretDNE, "", cliutils.JSON_INDENT)
+			if jerr != nil {
+				cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to marshal 'exchange node list' output: %v", jerr))
+			}
+			fmt.Printf("%s\n", jsonBytes)
+		}
+	}
+
+}
+
+// Adds or updates a secret in the secrets manager. Secret names are unique, if a secret already exists with the same name, the user
+// will be prompted if they want to overwrite the existing secret, unless the secretOverwrite flag is set
+func SecretAdd(org, credToUse, secretName, secretFile, secretKey, secretDetail string, secretOverwrite bool) {
+	// get message printer
+	msgPrinter := i18n.GetMessagePrinter()
+
+	// check the input
+	if secretFile != "" && secretDetail != "" {
+		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("-f is mutually exclusive with --secretDetail."))
+	}
+	if secretFile == "" && secretDetail == "" {
+		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Must specify either -f or --secretDetail."))
+	}
+
+	// check if the secret already exists by querying the api
+	secretExists := false
+	var resp []byte
+	checkQuery := func() int {
+		return cliutils.AgbotGet("org"+cliutils.AddSlash(org)+"/secrets"+cliutils.AddSlash(secretName), cliutils.OrgAndCreds(org, credToUse),
+			[]int{200, 401, 403, 404, 503}, &resp)
+	}
+	retCode := queryWithRetry(checkQuery, 3, 1)
+
+	// check the response
+	if retCode == 401 || retCode == 403 || retCode == 503 {
+		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, string(resp))
+	} else if retCode == 200 {
+		var secret SecretResponse
+		perr := json.Unmarshal(resp, &secret)
+		if perr != nil {
+			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to unmarshal REST API response: %v", perr))
+		}
+		secretExists = secret.Exists
+	}
+
+	// parse the key and details
+	var newSecret struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+	newSecret.Key = secretKey
+	if secretDetail != "" {
+		newSecret.Value = secretDetail
+	} else {
+		// parse in a file as bytes for the secret details
+		var secretBytes []byte
+		var err error
+		if secretFile == "-" {
+			secretBytes, err = ioutil.ReadAll(os.Stdin)
+		} else {
+			secretBytes, err = ioutil.ReadFile(secretFile)
+		}
+		if err != nil {
+			cliutils.Fatal(cliutils.FILE_IO_ERROR, msgPrinter.Sprintf("reading %s failed: %v", secretFile, err))
+		}
+		newSecret.Value = string(secretBytes)
+	}
+
+	// prompt for overwrite if the secret already exists
+	if secretExists && !secretOverwrite {
+		cliutils.ConfirmRemove(msgPrinter.Sprintf("Secret \"%s\" already exists in the secrets manager. Do you want to overwrite?", secretName))
+	}
+
+	// add/replace the secret to the secrets manager
+	var resp2 []byte
+	addQuery := func() int {
+		return cliutils.AgbotPutPost(http.MethodPut, "org"+cliutils.AddSlash(org)+"/secrets"+cliutils.AddSlash(secretName),
+			cliutils.OrgAndCreds(org, credToUse), []int{201, 401, 403, 503}, newSecret, &resp2)
+	}
+	retCode = queryWithRetry(addQuery, 3, 1)
+
+	// output success or failure
+	if retCode == 201 {
+		fmt.Printf("Secret \"%s\" successfully added to the secrets manager.\n", secretName)
+	} else if retCode == 401 || retCode == 403 || retCode == 503 {
+		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, string(resp2))
+	}
+
+}
+
+// Removes a secret in the secrets manager. If the secret does not exist, an error (fatal) is raised
+func SecretRemove(org, credToUse, secretName string) {
+	// get message printer
+	msgPrinter := i18n.GetMessagePrinter()
+
+	// query the agbot secure api
+	removeQuery := func() int {
+		return cliutils.AgbotDelete("org"+cliutils.AddSlash(org)+"/secrets"+cliutils.AddSlash(secretName), cliutils.OrgAndCreds(org, credToUse),
+			[]int{204, 401, 403, 404, 503})
+	}
+	retCode := queryWithRetry(removeQuery, 3, 1)
+
+	// output success or failure
+	if retCode == 204 {
+		fmt.Printf("Secret \"%v\" successfully deleted from the secrets manager.\n", secretName)
+	} else if retCode == 401 || retCode == 403 {
+		user, _ := cliutils.SplitIdToken(credToUse)
+		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, msgPrinter.Sprintf("Invalid credentials. User \"%s\" cannot access \"%s\".\n", user, secretName))
+	} else if retCode == 404 {
+		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, msgPrinter.Sprintf("Secret \"%s\" not found in the secrets manager, nothing to delete.\n", secretName))
+	} else if retCode == 503 {
+		cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, msgPrinter.Sprintf("Vault component not found in the management hub."))
+	}
+}

--- a/test/gov/agbot_apitest.sh
+++ b/test/gov/agbot_apitest.sh
@@ -486,7 +486,7 @@ echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} GET"
 CMD="curl -sLX GET -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}"
 echo "$CMD"
 RES=$($CMD)
-results "$RES" "200" "exists" "true"
+results "$RES" "200" "exists" "false"
 
 echo -e "\n${PREFIX} test ${LIST_ORG_SECRETS} GET"
 CMD="curl -sLX GET -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRETS}"

--- a/test/gov/gov-combined.sh
+++ b/test/gov/gov-combined.sh
@@ -397,6 +397,15 @@ if [ "$NOCOMPCHECK" != "1" ] && [ "$TESTFAIL" != "1" ]; then
       echo "Policy compatibility test using hzn command failure."
       exit 1
     fi
+
+    if [ "$HZN_VAULT" == "true" ]; then 
+      ./hzn_secretsmanager.sh 
+      if [ $? -ne 0 ]
+      then
+        echo "Policy compatibility test using hzn secretsmanager command failure."
+        exit 1
+      fi
+    fi
   fi
 
 fi

--- a/test/gov/hzn_secretsmanager.sh
+++ b/test/gov/hzn_secretsmanager.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+
+# ----------------------------
+# ----- HELPER FUNCTIONS -----
+# ----------------------------
+
+# Print a command and its response on separate lines. The inputs are:
+# $1 - the command 
+# $2 - the response
+function print_command_and_response {
+  echo -e "\n$1"
+  echo -e "$2"
+}
+
+# Verify a response. The inputs are:
+# $1 - the command
+# $2 - the response
+# $3 - expected result
+# $4 - error message
+function verify {
+
+    print_command_and_response "$1" "$2" 
+
+    respContains=$(echo $2 | grep "$3")
+    if [ "${respContains}" == "" ]; then
+        echo -e "\nERROR: $4"
+        exit 1
+    fi
+}
+
+# ----------------------------
+# ----- SETUP -----
+# ----------------------------
+
+# check environment variables
+if [ "$HZN_VAULT" != "true" ]
+then
+  echo -e "Skipping hzn secretsmanager tests"
+  exit 0
+fi
+
+if [ -z ${AGBOT_SAPI_URL} ]; then
+  echo -e "\n${PREFIX} Envvar AGBOT_SAPI_URL is empty. Skip test\n"
+  exit 0
+fi
+
+# set HZN_AGBOT_URL for the cli
+export HZN_AGBOT_URL=${AGBOT_SAPI_URL}
+
+PREFIX="\nhzn secretsmanager CLI test: "
+
+echo -e "$PREFIX start test"
+
+# user authentication variables
+E2EDEV_ORG="e2edev@somecomp.com"
+E2EDEV_ADMIN_AUTH="e2edevadmin:e2edevadminpw"
+USERDEV_ORG="userdev"
+USERDEV_ADMIN_AUTH="userdevadmin:userdevadminpw"
+
+# -----------------------
+# ----- ORG SECRETS -----
+# -----------------------
+echo -e "$PREFIX testing org level secrets"
+
+# list a secret that doesn't exist - expecting "{ exists: false }"
+echo -e "$PREFIX list an org secret that doesn't exist (expecting false)"
+
+CMD="hzn secretsmanager secret list -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} no-password"
+RES=$($CMD)
+verify "$CMD" "$RES" "false" "secret shouldn't exist"
+
+# add an org secret and check existence
+echo -e "$PREFIX add an org secret and check existence using 'list'"
+
+CMD="hzn secretsmanager secret add --secretKey password -d password123 -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} test-password"
+RES=$($CMD)
+print_command_and_response "$CMD" "$RES"
+
+CMD="hzn secretsmanager secret list -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH}"
+RES=$($CMD)
+verify "$CMD" "$RES" "test-password" "secret should exist after add"
+
+CMD="hzn secretsmanager secret list -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} test-password"
+RES=$($CMD)
+verify "$CMD" "$RES" "true" "secret should exist after add"
+
+# update the org secret and check with vault cli
+echo -e "$PREFIX update an org secret and check the updated details using 'vault get'"
+
+CMD="hzn secretsmanager secret add --secretKey password -d password321 -O -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} test-password"
+RES=$($CMD)
+print_command_and_response "$CMD" "$RES"
+
+CMD="vault kv get openhorizon/${USERDEV_ORG}/test-password"
+RES=$($CMD)
+verify "$CMD" "$RES" "password321" "secret detail should have been updated after add"
+
+# remove the org secret and check existence
+echo -e "$PREFIX remove an org secret and check its existence using 'list'"
+
+CMD="hzn secretsmanager secret remove -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} test-password"
+RES=$($CMD)
+print_command_and_response "$CMD" "$RES"
+
+CMD="hzn secretsmanager secret list -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} test-password"
+RES=$($CMD) 
+verify "$CMD" "$RES" "false" "secret shouldn't exist after remove"
+
+# ----------------------------
+# ----- USER SECRETS -----
+# ----------------------------
+echo -e "$PREFIX testing user level secrets"
+
+# list a secret that doesn't exist - expecting "{ exists: false }"
+echo -e "$PREFIX list a user secret that doesn't exist (expecting false)"
+
+CMD="hzn secretsmanager secret list -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin/no-password"
+RES=$($CMD)
+verify "$CMD" "$RES" "false" "secret shouldn't exist"
+
+# add a user secret and check existence 
+echo -e "$PREFIX add a user secret and check existence using 'list'"
+
+CMD="hzn secretsmanager secret add --secretKey password -d password123 -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin/test-password"
+RES=$($CMD)
+print_command_and_response "$CMD" "$RES"
+
+CMD="hzn secretsmanager secret list -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin/test-password"
+RES=$($CMD)
+verify "$CMD" "$RES" "true" "secret should exist after add"
+
+# update the user secret and check with vault cli 
+echo -e "$PREFIX update a user secret and check the updated details using 'vault get'"
+
+CMD="hzn secretsmanager secret add --secretKey password -d password321 -O -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin/test-password"
+RES=$($CMD)
+print_command_and_response "$CMD" "$RES"
+
+CMD="vault kv get openhorizon/${USERDEV_ORG}/user/userdevadmin/test-password"
+RES=$($CMD)
+verify "$CMD" "$RES" "password321" "secret detail should have been updated after add"
+
+# remove the user secret and check existence 
+echo -e "$PREFIX remove a user secret and check its existence using 'list'"
+
+CMD="hzn secretsmanager secret remove -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin/test-password"
+RES=$($CMD)
+print_command_and_response "$CMD" "$RES"
+
+CMD="hzn secretsmanager secret list -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin/test-password"
+RES=$($CMD)
+verify "$CMD" "$RES" "false" "secret shouldn't exist after remove"
+
+# ----------------------------
+# ----- EXPECTED ERRORS -----
+# ----------------------------
+echo -e "$PREFIX testing expected errors"
+
+echo -e "$PREFIX adding user secret for ${USERDEV_ORG} organization"
+CMD="hzn secretsmanager secret add --secretKey password -d password123 -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin/test-password"
+RES=$($CMD)
+print_command_and_response "$CMD" "$RES"
+
+echo -e "$PREFIX adding user secret for ${E2EDEV_ORG} organization"
+CMD="hzn secretsmanager secret add --secretKey password -d password321 -o ${E2EDEV_ORG} -u ${E2EDEV_ADMIN_AUTH} user/e2edevadmin/test-password"
+RES=$($CMD)
+print_command_and_response "$CMD" "$RES"
+
+# error on `list` - secret owned by a different user 
+echo -e "$PREFIX listing a secret owned by a different user"
+
+CMD="hzn secretsmanager secret list -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/e2edevadmin/test-password"
+echo -e "$CMD"
+$($CMD)
+if [ $? -eq 0 ]; then 
+  echo -e "\nERROR: shouldn't be able to list a secret owned by a different user"
+  exit 1
+fi 
+
+# error on `remove` - secret owned by a different user
+echo -e "$PREFIX removing a secret owned by a different user"
+
+CMD="hzn secretsmanager secret remove -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/e2edevadmin/test-password" 
+echo -e "$CMD"
+$($CMD)
+if [ $? -eq 0 ]; then 
+  echo -e "\nERROR: shouldn't be able to remove a secret owned by a different user"
+  exit 1
+fi 
+
+# error on `remove` - secret doesn't exist at the org level
+echo -e "$PREFIX removing a secret that doesn't exist at the org level"
+
+CMD="hzn secretsmanager secret remove -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} fake-password"
+echo -e "$CMD"
+$($CMD)
+if [ $? -eq 0 ]; then 
+  echo -e "\nERROR: shouldn't be able to remove a secret that doesn't exist"
+  exit 1
+fi 
+
+# error on `remove` - secret doesn't exist at the user level
+echo -e "$PREFIX removing a secret that doesn't exist at the user level"
+
+CMD="hzn secretsmanager secret remove -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin/fake-password"
+echo -e "$CMD"
+$($CMD)
+if [ $? -eq 0 ]; then 
+  echo -e "\nERROR: shouldn't be able to remove a secret that doesn't exist"
+  exit 1
+fi 
+
+# error on `add` - secret owned by a different user 
+echo -e "$PREFIX adding a secret owned by a different user"
+
+CMD="hzn secretsmanager secret add --secretKey password -d password456 -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/e2edevadmin/fake-password"
+echo -e "$CMD"
+$($CMD)
+if [ $? -eq 0 ]; then 
+  echo -e "\nERROR: shouldn't be able to remove a secret owned by a different user"
+  exit 1
+fi 
+
+# ----------------------------
+# ----- CLEANUP -----
+# ----------------------------
+echo -e "$PREFIX starting cleanup"
+
+# remove secrets
+echo -e "$PREFIX removing user secrets"
+CMD="hzn secretsmanager secret remove -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin/test-password"
+RES=$($CMD)
+print_command_and_response "$CMD" "$RES"
+
+CMD="hzn secretsmanager secret remove -o ${E2EDEV_ORG} -u ${E2EDEV_ADMIN_AUTH} user/e2edevadmin/test-password"
+RES=$($CMD)
+print_command_and_response "$CMD" "$RES"
+
+echo -e "$PREFIX complete test"
+
+
+


### PR DESCRIPTION
- Implemented `hzn secretsmanager secret list/add/remove` 
- Changed `test/gov/setup_secrets.sh` to use the CLI instead of the API
- Testing script `test/gov/hzn_secretsmanager.sh`
- Vault plugin returns a 404 instead of a 204 on a DELETE to a secret that doesn't exist 
- Vault plugin filters out the `user/` and empty secret directories when listing org secrets