### PR TITLE
Issue 2609 - Optimization: Make sure all patterns/policies are search…

### DIFF
--- a/exchange/pattern.go
+++ b/exchange/pattern.go
@@ -394,6 +394,7 @@ func ConvertCommon(p *Pattern, patternId string, dv DataVerification, nodeh Node
 // Structs and types for working with pattern based exchange searches
 type SearchExchangePatternRequest struct {
 	ServiceURL   string   `json:"serviceUrl,omitempty"`
+	Arch         string   `json:"arch,omitempty"`
 	NodeOrgIds   []string `json:"nodeOrgids,omitempty"`
 	SecondsStale int      `json:"secondsStale"`
 	NumEntries   int      `json:"numEntries"`


### PR DESCRIPTION
Keep map in NodeSearch of patterns/policies completely searched. This allows us to iterate through all policies and patterns in search before repeating search of patterns/policies already searched. This improves agreement times for scenario where hundreds or thousands of agents register with node policies that match multiple Deployment Policies

Signed-off-by: Doug Larson <larsond@us.ibm.com>