### PR TITLE
Issue 2613 - hzn agbot agreement list does not list long details when given agreement id

### DIFF
--- a/cli/agreementbot/agreement.go
+++ b/cli/agreementbot/agreement.go
@@ -97,27 +97,44 @@ func AgreementList(archivedAgreements bool, agreement string) {
 
 	apiAgreements := getAgreements(archivedAgreements)
 
-	// Go thru the apiAgreements and convert into our output struct and then print
-	if !archivedAgreements {
-		agreements := make([]ActiveAgreement, len(apiAgreements))
+	if agreement != "" {
+		// Look for our agreement id. This works for either active or archived
 		for i := range apiAgreements {
-			agreements[i] = *NewActiveAgreement(apiAgreements[i])
+			if agreement == apiAgreements[i].CurrentAgreementId {
+				// Found it
+				jsonBytes, err := json.MarshalIndent(apiAgreements[i], "", cliutils.JSON_INDENT)
+				if err != nil {
+					cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to marshal agreement with index %d: %v", i, err))
+				}
+				fmt.Printf("%s\n", jsonBytes)
+				return
+			}
 		}
-		jsonBytes, err := json.MarshalIndent(agreements, "", cliutils.JSON_INDENT)
-		if err != nil {
-			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to marshal 'agreement list' output: %v", err))
-		}
-		fmt.Printf("%s\n", jsonBytes)
+		// Did not find it
+		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("agreement id %s not found", agreement))
 	} else {
-		agreements := make([]ArchivedAgreement, len(apiAgreements))
-		for i := range apiAgreements {
-			agreements[i] = *NewArchivedAgreement(apiAgreements[i])
+		// Go thru the apiAgreements and convert into our output struct and then print
+		if !archivedAgreements {
+			agreements := make([]ActiveAgreement, len(apiAgreements))
+			for i := range apiAgreements {
+				agreements[i] = *NewActiveAgreement(apiAgreements[i])
+			}
+			jsonBytes, err := json.MarshalIndent(agreements, "", cliutils.JSON_INDENT)
+			if err != nil {
+				cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to marshal 'agreement list' output: %v", err))
+			}
+			fmt.Printf("%s\n", jsonBytes)
+		} else {
+			agreements := make([]ArchivedAgreement, len(apiAgreements))
+			for i := range apiAgreements {
+				agreements[i] = *NewArchivedAgreement(apiAgreements[i])
+			}
+			jsonBytes, err := json.MarshalIndent(agreements, "", cliutils.JSON_INDENT)
+			if err != nil {
+				cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to marshal 'agreement list' output: %v", err))
+			}
+			fmt.Printf("%s\n", jsonBytes)
 		}
-		jsonBytes, err := json.MarshalIndent(agreements, "", cliutils.JSON_INDENT)
-		if err != nil {
-			cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to marshal 'agreement list' output: %v", err))
-		}
-		fmt.Printf("%s\n", jsonBytes)
 	}
 }
 

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -135,7 +135,7 @@ Environment Variables:
 	agbotCancelAgreementId := agbotAgreementCancelCmd.Arg("agreement", msgPrinter.Sprintf("The active agreement to cancel.")).String()
 	agbotAgreementListCmd := agbotAgreementCmd.Command("list | ls", msgPrinter.Sprintf("List the active or archived agreements this Horizon agreement bot has with edge nodes.")).Alias("ls").Alias("list")
 	agbotlistArchivedAgreements := agbotAgreementListCmd.Flag("archived", msgPrinter.Sprintf("List archived agreements instead of the active agreements.")).Short('r').Bool()
-	agbotAgreement := agbotAgreementListCmd.Arg("agreement", msgPrinter.Sprintf("List just this one agreement.")).String()
+	agbotAgreement := agbotAgreementListCmd.Arg("agreement-id", msgPrinter.Sprintf("Show the details of this active or archived agreement.")).String()
 
 	agbotCacheCmd := agbotCmd.Command("cache", msgPrinter.Sprintf("Manage cached agbot-serving organizations, patterns, and deployment policies."))
 	agbotCacheDeployPol := agbotCacheCmd.Command("deploymentpol | dep", msgPrinter.Sprintf("List served deployment policies cached in the agbot.")).Alias("dep").Alias("deploymentpol")


### PR DESCRIPTION
Signed-off-by: polber <jeff@thekinards.com>

`hzn agbot agreement list [<agreement>]` is updated to use the given agreement id to filter for requested agreement and list details