### PR TITLE
Issue 2612 - hzn secretsmanager secret read command that allows authenticated users to see secret details

### DIFF
--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -852,7 +852,7 @@ func (b *BaseAgreementWorker) ValidateAndExtractSecrets(consumerPolicy *policy.P
 				}
 
 				// Call the secret manager plugin to get the secret details.
-				details, err := b.secretsMgr.GetSecretDetails(exchange.GetOrg(deviceId), secretUser, shortSecretName)
+				details, err := b.secretsMgr.GetSecretDetails(b.GetExchangeId(), b.GetExchangeToken(), exchange.GetOrg(deviceId), secretUser, shortSecretName)
 
 				if err != nil {
 					glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("error retrieving secret %v for policy %v, service %v/%v %v, error: %v", secretName, consumerPolicy.Header.Name, binding.ServiceOrgid, binding.ServiceUrl, binding.ServiceVersionRange, err)))

--- a/agreementbot/governance.go
+++ b/agreementbot/governance.go
@@ -251,7 +251,7 @@ func (w *AgreementBotWorker) GovernAgreements() int {
 											continue
 										}
 
-										details, err := w.secretProvider.GetSecretDetails(ag.Org, secretUser, secretName)
+										details, err := w.secretProvider.GetSecretDetails(w.GetExchangeId(), w.GetExchangeToken(), ag.Org, secretUser, secretName)
 										if err != nil {
 											glog.Errorf(logString(fmt.Sprintf("error retrieving secret %v for policy %v, error: %v", secretName, ag.PolicyName, err)))
 											continue

--- a/agreementbot/secrets/secrets.go
+++ b/agreementbot/secrets/secrets.go
@@ -31,7 +31,7 @@ type AgbotSecrets interface {
 
 	// This function assumes that the plugin maintains an authentication to the secret manager that it can use
 	// when it doesnt need to call APIs with user creds. The creds used instead have the ability to READ secrets.
-	GetSecretDetails(org, secretUser, secretName string) (SecretDetails, error)
+	GetSecretDetails(user, token, org, secretUser, secretName string) (SecretDetails, error)
 
 	// This function returns the secret manager's metadata about a given secret.
 	GetSecretMetadata(secretOrg, secretUser, secretName string) (SecretMetadata, error)

--- a/cli/cliutils/cliutils.go
+++ b/cli/cliutils/cliutils.go
@@ -876,6 +876,71 @@ func AgbotGet(urlSuffix, credentials string, goodHttpCodes []int, structure inte
 	return httpCode
 }
 
+// Runs a LIST to the agbot secure API and fills in the specified json structure. if the structure is just a string, fill in the raw json.
+// If the list of goodHttpCodes is non-empty and none match the actual http code, it will exit with an error; otherwise, the actual code is returned
+func AgbotList(urlSuffix, credentials string, goodHttpCodes []int, structure interface{}) (httpCode int) {
+
+	// get message printer
+	msgPrinter := i18n.GetMessagePrinter()
+
+	// check the agbot url
+	agbot_url := GetAgbotSecureAPIUrlBase()
+	if agbot_url == "" {
+		Fatal(HTTP_ERROR, msgPrinter.Sprintf("HZN_AGBOT_URL is not defined"))
+	}
+
+	// query the agbot secure api
+	url := agbot_url + "/" + urlSuffix
+	apiMsg := "LIST " + url
+
+	Verbose(apiMsg)
+
+	httpClient := GetHTTPClient(config.HTTPRequestTimeoutS)
+
+	resp := InvokeRestApi(httpClient, "LIST", url, credentials, nil, "Agbot", apiMsg)
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	respBody := io.Reader(resp.Body)
+	bodyBytes, err := ioutil.ReadAll(respBody)
+	if err != nil {
+		Fatal(HTTP_ERROR, msgPrinter.Sprintf("failed to read body response from %s: %v", apiMsg, err))
+	}
+	httpCode = resp.StatusCode
+	Verbose(msgPrinter.Sprintf("HTTP code: %d", httpCode))
+	if !isGoodCode(httpCode, goodHttpCodes) {
+		Fatal(HTTP_ERROR, msgPrinter.Sprintf("bad HTTP code %d from %s, output: %s", httpCode, apiMsg, string(bodyBytes)))
+	}
+
+	if len(bodyBytes) > 0 && structure != nil { // the DP front-end of exchange will return nothing when auth problem
+		switch s := structure.(type) {
+		case *[]byte:
+			// This is the signal that they want the raw body back
+			*s = bodyBytes
+		case *string:
+			// If the structure to fill in is just a string, unmarshal/remarshal it to get it in json indented form, and then return as a string
+			//todo: this gets it in json indented form, but also returns the fields in random order (because they were interpreted as a map)
+			var jsonStruct interface{}
+			err = json.Unmarshal(bodyBytes, &jsonStruct)
+			if err != nil {
+				Fatal(JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to unmarshal exchange body response from %s: %v", apiMsg, err))
+			}
+			jsonBytes, err := json.MarshalIndent(jsonStruct, "", JSON_INDENT)
+			if err != nil {
+				Fatal(JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to marshal exchange output from %s: %v", apiMsg, err))
+			}
+			*s = string(jsonBytes)
+		default:
+			err = json.Unmarshal(bodyBytes, structure)
+			if err != nil {
+				Fatal(JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to unmarshal exchange body response from %s: %v", apiMsg, err))
+			}
+		}
+	}
+	return
+}
+
 // Runs a PUT, POST, or PATCH to the agbot secure API to create or update a resource. If body is a string, it will be given to the exhcnage
 // as json. Otherwise, the struct will be marshaled to json.
 // If the list of goodHttpCodes is non-empty and none match the actual http code, it will exit with an error; otherwise, the actual code is returned

--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -670,12 +670,12 @@ Environment Variables:
 	utilVerifyPubKeyFile := utilVerifyCmd.Flag("public-key-file", msgPrinter.Sprintf("The path of public key file (that corresponds to the private key that was used to sign) to verify the signature of stdin.")).Short('K').Required().ExistingFile()
 	utilVerifySig := utilVerifyCmd.Flag("signature", msgPrinter.Sprintf("The supposed signature of stdin.")).Short('s').Required().String()
 
-	smCmd := app.Command("secretsmanager | sm", msgPrinter.Sprintf("List and manage secrets in the secrets manager. NOTE: You must authenticate as an administrator to list secrets available to the entire organization. This CLI does not read and pull secret details; to do so, you must authenticate as an administrator and use the secrets manager CLI.")).Alias("sm").Alias("secretsmanager")
+	smCmd := app.Command("secretsmanager | sm", msgPrinter.Sprintf("List and manage secrets in the secrets manager. NOTE: You must authenticate as an administrator to list secrets available to the entire organization.")).Alias("sm").Alias("secretsmanager")
 	smOrg := smCmd.Flag("org", msgPrinter.Sprintf("The Horizon organization ID. If not specified, HZN_ORG_ID will be used as a default.")).Short('o').String()
 	smUserPw := smCmd.Flag("user-pw", msgPrinter.Sprintf("Horizon Exchange credentials to query secrets manager resources. The default is HZN_EXCHANGE_USER_AUTH environment variable. If you don't prepend it with the user's org, it will automatically be prepended with the value of the HZN_ORG_ID environment variable.")).Short('u').PlaceHolder("USER:PW").String()
 	smSecretCmd := smCmd.Command("secret", msgPrinter.Sprintf("List and manage secrets in the secrets manager."))
 	smSecretListCmd := smSecretCmd.Command("list | ls", msgPrinter.Sprintf("Display the names of the secrets in the secrets manager.")).Alias("ls").Alias("list")
-	smSecretListName := smSecretListCmd.Arg("secretName", msgPrinter.Sprintf("List just this one secret. Returns a boolean indicating the existence of the secret. This is the name of the secret used in the secrets manager.")).String()
+	smSecretListName := smSecretListCmd.Arg("secretName", msgPrinter.Sprintf("List just this one secret. Returns a boolean indicating the existence of the secret. This is the name of the secret used in the secrets manager. If the secret does not exist, returns with exit code 1.")).String()
 	smSecretAddCmd := smSecretCmd.Command("add", msgPrinter.Sprintf("Add a secret to the secrets manager."))
 	smSecretAddName := smSecretAddCmd.Arg("secretName", msgPrinter.Sprintf("The name of the secret. It must be unique within your organization. This name is used in deployment policies and patterns to bind this secret to a secret name in a service definition.")).Required().String()
 	smSecretAddFile := smSecretAddCmd.Flag("secretFile", msgPrinter.Sprintf("Filepath to a file containing the secret details. Mutually exclusive with --secretDetail. Specify -f- to read from stdin.")).Short('f').String()
@@ -684,6 +684,8 @@ Environment Variables:
 	smSecretAddOverwrite := smSecretAddCmd.Flag("overwrite", msgPrinter.Sprintf("Overwrite the existing secret if it exists in the secrets manager. It will skip the 'do you want to overwrite' prompt.")).Short('O').Bool()
 	smSecretRemoveCmd := smSecretCmd.Command("remove | rm", msgPrinter.Sprintf("Remove a secret in the secrets manager.")).Alias("rm").Alias("remove")
 	smSecretRemoveName := smSecretRemoveCmd.Arg("secretName", msgPrinter.Sprintf("The name of the secret to be removed from the secrets manager.")).Required().String()
+	smSecretReadCmd := smSecretCmd.Command("read", msgPrinter.Sprintf("Read the details of a secret stored in the secrets manager. This consists of the key and value pair provided on secret creation."))
+	smSecretReadName := smSecretReadCmd.Arg("secretName", msgPrinter.Sprintf("The name of the secret to read in the secrets manager.")).Required().String()
 
 	versionCmd := app.Command("version", msgPrinter.Sprintf("Show the Horizon version.")) // using a cmd for this instead of --version flag, because kingpin takes over the latter and can't get version only when it is needed
 
@@ -1163,5 +1165,7 @@ Environment Variables:
 		secret_manager.SecretAdd(*smOrg, *smUserPw, *smSecretAddName, *smSecretAddFile, *smSecretAddKey, *smSecretAddDetail, *smSecretAddOverwrite)
 	case smSecretRemoveCmd.FullCommand():
 		secret_manager.SecretRemove(*smOrg, *smUserPw, *smSecretRemoveName)
+	case smSecretReadCmd.FullCommand():
+		secret_manager.SecretRead(*smOrg, *smUserPw, *smSecretReadName)
 	}
 }

--- a/exchange/secret.go
+++ b/exchange/secret.go
@@ -28,7 +28,7 @@ func VaultSecretExists(ec ExchangeContext, agbotURL string, org string, userName
 	retryCount := ec.GetHTTPFactory().RetryCount
 	retryInterval := ec.GetHTTPFactory().GetRetryInterval()
 	for {
-		if err, tpErr := InvokeExchange(ec.GetHTTPFactory().NewHTTPClient(nil), "GET", url, ec.GetExchangeId(), ec.GetExchangeToken(), nil, &resp); err != nil {
+		if err, tpErr := InvokeExchange(ec.GetHTTPFactory().NewHTTPClient(nil), "LIST", url, ec.GetExchangeId(), ec.GetExchangeToken(), nil, &resp); err != nil {
 			glog.Errorf(rpclogString(fmt.Sprintf(err.Error())))
 			return false, err
 		} else if tpErr != nil {

--- a/test/gov/agbot_apitest.sh
+++ b/test/gov/agbot_apitest.sh
@@ -525,14 +525,14 @@ LIST_ORG_SECRETS="org/${TEST_VAULT_SECRET_ORG}/secrets"
 CREATE_ORG_SECRETS="org/${TEST_VAULT_SECRET_ORG}/secrets/secret1"
 DELETE_ORG_SECRETS="org/${TEST_VAULT_SECRET_ORG}/secrets/secret1"
 
-echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} GET"
-CMD="curl -sLX GET -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}"
+echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} LIST"
+CMD="curl -sLX LIST -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}"
 echo "$CMD"
 RES=$($CMD)
 results "$RES" "200" "exists" "false"
 
-echo -e "\n${PREFIX} test ${LIST_ORG_SECRETS} GET"
-CMD="curl -sLX GET -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRETS}"
+echo -e "\n${PREFIX} test ${LIST_ORG_SECRETS} LIST"
+CMD="curl -sLX LIST -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRETS}"
 echo "$CMD"
 RES=$($CMD)
 results "$RES" "200" "${TEST_VAULT_SECRET_NAME}"
@@ -543,14 +543,14 @@ echo "$CMD"
 RES=$(curl -sLX POST -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} -d "${create_secret}" ${AGBOT_SAPI_URL}/${CREATE_ORG_SECRETS})
 results "$RES" "201" ""
 
-echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} GET"
-CMD="curl -sLX GET -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}1"
+echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} LIST"
+CMD="curl -sLX LIST -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}1"
 echo "$CMD"
 RES=$($CMD)
 results "$RES" "200" "exists" "true"
 
-echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} GET"
-CMD="curl -sLX GET -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}_wrong"
+echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} LIST"
+CMD="curl -sLX LIST -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}_wrong"
 echo "$CMD"
 RES=$($CMD)
 results "$RES" "200" "false"
@@ -561,14 +561,14 @@ echo "$CMD"
 RES=$($CMD)
 results "$RES" "401" "Failed to authenticate"
 
-echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} GET with invalid secret and secret org"
-CMD="curl -sLX GET -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}_wrong"
+echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} LIST with invalid secret and secret org"
+CMD="curl -sLX LIST -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}_wrong"
 echo "$CMD"
 RES=$($CMD)
 results "$RES" "200" "exists" "false"
 
-echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} GET with invalid org"
-CMD="curl -sLX GET -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/org/${TEST_VAULT_SECRET_ORG}_wrong/secrets"
+echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} LIST with invalid org"
+CMD="curl -sLX LIST -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/org/${TEST_VAULT_SECRET_ORG}_wrong/secrets"
 echo "$CMD"
 RES=$($CMD)
 results "$RES" "403" ""
@@ -579,8 +579,8 @@ echo "$CMD"
 RES=$($CMD)
 results "$RES" "204" ""
 
-echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} GET with deleted secret"
-CMD="curl -sLX GET -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}1"
+echo -e "\n${PREFIX} test ${LIST_ORG_SECRET} LIST with deleted secret"
+CMD="curl -sLX LIST -w %{http_code} ${CERT_VAR} -u ${USERDEV_ADMIN_AUTH} ${AGBOT_SAPI_URL}/${LIST_ORG_SECRET}1"
 echo "$CMD"
 RES=$($CMD)
 results "$RES" "200" "exists" "false"


### PR DESCRIPTION
Signed-off-by: Isabel Gan <Isabel.Gan@ibm.com>

API changes: `LIST` method supported for listing multiple and individual secrets (for an individual secret, will return `{ exists: true/false }`. `GET` is supported only for individual secrets, and will return the secret details if the user is allowed to read the secret. 