### PR TITLE
Issue 2651 - Error messages for the 'hzn secretsmanager' commands need to be cleaned up

### DIFF
--- a/agreementbot/secrets/plugin_errors.go
+++ b/agreementbot/secrets/plugin_errors.go
@@ -1,0 +1,187 @@
+package secrets
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/open-horizon/anax/cli/cliutils"
+)
+
+// ----- ERROR WRAPPER -----
+
+// overall SecretsProviderError structure that wraps the below errors; every error coming out of the secrets manager (which will be one
+// of the defined errors below) can be casted to this
+type SecretsProviderError struct {
+	// record the http response code and response of the secrets manager
+	ResponseCode int
+	Response     string
+
+	// implement error interface
+	Err error
+}
+
+func (e *SecretsProviderError) Error() string {
+	return e.Error()
+}
+
+// ----- HELPER FUNCTION -----
+
+// takes one of the errors below and wraps it into a SecretsProviderError
+// that records the response code and secrets provider response in addition to the error itself
+func WrapSecretsError(err error) *SecretsProviderError {
+
+	// if no error, ignore
+	if err == nil {
+		return nil
+	}
+
+	// case on the type of error
+	switch e := err.(type) {
+	case *PermissionDenied:
+		return &SecretsProviderError{ResponseCode: 403, Response: RespToString(e.Response), Err: err}
+	case *Unauthenticated:
+		return &SecretsProviderError{ResponseCode: 401, Response: e.LoginError.Error(), Err: err}
+	case *SecretsProviderUnavailable:
+		return &SecretsProviderError{ResponseCode: 503, Response: e.ProviderError.Error(), Err: err}
+	case *InvalidResponse:
+		// find the secrets provider response in the struct
+		var errString string
+		if e.ReadError != nil {
+			errString = e.ReadError.Error()
+		} else {
+			errString = string(e.Response)
+		}
+
+		return &SecretsProviderError{ResponseCode: 500, Response: errString, Err: err}
+	case *BadRequest:
+		return &SecretsProviderError{ResponseCode: e.ResponseCode, Response: RespToString(e.Response), Err: err}
+	case *NoSecretFound:
+		return &SecretsProviderError{ResponseCode: 404, Response: RespToString(e.Response), Err: err}
+	case *Unknown:
+		return &SecretsProviderError{ResponseCode: e.ResponseCode, Response: RespToString(e.Response), Err: err}
+	default:
+		return nil
+	}
+}
+
+// ----- ERRORS -----
+
+// PermissionDenied - 403
+// the user provided correct credentials but does not have permission to access the resource
+type PermissionDenied struct {
+	Response     map[string][]string
+	HttpMethod   string
+	SecretPath   string
+	ExchangeUser string
+}
+
+func (e *PermissionDenied) Error() string {
+	return fmt.Sprintf("Permission denied, user \"%s\" does not have %s access to %s.", e.ExchangeUser, e.HttpMethod, e.SecretPath)
+}
+
+// Unauthenticated - 401
+// the user provided wrong credentials, was not able to authenticate with the exchange
+type Unauthenticated struct {
+	LoginError   error
+	ExchangeUser string
+}
+
+func (e *Unauthenticated) Error() string {
+	return fmt.Sprintf("Unable to authenticate user \"%s\" with exchange: \"%s\".", e.ExchangeUser, e.LoginError.Error())
+}
+
+// SecretsProviderUnavailable - 503
+// the secrets manager service is unavailable
+type SecretsProviderUnavailable struct {
+	ProviderError error
+}
+
+func (e *SecretsProviderUnavailable) Error() string {
+	return fmt.Sprintf("Secrets manager service unavailable: \"%s\"", e.ProviderError.Error())
+}
+
+// InvalidResponse - 500
+// the plugin was unable to read or parse the secret manager's response
+type InvalidResponse struct {
+	ReadError  error
+	ParseError error
+	Response   []byte
+	HttpMethod string
+	SecretPath string
+}
+
+func (e *InvalidResponse) Error() string {
+	if e.ReadError != nil {
+		return fmt.Sprintf("Unable to read the secrets manager response to \"%s %s\": \"%s\"", e.HttpMethod, e.SecretPath, e.ReadError.Error())
+	} else {
+		// e.ParseError != nil
+		resp := fmt.Sprintf("Unable to parse the secrets manager response to \"%s %s\": \"%s\"", e.HttpMethod, e.SecretPath, e.ParseError.Error())
+		resp += fmt.Sprintf("\nResponse body: \"%s\"", string(e.Response))
+		return resp
+	}
+}
+
+// BadRequest - 400, 405
+// the secrets manager cannot handle the request because it is malformed/not handled
+type BadRequest struct {
+	ResponseCode int
+	Response     map[string][]string
+	HttpMethod   string
+	SecretPath   string
+	RequestBody  *SecretDetails
+}
+
+func (e *BadRequest) Error() string {
+	if e.ResponseCode == 400 {
+		resp := fmt.Sprintf("Bad request: \"%s %s\"", e.HttpMethod, e.SecretPath)
+		if e.RequestBody != nil {
+			jsonBytes, err := json.MarshalIndent(e.RequestBody, "", cliutils.JSON_INDENT)
+			if err == nil {
+				resp += fmt.Sprintf("\nRequest body: \"%s\"", jsonBytes)
+			}
+		}
+		return resp
+	} else {
+		// e.ResponseCode == 405
+		return fmt.Sprintf("Bad request, HTTP method not supported: \"%s %s\"", e.HttpMethod, e.SecretPath)
+	}
+}
+
+// NoSecretFound - 404
+// when listing secrets, no secrets were found, or when requesting a specific secret, the secret was not found
+type NoSecretFound struct {
+	Response   map[string][]string
+	SecretPath string
+}
+
+func (e *NoSecretFound) Error() string {
+	return fmt.Sprintf("No secret(s) found at %s.", e.SecretPath)
+}
+
+// Unknown
+// error returned by the secrets manager is unexpected and unknown
+type Unknown struct {
+	Response     map[string][]string
+	ResponseCode int
+	HttpMethod   string
+	SecretPath   string
+}
+
+func (e *Unknown) Error() string {
+	// format the secrets manager response
+	response := RespToString(e.Response)
+
+	// return the error message
+	return fmt.Sprintf("Unknown error occurred. Request: \"%s %s \"\nResponse Code: %d\nSecrets manager response: \"%s\"", e.HttpMethod, e.SecretPath, e.ResponseCode, response)
+}
+
+// ----- HELPER FUNCTIONS -----
+func RespToString(response map[string][]string) string {
+	jsonBytes, err := json.MarshalIndent(response, "", cliutils.JSON_INDENT)
+	var respString string
+	if err != nil {
+		respString = fmt.Sprintf("%v", response)
+	} else {
+		respString = fmt.Sprintf("%s", jsonBytes)
+	}
+	return respString
+}

--- a/agreementbot/secrets/vault/vault.go
+++ b/agreementbot/secrets/vault/vault.go
@@ -57,7 +57,7 @@ func (vs *AgbotVaultSecrets) listSecret(user, token, org, name, url string) erro
 	// Login the user to ensure that the vault ACLs can take effect
 	userVaultToken, err := vs.loginUser(user, token, org)
 	if err != nil {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to login user %s, error: %v", user, err), Details: "", RespCode: http.StatusUnauthorized}
+		return &secrets.Unauthenticated{LoginError: err, ExchangeUser: user}
 	}
 
 	// invoke the vault to get the secret details
@@ -67,19 +67,37 @@ func (vs *AgbotVaultSecrets) listSecret(user, token, org, name, url string) erro
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to list %s secret %s, error: %v", org, name, err), Details: "", RespCode: http.StatusServiceUnavailable}
+		return &secrets.SecretsProviderUnavailable{ProviderError: err}
 	}
 
 	// parse the vault response
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to read secret %s from %s, error: %v", name, org, err), Details: "", RespCode: http.StatusInternalServerError}
-	} else if httpCode := resp.StatusCode; httpCode == http.StatusNotFound {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Secret does not exist."), Details: "", RespCode: http.StatusNotFound}
-	} else if httpCode == http.StatusForbidden {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Secret not available with the specified credentials. Vault response %s", string(respBytes)), Details: "", RespCode: http.StatusForbidden}
-	} else if httpCode != http.StatusOK {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to find secret %s for org %s, HTTP status code: %v", name, org, httpCode), Details: "", RespCode: httpCode}
+		return &secrets.InvalidResponse{ReadError: err, HttpMethod: http.MethodGet, SecretPath: url}
+	} else {
+		glog.V(5).Infof(vaultPluginLogString(fmt.Sprintf("HTTP: %v, listing %s secret response: %v", resp.StatusCode, org, string(respBytes))))
+	}
+
+	// check for error
+	httpCode := resp.StatusCode
+	if httpCode != http.StatusOK {
+		// parse the vault response
+		var vaultResponse map[string][]string
+		perr := json.Unmarshal(respBytes, &vaultResponse)
+		if perr != nil {
+			return &secrets.InvalidResponse{ParseError: perr, Response: respBytes, HttpMethod: http.MethodGet, SecretPath: url}
+		}
+
+		// check the response code
+		if httpCode := resp.StatusCode; httpCode == http.StatusNotFound {
+			return &secrets.NoSecretFound{Response: vaultResponse, SecretPath: url}
+		} else if httpCode == http.StatusForbidden {
+			return &secrets.PermissionDenied{Response: vaultResponse, HttpMethod: http.MethodGet, SecretPath: url, ExchangeUser: user}
+		} else if httpCode == http.StatusBadRequest {
+			return &secrets.BadRequest{Response: vaultResponse, HttpMethod: http.MethodGet, SecretPath: url}
+		} else {
+			return &secrets.Unknown{Response: vaultResponse, ResponseCode: httpCode, HttpMethod: http.MethodGet, SecretPath: url}
+		}
 	}
 
 	glog.V(3).Infof(vaultPluginLogString(fmt.Sprintf("done listing %s.", name)))
@@ -105,11 +123,11 @@ func (vs *AgbotVaultSecrets) ListOrgUserSecrets(user, token, org, path string) (
 	url := fmt.Sprintf("%s/v1/openhorizon/metadata/%s"+cliutils.AddSlash(path), vs.cfg.GetAgbotVaultURL(), org)
 	secrets, err := vs.listSecrets(user, token, org, url, path)
 	if err != nil {
-		return nil, err 
-	} 
+		return nil, err
+	}
 
-	// trim the user/<user> prefix from the names 
-	var secretList []string 
+	// trim the user/<user> prefix from the names
+	var secretList []string
 	for _, secret := range secrets {
 		secretList = append(secretList, strings.TrimPrefix(secret, path+"/"))
 	}
@@ -121,14 +139,14 @@ func (vs *AgbotVaultSecrets) ListOrgUserSecrets(user, token, org, path string) (
 // of the names in the input queue ("" if top-level vault directory)
 func (vs *AgbotVaultSecrets) gatherSecretNames(user, token, org, path string, queue []string) []string {
 
-	var secretNames []string 
+	var secretNames []string
 
 	// go through the queue and check for directories and names
 	for _, secret := range queue {
 		newPath := path + secret
-		if secret[len(secret) - 1] == '/' {
-			// secret directory 
-			secretList, err := vs.ListOrgSecrets(user, token, org, newPath[:len(newPath) - 1])
+		if secret[len(secret)-1] == '/' {
+			// secret directory
+			secretList, err := vs.ListOrgSecrets(user, token, org, newPath[:len(newPath)-1])
 			if err == nil {
 				secretNames = append(secretNames, secretList...)
 			}
@@ -149,38 +167,55 @@ func (vs *AgbotVaultSecrets) listSecrets(user, token, org, url, path string) ([]
 	// Login the user to ensure that the vault ACLs can take effect
 	userVaultToken, err := vs.loginUser(user, token, org)
 	if err != nil {
-		return nil, secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to login user %s, error: %v", user, err), Details: "", RespCode: http.StatusUnauthorized}
+		return nil, &secrets.Unauthenticated{LoginError: err, ExchangeUser: user}
 	}
 
+	// invoke the vault to get the secret list
 	resp, err := vs.invokeVaultWithRetry(userVaultToken, url, "LIST", nil)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return nil, secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to list %s secrets, error: %v", org, err), Details: "", RespCode: http.StatusServiceUnavailable}
+		return nil, &secrets.SecretsProviderUnavailable{ProviderError: err}
 	}
 
+	// parse the vault response
 	respBytes, err := ioutil.ReadAll(resp.Body)
-	if respBytes != nil {
+	if err != nil {
+		return nil, &secrets.InvalidResponse{ReadError: err, HttpMethod: "LIST", SecretPath: url}
+	} else {
 		glog.V(5).Infof(vaultPluginLogString(fmt.Sprintf("HTTP: %v, listing %s secrets response: %v", resp.StatusCode, org, string(respBytes))))
 	}
 
-	if err != nil {
-		return nil, secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to read list %s secrets response, error: %v", org, err), Details: "", RespCode: http.StatusInternalServerError}
-	} else if httpCode := resp.StatusCode; httpCode == http.StatusNotFound {
-		return nil, secrets.ErrorResponse{Msg: fmt.Sprintf("No secrets for %s.", org), Details: "", RespCode: http.StatusNotFound}
-	} else if httpCode == http.StatusForbidden {
-		return nil, secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to list secrets for %s. Vault response %s ", org, string(respBytes)), Details: string(respBytes), RespCode: http.StatusForbidden}
-	} else if httpCode != http.StatusOK {
-		return nil, secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to list secrets for %s, HTTP status code: %v", org, httpCode), Details: "", RespCode: httpCode}
+	// check for error
+	httpCode := resp.StatusCode
+	if httpCode != http.StatusOK {
+		// parse the vault response
+		var vaultResponse map[string][]string
+		perr := json.Unmarshal(respBytes, &vaultResponse)
+		if perr != nil {
+			return nil, &secrets.InvalidResponse{ParseError: perr, Response: respBytes, HttpMethod: "LIST", SecretPath: url}
+		}
+
+		// check the response code
+		if httpCode := resp.StatusCode; httpCode == http.StatusNotFound {
+			return nil, &secrets.NoSecretFound{Response: vaultResponse, SecretPath: url}
+		} else if httpCode == http.StatusForbidden {
+			return nil, &secrets.PermissionDenied{Response: vaultResponse, HttpMethod: "LIST", SecretPath: url, ExchangeUser: user}
+		} else if httpCode == http.StatusBadRequest {
+			return nil, &secrets.BadRequest{Response: vaultResponse, HttpMethod: "LIST", SecretPath: url}
+		} else {
+			return nil, &secrets.Unknown{Response: vaultResponse, ResponseCode: httpCode, HttpMethod: "LIST", SecretPath: url}
+		}
 	}
 
+	// parse the vault response into the secret list
 	respMsg := ListSecretsResponse{}
 	if err := json.Unmarshal(respBytes, &respMsg); err != nil {
-		return nil, secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to parse response %v", string(respBytes)), Details: "", RespCode: http.StatusInternalServerError}
+		return nil, &secrets.InvalidResponse{ParseError: err, Response: respBytes, HttpMethod: "LIST", SecretPath: url}
 	}
 
-	// filter out user/ directory if top-level 
+	// filter out user/ directory if top-level
 	var secrets []string
 	if path == "" {
 		for _, secret := range respMsg.Data.Keys {
@@ -192,13 +227,13 @@ func (vs *AgbotVaultSecrets) listSecrets(user, token, org, url, path string) ([]
 		secrets = respMsg.Data.Keys
 	}
 
-	// gather all the multi-part secret names 
+	// gather all the multi-part secret names
 	runningPath := ""
 	if path != "" {
 		runningPath = path + "/"
 	}
 	secretList := vs.gatherSecretNames(user, token, org, runningPath, secrets)
-	
+
 	return secretList, nil
 }
 
@@ -221,9 +256,10 @@ func (vs *AgbotVaultSecrets) CreateOrgSecret(user, token, org, path string, data
 // This utility will be used to create secrets.
 func (vs *AgbotVaultSecrets) createSecret(user, token, org, vaultSecretName, url string, data secrets.SecretDetails) error {
 
+	// Login the user to ensure that the vault ACLs can take effect
 	userVaultToken, err := vs.loginUser(user, token, org)
 	if err != nil {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to login user %s, error %v", user, err), Details: "", RespCode: http.StatusUnauthorized}
+		return &secrets.Unauthenticated{LoginError: err, ExchangeUser: user}
 	}
 
 	glog.V(3).Infof(vaultPluginLogString(fmt.Sprintf("create secret %s in org %s as user %s", vaultSecretName, org, user)))
@@ -232,25 +268,43 @@ func (vs *AgbotVaultSecrets) createSecret(user, token, org, vaultSecretName, url
 		Data: data,
 	}
 
+	// invoke the vault to get the secret details
 	resp, err := vs.invokeVaultWithRetry(userVaultToken, url, http.MethodPost, body)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to create secret, error %v", err), Details: "", RespCode: http.StatusServiceUnavailable}
+		return &secrets.SecretsProviderUnavailable{ProviderError: err}
 	}
 
+	// parse the vault response
 	respBytes, err := ioutil.ReadAll(resp.Body)
-
-	if respBytes != nil {
+	if err != nil {
+		return &secrets.InvalidResponse{ReadError: err, HttpMethod: http.MethodPost, SecretPath: url}
+	} else {
 		glog.V(5).Infof(vaultPluginLogString(fmt.Sprintf("HTTP: %v, creating secret response: %v", resp.StatusCode, string(respBytes))))
 	}
 
-	if err != nil {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to read response, error: %v", err), Details: "", RespCode: http.StatusInternalServerError}
-	} else if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to create secret for %s, error %v", org, string(respBytes)), Details: "", RespCode: resp.StatusCode}
+	// check for error
+	httpCode := resp.StatusCode
+	if httpCode != http.StatusCreated && httpCode != http.StatusOK && httpCode != http.StatusNoContent {
+		// parse the vault response
+		var vaultResponse map[string][]string
+		perr := json.Unmarshal(respBytes, &vaultResponse)
+		if perr != nil {
+			return &secrets.InvalidResponse{ParseError: perr, Response: respBytes, HttpMethod: http.MethodPost, SecretPath: url}
+		}
+
+		// check the response code
+		if httpCode := resp.StatusCode; httpCode == http.StatusForbidden {
+			return &secrets.PermissionDenied{Response: vaultResponse, HttpMethod: http.MethodPost, SecretPath: url, ExchangeUser: user}
+		} else if httpCode == http.StatusBadRequest {
+			return &secrets.BadRequest{Response: vaultResponse, HttpMethod: http.MethodPost, SecretPath: url, RequestBody: &data}
+		} else {
+			return &secrets.Unknown{Response: vaultResponse, ResponseCode: httpCode, HttpMethod: http.MethodPost, SecretPath: url}
+		}
 	}
+
 	glog.V(3).Infof(vaultPluginLogString(fmt.Sprintf("done creating %s in vault.", vaultSecretName)))
 
 	return nil
@@ -275,9 +329,10 @@ func (vs *AgbotVaultSecrets) DeleteOrgSecret(user, token, org, path string) erro
 // This utility will be used to delete secrets.
 func (vs *AgbotVaultSecrets) deleteSecret(user, token, org, name, url string) error {
 
+	// Login the user to ensure that the vault ACLs can take effect
 	userVaultToken, err := vs.loginUser(user, token, org)
 	if err != nil {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to login user %s, error %v", user, err), Details: "", RespCode: http.StatusUnauthorized}
+		return &secrets.Unauthenticated{LoginError: err, ExchangeUser: user}
 	}
 
 	// check if the secret exists before deleting (if the secret doesn't exist, return 404)
@@ -286,21 +341,44 @@ func (vs *AgbotVaultSecrets) deleteSecret(user, token, org, name, url string) er
 		return listErr
 	}
 
+	// invoke the vault to remove the secret
 	glog.V(3).Infof(vaultPluginLogString(fmt.Sprintf("deleting secret %s in org %s as user %s", name, org, user)))
 	resp, err := vs.invokeVaultWithRetry(userVaultToken, url, http.MethodDelete, nil)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to delete secret, error %v", err), Details: "", RespCode: http.StatusServiceUnavailable}
+		return &secrets.SecretsProviderUnavailable{ProviderError: err}
 	}
 
+	// parse the vault response
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to read response, error: %v", err), Details: "", RespCode: http.StatusInternalServerError}
-	} else if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		return secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to delete secret for %s, error %v", org, string(respBytes)), Details: "", RespCode: resp.StatusCode}
+		return &secrets.InvalidResponse{ReadError: err, HttpMethod: http.MethodDelete, SecretPath: url}
+	} else {
+		glog.V(5).Infof(vaultPluginLogString(fmt.Sprintf("HTTP: %v, deleting secret response: %v", resp.StatusCode, string(respBytes))))
 	}
+
+	// check for error
+	httpCode := resp.StatusCode
+	if httpCode != http.StatusOK && httpCode != http.StatusNoContent {
+		// parse the vault response
+		var vaultResponse map[string][]string
+		perr := json.Unmarshal(respBytes, &vaultResponse)
+		if perr != nil {
+			return &secrets.InvalidResponse{ParseError: perr, Response: respBytes, HttpMethod: http.MethodDelete, SecretPath: url}
+		}
+
+		// check the response code
+		if httpCode := resp.StatusCode; httpCode == http.StatusForbidden {
+			return &secrets.PermissionDenied{Response: vaultResponse, HttpMethod: http.MethodDelete, SecretPath: url, ExchangeUser: user}
+		} else if httpCode == http.StatusBadRequest {
+			return &secrets.BadRequest{Response: vaultResponse, HttpMethod: http.MethodDelete, SecretPath: url}
+		} else {
+			return &secrets.Unknown{Response: vaultResponse, ResponseCode: httpCode, HttpMethod: http.MethodDelete, SecretPath: url}
+		}
+	}
+
 	glog.V(3).Infof(vaultPluginLogString(fmt.Sprintf("done deleting %s in vault.", name)))
 
 	return nil
@@ -313,28 +391,21 @@ func (vs *AgbotVaultSecrets) GetSecretDetails(user, token, org, secretUser, secr
 	res = secrets.SecretDetails{}
 	err = nil
 
+	// check the input
 	if org == "" {
-		err = secrets.ErrorResponse{Msg: "Organization name must not be an empty string", Details: "", RespCode: http.StatusBadRequest}
+		err = &secrets.BadRequest{Response: map[string][]string{"errors": {"Organization name must not be an empty string"}},
+			HttpMethod: "",
+			SecretPath: ""}
 		return
 	}
-
 	if secretName == "" {
-		err = secrets.ErrorResponse{Msg: "Secret name must not be an empty string", Details: "", RespCode: http.StatusBadRequest}
+		err = &secrets.BadRequest{Response: map[string][]string{"errors": {"Secret name must not be an empty string"}},
+			HttpMethod: "",
+			SecretPath: ""}
 		return
 	}
 
-	// check the credentials against the agbot's
-	var userVaultToken string
-	if user == vs.cfg.AgreementBot.ExchangeId && token == vs.cfg.AgreementBot.ExchangeToken {
-		userVaultToken = vs.token
-	} else {
-		userVaultToken, err = vs.loginUser(user, token, org)
-		if err != nil {
-			err = secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to login user %s, error %v", user, err), Details: "", RespCode: http.StatusUnauthorized}
-			return
-		}
-	}
-
+	// build the vault URL
 	url := fmt.Sprintf("%s/v1/openhorizon/data/%s/", vs.cfg.GetAgbotVaultURL(), org)
 	if secretUser != "" {
 		url += fmt.Sprintf("user/%s/%s", secretUser, secretName)
@@ -342,38 +413,69 @@ func (vs *AgbotVaultSecrets) GetSecretDetails(user, token, org, secretUser, secr
 		url += secretName
 	}
 
-	resp, err := vs.invokeVaultWithRetry(userVaultToken, url, http.MethodGet, nil)
+	// check the credentials against the agbot's
+	var userVaultToken string
+	var lerr error
+	if user == vs.cfg.AgreementBot.ExchangeId && token == vs.cfg.AgreementBot.ExchangeToken {
+		userVaultToken = vs.token
+	} else {
+		userVaultToken, lerr = vs.loginUser(user, token, org)
+		if lerr != nil {
+			err = &secrets.Unauthenticated{LoginError: lerr, ExchangeUser: user}
+			return
+		}
+	}
+
+	// invoke the vault to get the secret details
+	resp, verr := vs.invokeVaultWithRetry(userVaultToken, url, http.MethodGet, nil)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
-
-	if err != nil {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to read %s secret %s, error: %v", org, secretName, err), Details: "", RespCode: http.StatusServiceUnavailable}
+	if verr != nil {
+		err = &secrets.SecretsProviderUnavailable{ProviderError: verr}
 		return
 	}
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	// if respBytes != nil {
-	// 	glog.V(5).Infof(vaultPluginLogString(fmt.Sprintf("HTTP: %v, details response: %v", resp.StatusCode, string(respBytes))))
-	// }
-
-	if err != nil {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to read secret %s from %s, error: %v", secretName, org, err), Details: "", RespCode: http.StatusInternalServerError}
+	// parse the vault response
+	respBytes, rerr := ioutil.ReadAll(resp.Body)
+	if rerr != nil {
+		err = &secrets.InvalidResponse{ReadError: rerr, HttpMethod: http.MethodGet, SecretPath: url}
 		return
-	} else if httpCode := resp.StatusCode; httpCode == http.StatusNotFound {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Secret does not exist. Vault response %s", string(respBytes)), Details: "", RespCode: http.StatusNotFound}
-		return
-	} else if httpCode == http.StatusForbidden {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Secret not available with the specified credentials. Vault response %s", string(respBytes)), Details: "", RespCode: http.StatusForbidden}
-		return
-	} else if httpCode != http.StatusOK {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to find secret %s for org %s, HTTP status code: %v", secretName, org, httpCode), Details: "", RespCode: httpCode}
-		return
+	} else {
+		glog.V(5).Infof(vaultPluginLogString(fmt.Sprintf("HTTP: %v, deleting secret response: %v", resp.StatusCode, string(respBytes))))
 	}
 
+	// check for error
+	httpCode := resp.StatusCode
+	if httpCode != http.StatusOK {
+		// parse the vault response
+		var vaultResponse map[string][]string
+		perr := json.Unmarshal(respBytes, &vaultResponse)
+		if perr != nil {
+			err = &secrets.InvalidResponse{ParseError: perr, Response: respBytes, HttpMethod: http.MethodGet, SecretPath: url}
+			return
+		}
+
+		// check the response code
+		if httpCode := resp.StatusCode; httpCode == http.StatusNotFound {
+			err = &secrets.NoSecretFound{Response: vaultResponse, SecretPath: url}
+			return
+		} else if httpCode == http.StatusForbidden {
+			err = &secrets.PermissionDenied{Response: vaultResponse, HttpMethod: http.MethodGet, SecretPath: url, ExchangeUser: user}
+			return
+		} else if httpCode == http.StatusBadRequest {
+			err = &secrets.BadRequest{Response: vaultResponse, HttpMethod: http.MethodGet, SecretPath: url}
+			return
+		} else {
+			err = &secrets.Unknown{Response: vaultResponse, ResponseCode: httpCode, HttpMethod: http.MethodGet, SecretPath: url}
+			return
+		}
+	}
+
+	// parse the vault response into the secret details
 	r := GetSecretResponse{}
 	if uerr := json.Unmarshal(respBytes, &r); uerr != nil {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to parse response body %v", uerr), Details: "", RespCode: http.StatusInternalServerError}
+		err = &secrets.InvalidResponse{ParseError: uerr, Response: respBytes, HttpMethod: http.MethodGet, SecretPath: url}
 		return
 	}
 
@@ -389,16 +491,21 @@ func (vs *AgbotVaultSecrets) GetSecretMetadata(secretOrg, secretUser, secretName
 
 	glog.V(3).Infof(vaultPluginLogString(fmt.Sprintf("extract secret metadata for %s in org %s as user %s", secretName, secretOrg, secretUser)))
 
+	// check the input
 	if secretOrg == "" {
-		err = secrets.ErrorResponse{Msg: "Organization name must not be an empty string", Details: "", RespCode: http.StatusBadRequest}
+		err = &secrets.BadRequest{Response: map[string][]string{"errors": {"Organization name must not be an empty string"}},
+			HttpMethod: http.MethodGet,
+			SecretPath: ""}
 		return
 	}
-
 	if secretName == "" {
-		err = secrets.ErrorResponse{Msg: "Secret name must not be an empty string", Details: "", RespCode: http.StatusBadRequest}
+		err = &secrets.BadRequest{Response: map[string][]string{"errors": {"Secret name must not be an empty string"}},
+			HttpMethod: http.MethodGet,
+			SecretPath: ""}
 		return
 	}
 
+	// build the vault URL
 	url := fmt.Sprintf("%s/v1/openhorizon/metadata/%s/", vs.cfg.GetAgbotVaultURL(), secretOrg)
 	if secretUser != "" {
 		url += fmt.Sprintf("user/%s/%s", secretUser, secretName)
@@ -406,38 +513,55 @@ func (vs *AgbotVaultSecrets) GetSecretMetadata(secretOrg, secretUser, secretName
 		url += secretName
 	}
 
-	resp, err := vs.invokeVaultWithRetry(vs.token, url, http.MethodGet, nil)
+	// invoke the vault to get the secret metadata
+	resp, verr := vs.invokeVaultWithRetry(vs.token, url, http.MethodGet, nil)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
-
-	if err != nil {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to read %s secret %s, error: %v", secretOrg, secretName, err), Details: "", RespCode: http.StatusServiceUnavailable}
+	if verr != nil {
+		err = &secrets.SecretsProviderUnavailable{ProviderError: verr}
 		return
 	}
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	if respBytes != nil {
-		glog.V(5).Infof(vaultPluginLogString(fmt.Sprintf("HTTP: %v, metadata response: %v", resp.StatusCode, string(respBytes))))
+	// parse the vault response
+	respBytes, rerr := ioutil.ReadAll(resp.Body)
+	if rerr != nil {
+		err = &secrets.InvalidResponse{ReadError: rerr, HttpMethod: http.MethodGet, SecretPath: url}
+		return
+	} else {
+		glog.V(5).Infof(vaultPluginLogString(fmt.Sprintf("HTTP: %v, reading secret metadata response: %v", resp.StatusCode, string(respBytes))))
 	}
 
-	if err != nil {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to read secret %s from %s, error: %v", secretName, secretOrg, err), Details: "", RespCode: http.StatusInternalServerError}
-		return
-	} else if httpCode := resp.StatusCode; httpCode == http.StatusNotFound {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Secret does not exist. Vault response %s", string(respBytes)), Details: "", RespCode: http.StatusNotFound}
-		return
-	} else if httpCode == http.StatusForbidden {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Secret not available with the specified credentials. Vault response %s", string(respBytes)), Details: "", RespCode: http.StatusForbidden}
-		return
-	} else if httpCode != http.StatusOK {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to find secret %s for org %s, HTTP status code: %v", secretName, secretOrg, httpCode), Details: "", RespCode: httpCode}
-		return
+	// check for error
+	httpCode := resp.StatusCode
+	if httpCode != http.StatusOK {
+		// parse the vault response
+		var vaultResponse map[string][]string
+		perr := json.Unmarshal(respBytes, &vaultResponse)
+		if perr != nil {
+			err = &secrets.InvalidResponse{ParseError: perr, Response: respBytes, HttpMethod: http.MethodGet, SecretPath: url}
+			return
+		}
+
+		// check the response code
+		if httpCode := resp.StatusCode; httpCode == http.StatusNotFound {
+			err = &secrets.NoSecretFound{Response: vaultResponse, SecretPath: url}
+			return
+		} else if httpCode == http.StatusForbidden {
+			err = &secrets.PermissionDenied{Response: vaultResponse, HttpMethod: http.MethodGet, SecretPath: url, ExchangeUser: secretUser}
+			return
+		} else if httpCode == http.StatusBadRequest {
+			err = &secrets.BadRequest{Response: vaultResponse, HttpMethod: http.MethodGet, SecretPath: url}
+		} else {
+			err = &secrets.Unknown{Response: vaultResponse, ResponseCode: httpCode, HttpMethod: http.MethodGet, SecretPath: url}
+			return
+		}
 	}
 
+	// parse the vault response into the secret metadata
 	r := ListSecretResponse{}
 	if uerr := json.Unmarshal(respBytes, &r); uerr != nil {
-		err = secrets.ErrorResponse{Msg: fmt.Sprintf("Unable to parse response body %v", uerr), Details: "", RespCode: http.StatusInternalServerError}
+		err = &secrets.InvalidResponse{ParseError: uerr, Response: respBytes, HttpMethod: http.MethodGet, SecretPath: url}
 		return
 	}
 
@@ -466,7 +590,7 @@ func (vs *AgbotVaultSecrets) loginUser(user, token, org string) (string, error) 
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return "", errors.New(fmt.Sprintf("agbot unable to login user %s, error: %v", user, err))
+		return "", errors.New(fmt.Sprintf("agbot unable to login user %s: %v", user, err))
 	}
 
 	httpCode := resp.StatusCode
@@ -477,7 +601,7 @@ func (vs *AgbotVaultSecrets) loginUser(user, token, org string) (string, error) 
 	// Save the login token
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.New(fmt.Sprintf("unable to read login response, error: %v", err))
+		return "", errors.New(fmt.Sprintf("unable to read login response: %v", err))
 	}
 
 	respMsg := LoginResponse{}

--- a/test/gov/hzn_secretsmanager.sh
+++ b/test/gov/hzn_secretsmanager.sh
@@ -231,89 +231,78 @@ print_command_and_response "$CMD" "$RES"
 echo -e "$PREFIX listing a secret owned by a different user"
 
 CMD="hzn sm secret list -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/e2edevadmin/test-password"
-echo -e "$CMD"
-$($CMD)
-if [ $? -eq 0 ]; then 
-  echo -e "\nERROR: shouldn't be able to list a secret owned by a different user"
-  exit 1
-fi 
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "Permission denied" "shouldn't be able to list a secret owned by a different user"
 
 # error on `remove` - secret owned by a different user
 echo -e "$PREFIX removing a secret owned by a different user"
 
-CMD="hzn sm secret remove -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/e2edevadmin/test-password" 
-echo -e "$CMD"
-$($CMD)
-if [ $? -eq 0 ]; then 
-  echo -e "\nERROR: shouldn't be able to remove a secret owned by a different user"
-  exit 1
-fi 
+CMD="hzn sm secret remove -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/e2edevadmin/test-password"  
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "Permission denied" "shouldn't be able to remove a secret owned by a different user"
 
 # error on `remove` - secret doesn't exist at the org level
 echo -e "$PREFIX removing a secret that doesn't exist at the org level"
 
 CMD="hzn sm secret remove -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} fake-password"
-echo -e "$CMD"
-$($CMD)
-if [ $? -eq 0 ]; then 
-  echo -e "\nERROR: shouldn't be able to remove a secret that doesn't exist"
-  exit 1
-fi 
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "nothing to remove" "shouldn't be able to remove a secret that doesn't exist"
 
 # error on `remove` - secret doesn't exist at the user level
 echo -e "$PREFIX removing a secret that doesn't exist at the user level"
 
 CMD="hzn sm secret remove -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin/fake-password"
-echo -e "$CMD"
-$($CMD)
-if [ $? -eq 0 ]; then 
-  echo -e "\nERROR: shouldn't be able to remove a secret that doesn't exist"
-  exit 1
-fi 
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "nothing to remove" "shouldn't be able to remove a secret that doesn't exist"
 
 # error on `read` - secret doesn't exist
 echo -e "$PREFIX reading a secret that doesn't exist"
 
 CMD="hzn sm secret read -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} fake-password"
-echo -e "$CMD"
-$($CMD)
-if [ $? -eq 0 ]; then 
-  echo -e "\nERROR: shouldn't be able to read a secret that doesn't exist"
-  exit 1
-fi 
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "No secret(s) found" "shouldn't be able to read a secret that doesn't exist"
 
 # error on `read` - user can't read org level secrets 
 echo -e "$PREFIX non-admin shouldn't read org level secrets"
 
 CMD="hzn sm secret read -o ${USERDEV_ORG} -u ${USERDEV_USER_AUTH} test-password"
-echo -e "$CMD"
-$($CMD)
-if [ $? -eq 0 ]; then 
-  echo -e "\nERROR: user shouldn't be able to read org-level secrets"
-  exit 1
-fi 
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "Permission denied" "user shouldn't be able to read org-level secrets"
 
 # error on `read` - user can't read another user's secrets
 echo -e "$PREFIX user shouldn't read another user's secrets"
 
 CMD="hzn sm secret read -o ${USERDEV_ORG} -u ${USERDEV_USER_AUTH} user/userdevadmin/test-password"
-echo -e "$CMD"
-$($CMD)
-if [ $? -eq 0 ]; then 
-  echo -e "\nERROR: user shouldn't be able to read org-level secrets"
-  exit 1
-fi 
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "Permission denied" "user shouldn't be able to read another user's secrets"
 
 # error on `add` - secret owned by a different user 
 echo -e "$PREFIX adding a secret owned by a different user"
 
 CMD="hzn sm secret add --secretKey password -d password456 -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/e2edevadmin/fake-password"
-echo -e "$CMD"
-$($CMD)
-if [ $? -eq 0 ]; then 
-  echo -e "\nERROR: shouldn't be able to remove a secret owned by a different user"
-  exit 1
-fi 
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "Permission denied" "user shouldn't be able to add to another user's secrets"
+
+# error on `read` - bad request 
+echo -e "$PREFIX passing an incorrect secret name into add"
+
+CMD="hzn sm secret read -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user"
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "User must be specified" "shouldn't be able to create secret with incorrect name"
+
+# error on `read` - bad request 
+echo -e "$PREFIX passing an incorrect secret name into add"
+
+CMD="hzn sm secret read -o ${USERDEV_ORG} -u ${USERDEV_ADMIN_AUTH} user/userdevadmin"
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "Incorrect secret name" "shouldn't be able to create secret with incorrect name"
+
+# error on `list` - incorrect credentials
+echo -e "$PREFIX passing incorrect exchange credentials into list"
+
+CMD="hzn sm secret list -o ${USERDEV_ORG} -u userdevfake:userdevfakepw test-password"
+RES=$($CMD 2>&1)
+verify "$CMD" "$RES" "Failed to authenticate" "shouldn't be able to access secrets with incorrect credentials"
 
 # ----------------------------
 # ----- CLEANUP -----


### PR DESCRIPTION
Created custom errors for the vault plugin in `agreementbot/secrets/plugin_errors.go`. Any errors coming from the vault plugin related to secrets must have the `VaultError` type, which has an `Error()` function as well as functions to retrieve the vault's response and response code. 