### PR TITLE
Issue 2665 - Dependency service are missing ESS env vars, preventing …

### DIFF
--- a/cli/dev/utils.go
+++ b/cli/dev/utils.go
@@ -313,7 +313,6 @@ func makeByValueAttributes(attrs []persistence.Attribute) []persistence.Attribut
 // Create the environment variable map needed by the container worker to hold the environment variables that are passed to the
 // workload container.
 func createEnvVarMap(agreementId string,
-	workloadPW string,
 	global []common.GlobalSet,
 	msURL string,
 	configVar map[string]interface{},
@@ -339,7 +338,6 @@ func createEnvVarMap(agreementId string,
 		agreementId,
 		GetNodeId(),
 		org,
-		workloadPW,
 		os.Getenv(DEVTOOL_HZN_EXCHANGE_URL),
 		os.Getenv(DEVTOOL_HZN_PATTERN),
 		cw.Config.GetFileSyncServiceProtocol(),
@@ -692,10 +690,8 @@ func StartContainers(deployment *containermessage.DeploymentDescription,
 	}
 
 	agId := ""
-	wlpw := ""
 	if agreementBased {
 		agId = id
-		wlpw = "deprecated"
 	}
 
 	// Dependencies that require userinput variables to be set must have those variables set in the current userinput file,
@@ -703,7 +699,7 @@ func StartContainers(deployment *containermessage.DeploymentDescription,
 	configVars := getConfiguredVariables(configUserInputs, specRef)
 
 	// Now that we have the configured variables, turn everything into environment variables for the container.
-	environmentAdditions, enverr := createEnvVarMap(agId, wlpw, globals, specRef, configVars, defUserInputs, org, cw, persistence.AttributesToEnvvarMap)
+	environmentAdditions, enverr := createEnvVarMap(agId, globals, specRef, configVars, defUserInputs, org, cw, persistence.AttributesToEnvvarMap)
 	if enverr != nil {
 		return nil, errors.New(msgPrinter.Sprintf("unable to create environment variables"))
 	}

--- a/cutil/cutil.go
+++ b/cutil/cutil.go
@@ -227,7 +227,7 @@ func VerifyWorkloadVarTypes(varValue interface{}, expectedType string) error {
 
 // This function may seem simple but since it is shared with the hzn dev CLI, an update to it will cause a compile error in the CLI
 // code. This will prevent us from adding a new platform env var but forgetting to update the CLI.
-func SetPlatformEnvvars(envAdds map[string]string, prefix string, agreementId string, deviceId string, org string, workloadPW string, exchangeURL string, pattern string, fssProtocol string, fssAddress string, fssPort string) {
+func SetPlatformEnvvars(envAdds map[string]string, prefix string, agreementId string, deviceId string, org string, exchangeURL string, pattern string, fssProtocol string, fssAddress string, fssPort string) {
 
 	// The agreement id that is controlling the lifecycle of this container.
 	if agreementId != "" {
@@ -245,11 +245,6 @@ func SetPlatformEnvvars(envAdds map[string]string, prefix string, agreementId st
 
 	// The pattern that the node is hosting.
 	envAdds[prefix+"PATTERN"] = pattern
-
-	// Deprecated workload password, used only by legacy POC workloads.
-	if workloadPW != "" {
-		envAdds[prefix+"HASH"] = workloadPW
-	}
 
 	// Add in the exchange URL so that the workload knows which ecosystem its part of
 	envAdds[prefix+"EXCHANGE_URL"] = exchangeURL

--- a/governance/governance.go
+++ b/governance/governance.go
@@ -1537,7 +1537,6 @@ func (w *GovernanceWorker) RecordReply(proposal abstractprotocol.Proposal, proto
 			proposal.AgreementId(),
 			exchange.GetId(w.GetExchangeId()),
 			exchange.GetOrg(w.GetExchangeId()),
-			workload.WorkloadPassword,
 			w.GetExchangeURL(),
 			w.devicePattern,
 			w.BaseWorker.Manager.Config.GetFileSyncServiceProtocol(),

--- a/governance/microservice.go
+++ b/governance/microservice.go
@@ -296,10 +296,17 @@ func (w *GovernanceWorker) GetEnvVarsForServiceDepolyment(msdef *persistence.Mic
 		}
 	}
 
-	envAdds[config.ENVVAR_PREFIX+"DEVICE_ID"] = exchange.GetId(w.GetExchangeId())
-	envAdds[config.ENVVAR_PREFIX+"ORGANIZATION"] = exchange.GetOrg(w.GetExchangeId())
-	envAdds[config.ENVVAR_PREFIX+"PATTERN"] = w.devicePattern
-	envAdds[config.ENVVAR_PREFIX+"EXCHANGE_URL"] = w.Config.Edge.ExchangeURL
+	cutil.SetPlatformEnvvars(envAdds,
+		config.ENVVAR_PREFIX,
+		"",
+		exchange.GetId(w.GetExchangeId()),
+		exchange.GetOrg(w.GetExchangeId()),
+		w.Config.Edge.ExchangeURL,
+		w.devicePattern,
+		w.BaseWorker.Manager.Config.GetFileSyncServiceProtocol(),
+		w.BaseWorker.Manager.Config.GetFileSyncServiceAPIListen(),
+		strconv.Itoa(int(w.BaseWorker.Manager.Config.GetFileSyncServiceAPIPort())))
+
 
 	// Add in any default variables from the microservice userInputs that havent been overridden
 	for _, ui := range msdef.UserInputs {


### PR DESCRIPTION
…apps from using the /secrets API

Signed-off-by: zhangl <zhangl@us.ibm.com>

Print the envs started with `HZN_ESS` in a dependent service container now shows the new added envs:
![Screen Shot 2021-07-26 at 10 11 47 PM](https://user-images.githubusercontent.com/49077510/127084145-03c5bcc5-cd9b-4b9b-b6ea-1c633b2a30bc.png)

