### PR TITLE
Issue 2624 - Check agbot and agent logs for secret details

### DIFF
--- a/abstractprotocol/protocol.go
+++ b/abstractprotocol/protocol.go
@@ -221,7 +221,7 @@ func CreateProposal(p ProtocolHandler,
 	if TCPolicy, err := policy.Create_Terms_And_Conditions(producerPolicy, consumerPolicy, workload, agreementId, defaultPW, defaultNoData, version); err != nil {
 		return nil, errors.New(fmt.Sprintf("Protocol %v initiation received error trying to merge policy %v and %v, error: %v", p.Name(), producerPolicy, consumerPolicy, err))
 	} else {
-		glog.V(5).Infof(AAPlogString(p.Name(), fmt.Sprintf("Merged Policy %v", *TCPolicy)))
+		glog.V(5).Infof(AAPlogString(p.Name(), fmt.Sprintf("Merged Policy %v", TCPolicy)))
 
 		if tcBytes, err := json.Marshal(TCPolicy); err != nil {
 			return nil, errors.New(fmt.Sprintf("Protocol %v error marshalling TsAndCs %v, error: %v", p.Name(), *TCPolicy, err))


### PR DESCRIPTION
_abstractprotocol/protocol.go_ `CreateProposal()` function was updated to log the `Policy` as a pointer instead of a dereferenced pointer because that invoked the `Policy` `String()` method which is cleaner and does not print the secret details.

The `Policy` struct `String()` method is updated to remove newlines so that all the lines are written to the logs.

_producer/producer_protocol_handler.go_ had no instances of the `Proposal` or `Policy` objects being logged with the secret details in its `sendMessage()` function, but since _agreementbot/consumer_protocol_handler.go_ does, I thought it would be nice to put the same fix in both for symmetry and as a preventative measure.