### PR TITLE
Generated tokens should match exchange standards

### DIFF
--- a/cutil/cutil.go
+++ b/cutil/cutil.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"math"
+	mrand "math/rand"
 	"net"
 	"os"
 	"path"
@@ -51,13 +52,26 @@ func FirstN(n int, ss []string) []string {
 }
 
 func SecureRandomString() (string, error) {
-	bytes := make([]byte, 64)
 
+	random := mrand.New(mrand.NewSource(int64(time.Now().Nanosecond())))
+	
+	randStr := ""
+	randStr += string(rune(random.Intn(10) + 48))
+	randStr += string(rune(random.Intn(26) + 65))
+	randStr += string(rune(random.Intn(26) + 97))
+	
+	bytes := make([]byte, 63)
 	if _, err := rand.Read(bytes); err != nil {
 		return "", err
-	} else {
-		return base64.URLEncoding.EncodeToString(bytes), nil
 	}
+	randStr += base64.URLEncoding.EncodeToString(bytes)
+	
+	shuffledStr := []rune(randStr)
+    mrand.Shuffle(len(shuffledStr), func(i, j int) {
+        shuffledStr[i], shuffledStr[j] = shuffledStr[j], shuffledStr[i]
+    })
+	
+	return string(shuffledStr), nil
 }
 
 func GenerateAgreementId() (string, error) {


### PR DESCRIPTION
This PR is to update the function anax uses to generate tokens. The generated tokens need to match the new exchange standards:

- a digit must occur at least once
- minimum of 15 chars
- one uppercase letter
- one lowercase letter