### PR TITLE
Issue 2731 - make agreements after secrets are created

### DIFF
--- a/agreementbot/basic_agreement_worker.go
+++ b/agreementbot/basic_agreement_worker.go
@@ -392,6 +392,11 @@ func (a *BasicAgreementWorker) start(work *PrioritizedWorkQueue, random *rand.Ra
 
 			if wi.Reply.IsAccepted() {
 				if wi.Reply.IsSecretUpdate() {
+
+					// Get the agreement id lock to prevent any other thread from processing this same agreement.
+					lock := a.alm.getAgreementLock(wi.Reply.AgreementId())
+					lock.Lock()
+
 					// update the system to indicate that the secret update is complete.
 					glog.V(5).Infof(bwlogstring(a.workerID, fmt.Sprintf("secret update accepted %v", wi.Reply.ShortString())))
 
@@ -408,6 +413,9 @@ func (a *BasicAgreementWorker) start(work *PrioritizedWorkQueue, random *rand.Ra
 							deleteMessage = false
 						}
 					}
+
+					// Drop the agreement lock
+					lock.Unlock()
 
 				}
 

--- a/events/secret_events.go
+++ b/events/secret_events.go
@@ -10,7 +10,7 @@ type SecretUpdate struct {
 	SecretFullName   string // This name is not org qualified
 	SecretUpdateTime int64
 	PolicyNames      []string // An array of org qualified policy names
-	PatternNames     []string // An array of org aualified pattern names
+	PatternNames     []string // An array of org qualified pattern names
 }
 
 // Returns a new SecretUpdate object with a copied policy and pattern name list.


### PR DESCRIPTION
Signed-off-by: Dave Booz <booz@us.ibm.com>
1) Keep track of referenced secrets even if they aren't created yet.
2) Ensure that when the secret is created, agreements are formed as quickly as possible.
3) Got lucky and exposed a problem during testing where an agreement reply AND agreement update reply are processed simultaneously, resulting in one of them having their database update over-written by the other.