### PR TITLE
Issue 2850 - agent-install.sh: fix edge cluster upgrade issue

### DIFF
--- a/agent-install/agent-uninstall.sh
+++ b/agent-install/agent-uninstall.sh
@@ -374,6 +374,9 @@ function deleteAgentResources() {
     log_info "Deleting namespace..."
     $KUBECTL delete namespace $AGENT_NAMESPACE --force=true --grace-period=0
 
+    log_info "Deleting cert file from /etc/default/cert ..."
+    rm /etc/default/cert/agent-install.crt
+
     log_debug "deleteAgentResources() end"
 }
 


### PR DESCRIPTION
Signed-off-by: zhangl <zhangl@us.ibm.com>

When the user upgrade edge cluster agent with `./agent-install.sh -D cluster -i 'css:' -s`, which skip the registration, it end up with unregistered. That is because 
1) node name of edge cluster agent node is traced the path of device agent (from horizon env file or hostname). It end up with the node id traced from device agent path is different from current edge cluster deployment. 

2) the cert file is not copied/moved to `/etc/default/cert`, however the cert at that location is checked when we compare old horizon env and new horizon env. 

Then the install script will think current horizon env and current registration is not correct so the script unregisters the agent. 
And because `-s` is specified, it will not registered again.

The PR added paths to retrieve node id from current edge cluster