### PR TITLE
Issue 2879 - assess each object manager policy

### DIFF
--- a/agreementbot/agreementworker.go
+++ b/agreementbot/agreementworker.go
@@ -1077,11 +1077,19 @@ func (b *BaseAgreementWorker) HandleAgreementReply(cph ConsumerProtocolHandler, 
 						objPolicies := b.mmsObjMgr.GetObjectPolicies(agreement.Org, serviceNamePieces[0], serviceNamePieces[2], serviceNamePieces[1])
 
 						destsToAddMap := make(map[string]*exchange.ObjectDestinationsToAdd, 0)
-						if addedToList, _, err := AssignObjectToNodes(b, objPolicies, agreement.DeviceId, nodePolicy, destsToAddMap, false); err != nil {
+						destsToDeleteMap := make(map[string]*exchange.ObjectDestinationsToDelete, 0)
+
+						if err := AssignObjectToNodes(b, objPolicies, agreement.DeviceId, nodePolicy, destsToAddMap, destsToDeleteMap, nil, false); err != nil {
 							glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("unable to assign object(s) to node %v, error %v", agreement.DeviceId, err)))
-						} else if addedToList {
+						}
+
+						if len(destsToAddMap) > 0 {
 							AddDestinationsForObjects(b, destsToAddMap)
 						}
+						if len(destsToDeleteMap) > 0 {
+							DeleteDestinationsForObjects(b, destsToDeleteMap)
+						}
+
 					}
 				} else if b.GetCSSURL() == "" {
 					glog.Errorf(BAWlogstring(workerId, fmt.Sprintf("unable to evaluate object placement because there is no CSS URL configured in this agbot")))

--- a/config/config.go
+++ b/config/config.go
@@ -126,6 +126,7 @@ type AGConfig struct {
 	PolicySearchOrder             bool             // When true, search policies from most recently changed to least recently changed.
 	Vault                         VaultConfig      // The hashicorp vault config to connect to and fetch secrets from.
 	SecretsUpdateCheck            int              // The number of seconds between checks for updated secrets.
+	CSSDestinationBatchSize       int              // The max number of destination updates to send to CSS in a single update.
 }
 
 // Contains the hashicorp vault configuration used within AGConfig.
@@ -370,16 +371,17 @@ func Read(file string) (*HorizonConfig, error) {
 				K8sCRInstallTimeoutS:           K8sCRInstallTimeoutS_DEFAULT,
 			},
 			AgreementBot: AGConfig{
-				MessageKeyCheck:     AgbotMessageKeyCheck_DEFAULT,
-				AgreementBatchSize:  AgbotAgreementBatchSize_DEFAULT,
-				AgreementQueueSize:  AgbotAgreementQueueSize_DEFAULT,
-				MessageQueueScale:   AgbotMessageQueueScale_DEFAULT,
-				QueueHistorySize:    AgbotQueueHistorySize_DEFAULT,
-				FullRescanS:         AgbotFullRescan_DEFAULT,
-				MaxExchangeChanges:  AgbotMaxChanges_DEFAULT,
-				RetryLookBackWindow: AgbotRetryLookBackWindow_DEFAULT,
-				PolicySearchOrder:   AgbotPolicySearchOrder_DEFAULT,
-				SecretsUpdateCheck:  SecretsUpdateCheck_DEFAULT,
+				MessageKeyCheck:         AgbotMessageKeyCheck_DEFAULT,
+				AgreementBatchSize:      AgbotAgreementBatchSize_DEFAULT,
+				AgreementQueueSize:      AgbotAgreementQueueSize_DEFAULT,
+				MessageQueueScale:       AgbotMessageQueueScale_DEFAULT,
+				QueueHistorySize:        AgbotQueueHistorySize_DEFAULT,
+				FullRescanS:             AgbotFullRescan_DEFAULT,
+				MaxExchangeChanges:      AgbotMaxChanges_DEFAULT,
+				RetryLookBackWindow:     AgbotRetryLookBackWindow_DEFAULT,
+				PolicySearchOrder:       AgbotPolicySearchOrder_DEFAULT,
+				SecretsUpdateCheck:      SecretsUpdateCheck_DEFAULT,
+				CSSDestinationBatchSize: AgbotCSSDestinationBatchSize_DEFAULT,
 			},
 		}
 
@@ -554,6 +556,7 @@ func (agc *AGConfig) String() string {
 		", CheckUpdatedPolicyS: %v"+
 		", CSSURL: %v"+
 		", CSSSSLCert: %v"+
+		", CSSDestinationBatchSize: %v"+
 		", AgreementBatchSize: %v"+
 		", AgreementQueueSize: %v"+
 		", MessageQueueScale: %v"+
@@ -569,7 +572,7 @@ func (agc *AGConfig) String() string {
 		agc.IgnoreContractWithAttribs, agc.ExchangeURL, agc.ExchangeHeartbeat, agc.ExchangeId,
 		mask, agc.DVPrefix, agc.ActiveDeviceTimeoutS, agc.ExchangeMessageTTL, agc.MessageKeyPath, mask, agc.APIListen,
 		agc.SecureAPIListenHost, agc.SecureAPIListenPort, agc.SecureAPIServerCert, agc.SecureAPIServerKey,
-		agc.PurgeArchivedAgreementHours, agc.CheckUpdatedPolicyS, agc.CSSURL, agc.CSSSSLCert, agc.AgreementBatchSize,
+		agc.PurgeArchivedAgreementHours, agc.CheckUpdatedPolicyS, agc.CSSURL, agc.CSSSSLCert, agc.CSSDestinationBatchSize, agc.AgreementBatchSize,
 		agc.AgreementQueueSize, agc.MessageQueueScale, agc.QueueHistorySize, agc.FullRescanS, agc.MaxExchangeChanges,
 		agc.RetryLookBackWindow, agc.PolicySearchOrder, agc.Vault)
 }

--- a/config/constants.go
+++ b/config/constants.go
@@ -119,3 +119,6 @@ const K8sCRInstallTimeoutS_DEFAULT = 180
 
 // Time between secret update checks
 const SecretsUpdateCheck_DEFAULT = 60
+
+// Batch destination size to send to CSS
+const AgbotCSSDestinationBatchSize_DEFAULT = 200


### PR DESCRIPTION
Signed-off-by: Doug Larson <larsond@us.ibm.com>

- Look at each object manager policy individually
- Avoid long log messages printing destinations
- Batch destination updates to CSS to avoid a single huge POST
- Agbot can determine if an agent is already in the destination list to avoid unnecessary call to CSS