### PR TITLE
Issue-3008: agent-install.sh add support for Raspberry Pi OS arm64 bullseye/debian 11

### DIFF
--- a/agent-install/agent-install.sh
+++ b/agent-install/agent-install.sh
@@ -19,7 +19,7 @@ VERB_DEBUG=5
 # You can add to these lists of supported values by setting/exporting the corresponding <varname>_APPEND variable to a string of space-separated words.
 # This allows you to experiment with platforms or variations that are not yet officially tested/supported.
 SUPPORTED_DEBIAN_VARIANTS=(ubuntu raspbian debian $SUPPORTED_DEBIAN_VARIANTS_APPEND)   # compared to what our detect_distro() sets DISTRO to
-SUPPORTED_DEBIAN_VERSION=(focal bionic buster xenial stretch $SUPPORTED_DEBIAN_VERSION_APPEND)   # compared to what our detect_distro() sets CODENAME to
+SUPPORTED_DEBIAN_VERSION=(bullseye focal bionic buster xenial stretch $SUPPORTED_DEBIAN_VERSION_APPEND)   # compared to what our detect_distro() sets CODENAME to
 SUPPORTED_DEBIAN_ARCH=(amd64 arm64 armhf $SUPPORTED_DEBIAN_ARCH_APPEND)   # compared to dpkg --print-architecture
 SUPPORTED_REDHAT_VARIANTS=(rhel centos fedora $SUPPORTED_REDHAT_VARIANTS_APPEND)   # compared to what our detect_distro() sets DISTRO to
 # Note: RHEL 8.3 is not officially supported yet, but is enabled only for testing and tech preview purposes
@@ -1409,6 +1409,7 @@ function debian_device_install_prereqs() {
             else
                 curl -fsSL https://download.docker.com/linux/$DISTRO/gpg | apt-key add -
                 add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$DISTRO $(lsb_release -cs) stable"
+                runCmdQuietly apt-get update -q
                 runCmdQuietly apt-get install -yqf docker-ce docker-ce-cli containerd.io
             fi
         fi


### PR DESCRIPTION
## Issue

Add support for Raspberry Pi OS/Debian Bullseye in `agent-install.sh`.

## Overview of Changes

- Added `bullseye` to `SUPPORTED_DEBIAN_VERSION`
- Within `debian_device_install_prereqs()` run a `apt-get update` after adding the Docker repository.

## Setup

### Open Horizon HUB

- Virtualbox Version 6.1.32 running Ubuntu 18.04.6 LTS

Installation instructions are followed here:
https://open-horizon.github.io/common-requests/install.html
https://wiki.lfedge.org/display/OH/Sample+Open+Horizon+setup

### Agent 

Tested on:
- Raspberry Pi 4 running Raspberry PI OS Lite (Bullseye) - 64bit
- Raspberry Pi 4 running Raspberry PI OS Lite (Bullseye) - 32bit
- Raspberry Pi 4 running Raspberry PI OS Lite (Buster) - 32bit

## Test Methodology

On a fresh install of Raspberry PI OS Lite run the following commands:

```
sudo -s -E
apt-get -y update && apt-get -y upgrade && apt-get -y install git vim

git clone https://github.com/open-horizon/anax.git &&  cd anax/agent-install/

export HZN_ORG_ID=myorg
export HZN_EXCHANGE_USER_AUTH=admin:*****
export HZN_DEVICE_TOKEN=****
export HZN_DEVICE_ID=node1
export HZN_EXCHANGE_URL=http://{HUB_INTERAL_IP}:3090/v1/
export HZN_FSS_CSSURL=http://{HUB_INTERAL_IP}:9443/

env | grep HZN

curl -sSL https://raw.githubusercontent.com/WatchJolley/anax/issue-3008/agent-install/agent-install.sh | sudo -s -E bash -s -- -i anax: -k css: -c css: -p IBM/pattern-ibm.helloworld -w '*' -T 120
```

## Outcome

Each test instance saw `agent-install.sh` end in:

```
Status of the services you are watching:
    IBM/ibm.helloworld  Progress so far: agreement is accepted
Status of the services you are watching:
    IBM/ibm.helloworld  Progress so far: service is created
Status of the services you are watching:
    IBM/ibm.helloworld  Progress so far: execution is started
Status of the services you are watching:
    IBM/ibm.helloworld  Success
```

Using `docker ps` we can see the agent is running:

```
CONTAINER ID   IMAGE                              COMMAND                  CREATED          STATUS          PORTS     NAMES
d744df7e68f3   openhorizon/ibm.helloworld_arm64   "/bin/sh -c /service…"   37 seconds ago   Up 30 seconds             707eea0fd75f69993aa524c948633b29714dc6db280aa029ff1544685308a5dc-ibm.helloworld
```


Signed-off-by: Ben Jolley <ben.jolley@ibm.com>