### PR TITLE
Issue 3055 - Fix proceeed misspelling

### DIFF
--- a/agreementbot/changes_worker.go
+++ b/agreementbot/changes_worker.go
@@ -258,7 +258,7 @@ func (w *ChangesWorker) postProcessChanges(changes *exchange.ExchangeChanges) {
 }
 
 // Process any error from the /changes API and update the heartbeat state appropriately. Return true if the
-// caller should not proceeed to process the response.
+// caller should not proceed to process the response.
 func (w *ChangesWorker) handleHeartbeatStateAndError(changes *exchange.ExchangeChanges, err error) bool {
 	if err != nil {
 		glog.Errorf(chglog(fmt.Sprintf("heartbeat and change retrieval failed, error %v", err)))

--- a/changes/changes_worker.go
+++ b/changes/changes_worker.go
@@ -354,7 +354,7 @@ func (w *ChangesWorker) postProcessChanges(changes *exchange.ExchangeChanges, in
 }
 
 // Process any error from the /changes API and update the heartbeat state appropriately. Return true if the
-// caller should not proceeed to process the response.
+// caller should not proceed to process the response.
 func (w *ChangesWorker) handleHeartbeatStateAndError(changes *exchange.ExchangeChanges, err error) bool {
 	if err != nil {
 		glog.Errorf(chglog(fmt.Sprintf("heartbeat and change retrieval failed, error %v", err)))

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -258,10 +258,10 @@ func DoIt(org, pattern, nodeIdTok, userPw, inputFile string, nodeOrgFromFlag str
 	if pattern == "" {
 		if exchangePattern == "" {
 			if nodepolicyFlag == "" {
-				msgPrinter.Printf("No pattern or node policy is specified. Will proceeed with the existing node policy.")
+				msgPrinter.Printf("No pattern or node policy is specified. Will proceed with the existing node policy.")
 				msgPrinter.Println()
 			} else {
-				msgPrinter.Printf("Will proceeed with the given node policy.")
+				msgPrinter.Printf("Will proceed with the given node policy.")
 				msgPrinter.Println()
 			}
 		} else {
@@ -291,7 +291,7 @@ func DoIt(org, pattern, nodeIdTok, userPw, inputFile string, nodeOrgFromFlag str
 		if len(pat.Services) == 0 {
 			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Cannot proceed with the given pattern %s because it does not include any services.", pattern))
 		} else {
-			msgPrinter.Printf("Will proceeed with the given pattern %s.", pattern)
+			msgPrinter.Printf("Will proceed with the given pattern %s.", pattern)
 			msgPrinter.Println()
 		}
 	}


### PR DESCRIPTION
This PR fixes https://github.com/open-horizon/anax/issues/3055

`Proceed` in several messages and comments has been corrected.

Signed-off-by: John Walicki <walicki@us.ibm.com>