### PR TITLE
Issue 3063 - Fix arm64 anax container images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,17 @@ ifdef GO_BUILD_LDFLAGS
 	GO_BUILD_LDFLAGS := -ldflags="$(GO_BUILD_LDFLAGS) -s -w"
 endif
 
+# Test if we can use Docker buildx if USE_DOCKER_BUILDX is set. If not, then we can't build multi-arch images on x86 but 
+#  will instead need to have a build platform of each arch to build images of different archs
+DOCKER_BUILDX_PLATFORM=$(arch)
+ifeq ($(arch),ppc64el)
+DOCKER_BUILDX_PLATFORM = ppc64le
+endif
+
+DOCKER_BUILD_CMD = build
+ifneq ($(origin USE_DOCKER_BUILDX), undefined)
+DOCKER_BUILD_CMD = buildx build --platform linux/$(DOCKER_BUILDX_PLATFORM)
+endif
 
 ifndef verbose
 .SILENT:
@@ -316,6 +327,7 @@ macinstall: $(MAC_PKG)
 macpkginfo:
 	$(MAKE) -C pkg/mac macpkginfo
 
+# note that we can use Docker buildx for building multiplatform archs on x86 if we export USE_DOCKER_BUILDX=true
 anax-image:
 	@echo "Producing anax docker image $(ANAX_IMAGE)"
 	if [[ $(arch) == "amd64" || $(arch) == "ppc64el" || $(arch) == "s390x" || $(arch) == "arm64" ]]; then \
@@ -324,7 +336,7 @@ anax-image:
 	  cp $(EXECUTABLE) $(ANAX_CONTAINER_DIR); \
 	  cp $(CLI_EXECUTABLE) $(ANAX_CONTAINER_DIR); \
 	  cp -f $(LICENSE_FILE) $(ANAX_CONTAINER_DIR); \
-	  cd $(ANAX_CONTAINER_DIR) && docker build $(DOCKER_MAYBE_CACHE) $(ANAX_IMAGE_LABELS) -t $(ANAX_IMAGE) -f Dockerfile.ubi.$(arch) . && \
+	  cd $(ANAX_CONTAINER_DIR) && docker $(DOCKER_BUILD_CMD) $(DOCKER_MAYBE_CACHE) $(ANAX_IMAGE_LABELS) -t $(ANAX_IMAGE) -f Dockerfile.ubi.$(arch) . && \
 	  docker tag $(ANAX_IMAGE) $(ANAX_IMAGE_STG); \
 	else echo "Building the anax docker image is not supported on $(arch)"; fi
 
@@ -399,13 +411,14 @@ agbot-package: agbot-image
 		echo "anax-k8s container $(AGBOT_IMAGE_STG):$(AGBOT_IMAGE_VERSION) already present in $(IMAGE_REPO)"; \
 	fi
 
+# note that we can use Docker buildx for building multiplatform archs on x86 if we export USE_DOCKER_BUILDX=true
 anax-k8s-image: anax-k8s-clean
 	cp $(EXECUTABLE) $(ANAX_K8S_CONTAINER_DIR)
 	cp $(CLI_EXECUTABLE) $(ANAX_K8S_CONTAINER_DIR)
 	cp -f $(LICENSE_FILE) $(ANAX_K8S_CONTAINER_DIR)
 	@echo "Producing ANAX K8S docker image $(ANAX_K8S_IMAGE_STG)"
 	if [[ $(arch) == "amd64" || $(arch) == "ppc64el" || $(arch) == "arm64" ]]; then \
-		cd $(ANAX_K8S_CONTAINER_DIR) && docker build $(DOCKER_MAYBE_CACHE) $(ANAX_K8S_IMAGE_LABELS) -t $(ANAX_K8S_IMAGE_STG) -f Dockerfile.ubi.$(arch) .; \
+		cd $(ANAX_K8S_CONTAINER_DIR) && docker $(DOCKER_BUILD_CMD) $(DOCKER_MAYBE_CACHE) $(ANAX_K8S_IMAGE_LABELS) -t $(ANAX_K8S_IMAGE_STG) -f Dockerfile.ubi.$(arch) .; \
 	fi
 	docker tag $(ANAX_K8S_IMAGE_STG) $(ANAX_K8S_IMAGE_BASE):$(ANAX_K8S_IMAGE_VERSION)
 

--- a/anax-in-container/README.md
+++ b/anax-in-container/README.md
@@ -10,19 +10,28 @@ This page provides guidance for building and running a containerized version of 
 > **Note:** Currently supported architectures for running Horizon Agent (anax) in container:
 >
 > - amd64
-> - ppc64le
+> - arm64
+> - ppc64el
 > - s390x
 
 ## Build and Push the Horizon Agent Container
 
-If you are building a Docker image for a platform different than the one you're building on (cross-platform build), you must export the target host platform variables first, e.g. for `ppc64le` architecture with Ubuntu 18.04 host use the following procedure:
+Building multi-architecture Docker images can be done by exporting the target host platform variables and a variable to enable
+[Docker Buildx](https://docs.docker.com/buildx/working-with-buildx/). This requires Docker >= 19.03 and certain host packages to
+be installed and running (`qemu-user-static` and `binmt-support`). Alternatively, instead of installing the needed packages, you can
+also run the `multiarch/qemu-user-static` Docker image which will setup the QEMU simulator for use with Buildx. Note that you must
+continually run this Docker image in order to use Buildx to build muli-arch images.
 
 ```bash
 # List of possible values:
-#   `arch`: armhf, arm64, amd64, ppc64el
+#   `arch`: arm64, amd64, ppc64el, s390x
 #   `opsys`: Linux, Darwin
 export arch=ppl64el
+#export arch=arm64
 export opsys=Linux # (output of 'uname -s' command on target)
+export USE_DOCKER_BUILDX=true
+# setup the QEMU simulator. You can then run `docker buildx ls` to see which platforms are available.
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 # In Makefile, modify line: DOCKER_IMAGE_VERSION ?= x.x.x, or set that variable in the environment
 make anax-image
 # test container locally with:


### PR DESCRIPTION
# Pull Request Template

## Description

Fix arm64 anax container images by enabling multi-arch builds using Docker Buildx

Fixes #3063 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Internal IBM Jenkins job builds Docker images with and without using Buildx options.

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
