### PR TITLE
Issue 3091 - Remove version range support from manifest CLI

### DIFF
--- a/cli/node_management/agentfiles.go
+++ b/cli/node_management/agentfiles.go
@@ -146,6 +146,9 @@ func getAgentFiles(org, credToUse, fileTypeFilter, fileVersionFilter string) []a
 	// Sort the files by type (if the type was not filtered) and then by version in descending order
 	sort.Slice(agentFileObjects, func(i, j int) bool {
 		if agentFileObjects[i].AgentFileType == agentFileObjects[j].AgentFileType {
+			if strings.Contains(agentFileObjects[i].AgentFileVersion, agentFileObjects[j].AgentFileVersion) {
+				return agentFileObjects[i].AgentFileVersion < agentFileObjects[j].AgentFileVersion
+			}
 			return agentFileObjects[i].AgentFileVersion > agentFileObjects[j].AgentFileVersion
 		}
 		return agentFileObjects[i].AgentFileType > agentFileObjects[j].AgentFileType

--- a/cli/node_management/manifest.go
+++ b/cli/node_management/manifest.go
@@ -226,8 +226,8 @@ func checkManifestFile(org, credToUse string, manifestData AgentUpgradeManifestD
 		var manSoftwareFilesVersion string
 		if manifestData.SoftwareUpgrade.Version == "latest" {
 			manSoftwareFilesVersion = ""
-		} else if _, err := semanticversion.Version_Expression_Factory(manifestData.SoftwareUpgrade.Version); err != nil {
-			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("The version specified in SoftwareUpgrade is not a valid version range, version string or \"latest\": %v", err))
+		} else if isValidVersion := semanticversion.IsVersionString(manifestData.SoftwareUpgrade.Version); !isValidVersion {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("The version specified in SoftwareUpgrade is not a valid version string or \"latest\": %v", manifestData.SoftwareUpgrade.Version))
 		} else {
 			manSoftwareFilesVersion = manifestData.SoftwareUpgrade.Version
 		}
@@ -242,7 +242,7 @@ func checkManifestFile(org, credToUse string, manifestData AgentUpgradeManifestD
 			}
 			if !found {
 				validFile = false
-				errMsg += msgPrinter.Sprintf("File \"%s\" version(s) \"%s\" of type \"agent_software_files\".", manFile, manifestData.SoftwareUpgrade.Version)
+				errMsg += msgPrinter.Sprintf("File \"%s\" version \"%s\" of type \"agent_software_files\".", manFile, manifestData.SoftwareUpgrade.Version)
 				errMsg += msgPrinter.Sprintln()
 			}
 		}
@@ -254,8 +254,8 @@ func checkManifestFile(org, credToUse string, manifestData AgentUpgradeManifestD
 		var manCertFilesVersion string
 		if manifestData.CertificateUpgrade.Version == "latest" {
 			manCertFilesVersion = ""
-		} else if _, err := semanticversion.Version_Expression_Factory(manifestData.CertificateUpgrade.Version); err != nil {
-			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("The version specified in CertificateUpgrade is not a valid version range, version string or \"latest\": %v", err))
+		} else if isValidVersion := semanticversion.IsVersionString(manifestData.CertificateUpgrade.Version); !isValidVersion {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("The version specified in CertificateUpgrade is not a valid version string or \"latest\": %v", manifestData.CertificateUpgrade.Version))
 		} else {
 			manCertFilesVersion = manifestData.CertificateUpgrade.Version
 		}
@@ -270,7 +270,7 @@ func checkManifestFile(org, credToUse string, manifestData AgentUpgradeManifestD
 			}
 			if !found {
 				validFile = false
-				errMsg += msgPrinter.Sprintf("File \"%s\" version(s) \"%s\" of type \"agent_cert_files\".", manFile, manifestData.CertificateUpgrade.Version)
+				errMsg += msgPrinter.Sprintf("File \"%s\" version \"%s\" of type \"agent_cert_files\".", manFile, manifestData.CertificateUpgrade.Version)
 				errMsg += msgPrinter.Sprintln()
 			}
 		}
@@ -282,8 +282,8 @@ func checkManifestFile(org, credToUse string, manifestData AgentUpgradeManifestD
 		var manConfigFilesVersion string
 		if manifestData.ConfigurationUpgrade.Version == "latest" {
 			manConfigFilesVersion = ""
-		} else if _, err := semanticversion.Version_Expression_Factory(manifestData.ConfigurationUpgrade.Version); err != nil {
-			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("The version specified in ConfigurationUpgrade is not a valid version range, version string or \"latest\": %v", err))
+		} else if isValidVersion := semanticversion.IsVersionString(manifestData.ConfigurationUpgrade.Version); !isValidVersion {
+			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("The version specified in ConfigurationUpgrade is not a valid version string or \"latest\": %v", manifestData.ConfigurationUpgrade.Version))
 		} else {
 			manConfigFilesVersion = manifestData.ConfigurationUpgrade.Version
 		}
@@ -298,7 +298,7 @@ func checkManifestFile(org, credToUse string, manifestData AgentUpgradeManifestD
 			}
 			if !found {
 				validFile = false
-				errMsg += msgPrinter.Sprintf("File \"%s\" version(s) \"%s\" of type \"agent_config_files\".", manFile, manifestData.ConfigurationUpgrade.Version)
+				errMsg += msgPrinter.Sprintf("File \"%s\" version \"%s\" of type \"agent_config_files\".", manFile, manifestData.ConfigurationUpgrade.Version)
 				errMsg += msgPrinter.Sprintln()
 			}
 		}
@@ -353,19 +353,19 @@ func ManifestNew() {
 		`    "files": [               /* ` + msgPrinter.Sprintf("A list of agent software files stored in the Management Hub.") + ` */`,
 		`      ""                     /* ` + msgPrinter.Sprintf("Run 'hzn nm agentfiles list -t agent_software_files' to get a list of available files.") + ` */`,
 		`    ],`,
-		`    "version": ""            /* ` + msgPrinter.Sprintf("The agent software version range this manifest applies to. Specify \"latest\" to get the most recent version.") + ` */`,
+		`    "version": ""            /* ` + msgPrinter.Sprintf("The agent software version this manifest applies to. Specify \"latest\" to get the most recent version.") + ` */`,
 		`  },`,
 		`  "certificateUpgrade": {    /* ` + msgPrinter.Sprintf("Fill in this section to upgrade the agent certificate. Remove this section to prevent certificate upgrade.") + ` */`,
 		`    "files": [               /* ` + msgPrinter.Sprintf("The name of a cert file stored in the Management Hub. Default is \"agent-install.crt\".") + ` */`,
 		`      "agent-install.crt"    /* ` + msgPrinter.Sprintf("Run 'hzn nm agentfiles list -t agent_cert_files' to get a list of available files.") + ` */`,
 		`    ],`,
-		`    "version": ""            /* ` + msgPrinter.Sprintf("The agent cert version range this manifest applies to. Specify \"latest\" to get the most recent version.") + ` */`,
+		`    "version": ""            /* ` + msgPrinter.Sprintf("The agent cert version this manifest applies to. Specify \"latest\" to get the most recent version.") + ` */`,
 		`  },`,
 		`  "configurationUpgrade": {  /* ` + msgPrinter.Sprintf("Fill in this section to upgrade the agent config. Remove this section to prevent config upgrade.") + ` */`,
 		`    "files": [               /* ` + msgPrinter.Sprintf("The name of a cert file stored in the Management Hub. Default is \"agent-install.crt\".") + ` */`,
 		`      "agent-install.cfg"    /* ` + msgPrinter.Sprintf("Run 'hzn nm agentfiles list -t agent_config_files' to get a list of available files.") + ` */`,
 		`    ],`,
-		`    "version": ""            /* ` + msgPrinter.Sprintf("The agent config version range this manifest applies to. Specify \"latest\" to get the most recent version.") + ` */`,
+		`    "version": ""            /* ` + msgPrinter.Sprintf("The agent config version this manifest applies to. Specify \"latest\" to get the most recent version.") + ` */`,
 		`  }`,
 		`}`,
 	}


### PR DESCRIPTION
Signed-off-by: Jeff Kinard <jeff@thekinards.com>

## Description

This PR fixes issue #3091 - Remove version range support from manifest CLI. Before this change, a user could add a Manifest file to the CSS, using the agent CLI, with a manifest file that included version *ranges* for the various upgrade types. However, only version *strings* and "latest" will be the only acceptable ways to specify upgrade versions. With this PR, the `hzn nm manifest add` command will now check the given manifest to make sure the given file versions are version strings or "latest".

This PR also fixes some typos, removes the usage of "version range" from the help outputs.

Finally, this PR also fixes how agent files are sorted when using the `hzn nm agentfiles list` command. Before, versions were sorted in descending order according to lexicographical order, but this was problematic when it came to pre-release versions as they were treated as "newer" than their non-pre-release counterparts when they should be treated as older. For example, agentFile-1.0.0 should be listed above agentFile-1.0.0-beta as it is the stable release, and therefore "newer". 

Fixes #3091

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This was tested by giving the `hzn nm manifest add` command a manifest with version ranges specified to ensure it outputted an error message. It was then tested by giving valid manifest files to make sure they were accepted.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
