### PR TITLE
Issue 3119 - Use semantic versioning for sorting files in hzn nm agentfiles list

### DIFF
--- a/cli/node_management/agentfiles.go
+++ b/cli/node_management/agentfiles.go
@@ -146,10 +146,11 @@ func getAgentFiles(org, credToUse, fileTypeFilter, fileVersionFilter string) []a
 	// Sort the files by type (if the type was not filtered) and then by version in descending order
 	sort.Slice(agentFileObjects, func(i, j int) bool {
 		if agentFileObjects[i].AgentFileType == agentFileObjects[j].AgentFileType {
-			if strings.Contains(agentFileObjects[i].AgentFileVersion, agentFileObjects[j].AgentFileVersion) {
-				return agentFileObjects[i].AgentFileVersion < agentFileObjects[j].AgentFileVersion
+			if greaterThan, err := semanticversion.CompareVersions(agentFileObjects[i].AgentFileVersion, agentFileObjects[j].AgentFileVersion); err != nil {
+				cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, msgPrinter.Sprintf("error comparing agent file versions: %v", err))
+			} else {
+				return greaterThan > 0
 			}
-			return agentFileObjects[i].AgentFileVersion > agentFileObjects[j].AgentFileVersion
 		}
 		return agentFileObjects[i].AgentFileType > agentFileObjects[j].AgentFileType
 	})


### PR DESCRIPTION
Signed-off-by: Jeff Kinard <jeff@thekinards.com>

## Description

This PR fixes the sorting of the files outputted by running `hzn nodemanagement agentfiles list`. Files are now sorted semantically based on their version string rather than lexigraphically.

Fixes #3119

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested by running `hzn nodemanagement agentfiles list` and checking the output.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.
