### PR TITLE
Issue 3139 - fix missing msgprinter statements for i18n

### DIFF
--- a/cli/dev/utils.go
+++ b/cli/dev/utils.go
@@ -555,7 +555,7 @@ func ProcessStartDependencies(dir string, deps []*common.ServiceFile, globals []
 					var err error
 					serviceContainers, err := cw.GetClient().ListContainers(docker.ListContainersOptions{Filters: map[string][]string{"network": []string{nwName}}})
 					if err != nil {
-						return nil, fmt.Errorf("unable to get list of containers in network %v, error %v", nwName, err)
+						return nil, fmt.Errorf(msgPrinter.Sprintf("unable to get list of containers in network %v, error %v", nwName, err))
 					} else {
 						containers = append(containers, serviceContainers...)
 					}

--- a/cli/exchange/user.go
+++ b/cli/exchange/user.go
@@ -135,9 +135,9 @@ func checkExchangeVersionForOptionalUserEmail(org, userPwCreds string) (bool, er
 	exchangeVersion := strings.TrimSpace(string(output))
 
 	if !semanticversion.IsVersionString(exchangeVersion) {
-		return false, fmt.Errorf("The current exchange version %v is not a valid version string.", exchangeVersion)
+		return false, fmt.Errorf(i18n.GetMessagePrinter().Sprintf("The current exchange version %v is not a valid version string.", exchangeVersion))
 	} else if comp, err := semanticversion.CompareVersions(exchangeVersion, USER_EMAIL_OPTIONAL_EXCHANGE_VERSION); err != nil {
-		return false, fmt.Errorf("Failed to compare the versions. %v", err)
+		return false, fmt.Errorf(i18n.GetMessagePrinter().Sprintf("Failed to compare the versions. %v", err))
 	} else if comp < 0 {
 		// current exchange version < 2.61.0. User email is required
 		return false, nil

--- a/cli/plugin_registry/plugin_registry.go
+++ b/cli/plugin_registry/plugin_registry.go
@@ -3,7 +3,6 @@ package plugin_registry
 import (
 	"crypto/rsa"
 	"errors"
-	"fmt"
 	"github.com/open-horizon/anax/i18n"
 )
 
@@ -92,7 +91,7 @@ func (d DeploymentConfigRegistry) StopTest(homeDirectory string) error {
 		}
 	}
 
-	return errors.New(fmt.Sprintf("stopping test mode is not supported for this project"))
+	return errors.New(i18n.GetMessagePrinter().Sprintf("stopping test mode is not supported for this project"))
 }
 
 func (d DeploymentConfigRegistry) HasPlugin(name string) bool {

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -462,7 +462,7 @@ func CreateNode(nodeDevice api.HorizonDevice, timeout int) error {
 				if httpCode == cliutils.ANAX_ALREADY_CONFIGURED {
 					cliutils.Fatal(cliutils.HTTP_ERROR, msgPrinter.Sprintf("this Horizon node is already registered or in the process of being registered. If you want to register it differently, run 'hzn unregister' first."))
 				} else if httpCode != 200 && httpCode != 201 {
-					return fmt.Errorf("Bad HTTP code %d returned from node.", httpCode)
+					return fmt.Errorf(msgPrinter.Sprintf("Bad HTTP code %d returned from node.", httpCode))
 				} else {
 					return nil
 				}
@@ -548,7 +548,7 @@ func SetConfigState(timeout int, inputFile string) error {
 		select {
 		case output := <-c:
 			if output == "done" {
-				cliutils.Verbose("Call to node to change state to configured executed successfully.")
+				cliutils.Verbose(msgPrinter.Sprintf("Call to node to change state to configured executed successfully."))
 				return nil
 			} else {
 				return fmt.Errorf("%v", output)
@@ -557,14 +557,14 @@ func SetConfigState(timeout int, inputFile string) error {
 		case <-time.After(time.Duration(channelWait) * time.Second):
 			totalWait = totalWait - channelWait
 			if totalWait <= 0 {
-				cliutils.Verbose("Timeout on the call to update node config state. Checking if it is updated.")
+				cliutils.Verbose(msgPrinter.Sprintf("Timeout on the call to update node config state. Checking if it is updated."))
 				state := api.Configstate{}
 				cliutils.HorizonGet("node/configstate", []int{200, 201}, &state, true)
 				if *state.State == "unconfigured" {
-					cliutils.Verbose("Node state is unconfigured.")
+					cliutils.Verbose(msgPrinter.Sprintf("Node state is unconfigured."))
 					return nil
 				}
-				return fmt.Errorf("Timeout waiting for node config state call to return.")
+				return fmt.Errorf(msgPrinter.Sprintf("Timeout waiting for node config state call to return."))
 			}
 			cliutils.Verbose(msgPrinter.Sprintf("Waiting for node config state update call to return. %d seconds until timeout.", totalWait))
 		}

--- a/cli/register/servicewait.go
+++ b/cli/register/servicewait.go
@@ -367,7 +367,7 @@ func WaitForService(org string, waitService string, waitTimeout int, pattern str
 				if strings.Contains(el.Message, serviceFullName) {
 					printLog = true
 				} else if es, err := persistence.GetRealEventSource(el.SourceType, el.Source); err != nil {
-					cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, "unable to convert eventlog source, error: %v", err)
+					cliutils.Fatal(cliutils.CLI_GENERAL_ERROR, msgPrinter.Sprintf("unable to convert eventlog source, error: %v", err))
 				} else if (*es).Matches(match) {
 					printLog = true
 				}

--- a/cli/sdo/key.go
+++ b/cli/sdo/key.go
@@ -274,46 +274,55 @@ func import1Key(org, userCreds string, keyFileReader io.Reader, keyFileName stri
 
 // Check if keyfile stored in KeyFile struct as any empty fields
 func checkEmptyKeyFields(key KeyFile) error {
+	msgPrinter := i18n.GetMessagePrinter()
 	errMsg := ""
 	if key.Name == "" {
-		errMsg += "\tfield \"key_name\" is missing\n"
+		errMsg += fmt.Sprintf("\t") + msgPrinter.Sprintf("field \"key_name\" is missing") + fmt.Sprintf("\n")
 	}
 	if key.CommonName == "" {
-		errMsg += "\tfield \"common_name\" is missing\n"
+		field := "common_name"
+		errMsg += fmt.Sprintf("\t") + msgPrinter.Sprintf("field \"%s\" is missing", field) + fmt.Sprintf("\n")
 	}
 	if key.Email == "" {
-		errMsg += "\tfield \"email_name\" is missing\n"
+		field := "email_name"
+		errMsg += fmt.Sprintf("\t") + msgPrinter.Sprintf("field \"%s\" is missing", field) + fmt.Sprintf("\n")
 	}
 	if key.Company == "" {
-		errMsg += "\tfield \"company_name\" is missing\n"
+		field := "company_name"
+		errMsg += fmt.Sprintf("\t") + msgPrinter.Sprintf("field \"%s\" is missing", field) + fmt.Sprintf("\n")
 	}
 	if key.Country == "" {
-		errMsg += "\tfield \"country_name\" is missing\n"
+		field := "country_name"
+		errMsg += fmt.Sprintf("\t") + msgPrinter.Sprintf("field \"%s\" is missing", field) + fmt.Sprintf("\n")
 	}
 	if key.State == "" {
-		errMsg += "\tfield \"state_name\" is missing\n"
+		field := "state_name"
+		errMsg += fmt.Sprintf("\t") + msgPrinter.Sprintf("field \"%s\" is missing", field) + fmt.Sprintf("\n")
 	}
 	if key.Locale == "" {
-		errMsg += "\tfield \"locale_name\" is missing\n"
+		field := "locale_name"
+		errMsg += fmt.Sprintf("\t") + msgPrinter.Sprintf("field \"%s\" is missing", field) + fmt.Sprintf("\n")
 	}
 	if errMsg != "" {
-		errMsg += "Please fill these and try again.\n"
+		errMsg += fmt.Sprintf("\t") + msgPrinter.Sprintf("Please fill these and try again.") + fmt.Sprintf("\n")
 		return errors.New(errMsg)
 	}
 	return nil
 }
 
 func checkKeyName(s string) error {
+	msgPrinter := i18n.GetMessagePrinter()
 	for _, r := range s {
 		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
-			return errors.New("Key name can only contain lowercase characters, numbers, and hyphens")
+			return errors.New(msgPrinter.Sprintf("Key name can only contain lowercase characters, numbers, and hyphens"))
 		}
 	}
 	return nil
 }
 
 func checkKeyCountry(s string) error {
-	err := "Country name must be a 2 Letter Country Code"
+	msgPrinter := i18n.GetMessagePrinter()
+	err := msgPrinter.Sprintf("Country name must be a 2 Letter Country Code")
 	if len(s) != 2 {
 		return errors.New(err)
 	}

--- a/cli/sdo/voucher.go
+++ b/cli/sdo/voucher.go
@@ -53,8 +53,8 @@ type InspectOutput struct {
 // hzn sdo voucher inspect <voucher-file>
 func VoucherInspect(voucherFile *os.File) {
 	defer voucherFile.Close()
-	cliutils.Verbose("Inspecting voucher file name: %s", voucherFile.Name())
 	msgPrinter := i18n.GetMessagePrinter()
+	cliutils.Verbose(msgPrinter.Sprintf("Inspecting voucher file name: %s", voucherFile.Name()))
 
 	outStruct := InspectOutput{}
 	voucherBytes, err := ioutil.ReadAll(bufio.NewReader(voucherFile))
@@ -70,7 +70,8 @@ func VoucherInspect(voucherFile *os.File) {
 }
 
 func DeprecatedVoucherInspect(voucherFile *os.File) {
-	fmt.Fprintf(os.Stderr, "WARNING: \"hzn voucher inspect\" is deprecated and will be removed in a future release. Please use \"hzn sdo voucher inspect\" instead.\n")
+	msgPrinter := i18n.GetMessagePrinter()
+	fmt.Fprintf(os.Stderr, msgPrinter.Sprintf("WARNING: \"hzn voucher inspect\" is deprecated and will be removed in a future release. Please use \"hzn sdo voucher inspect\" instead.\n"))
 	VoucherInspect(voucherFile)
 }
 
@@ -79,7 +80,7 @@ func parseVoucherBytes(voucherBytes []byte, outStruct *InspectOutput) error {
 	msgPrinter := i18n.GetMessagePrinter()
 	voucher := Voucher{}
 	if err := json.Unmarshal(voucherBytes, &voucher); err != nil {
-		return errors.New("parsing json: " + err.Error())
+		return errors.New(msgPrinter.Sprintf("parsing json: %s", err.Error()))
 	}
 
 	// Do further parsing of the json, for those parts that have varying types
@@ -108,7 +109,7 @@ func parseVoucherBytes(voucherBytes []byte, outStruct *InspectOutput) error {
 											cliutils.Warning(msgPrinter.Sprintf("base64 decoding %s: %v", t4, err))
 										} else {
 											// The decoded value is a byte array of length 4. Each byte is 1 of the numbers of the IP address
-											cliutils.Verbose("decoding %s yielded %d bytes", t4, n)
+											cliutils.Verbose(msgPrinter.Sprintf("decoding %s yielded %d bytes", t4, n))
 											if n == 4 && len(ipBytes) == 4 {
 												host = fmt.Sprintf("%d.%d.%d.%d", int(ipBytes[0]), int(ipBytes[1]), int(ipBytes[2]), int(ipBytes[3]))
 											}
@@ -129,13 +130,13 @@ func parseVoucherBytes(voucherBytes []byte, outStruct *InspectOutput) error {
 		}
 	}
 	if len(outStruct.Voucher.RendezvousUrls) == 0 {
-		return errors.New("did not find any rendezvous server URLs in the voucher")
+		return errors.New(msgPrinter.Sprintf("did not find any rendezvous server URLs in the voucher"))
 	}
 
 	// Get, decode, and convert the device uuid
 	uu, err := uuid.FromBytes(voucher.Oh.Guid)
 	if err != nil {
-		return errors.New("decoding UUID: " + err.Error())
+		return errors.New(msgPrinter.Sprintf("decoding UUID: %s", err.Error()))
 	}
 	outStruct.Device.Uuid = uu.String()
 
@@ -286,7 +287,8 @@ func VoucherList(org, userCreds, voucher string, namesOnly bool) {
 }
 
 func DeprecatedVoucherList(org, userCreds, voucher string, namesOnly bool) {
-	fmt.Fprintf(os.Stderr, "WARNING: \"hzn voucher list\" is deprecated and will be removed in a future release. Please use \"hzn sdo voucher list\" instead.\n")
+	msgPrinter := i18n.GetMessagePrinter()
+	fmt.Fprintf(os.Stderr, msgPrinter.Sprintf("WARNING: \"hzn voucher list\" is deprecated and will be removed in a future release. Please use \"hzn sdo voucher list\" instead.\n"))
 	VoucherList(org, userCreds, voucher, namesOnly)
 }
 
@@ -303,7 +305,8 @@ func VoucherDownload(org, userCreds, device, outputFile string, overwrite bool) 
 	// Download response body directly to file
 	if outputFile != "" {
 		fileName := cliutils.DownloadToFile(outputFile, device, respBodyBytes, ".json", 0600, overwrite)
-		fmt.Printf("Voucher \"%s\" successfully downloaded to %s from the SDO owner services.\n", device, fileName)
+		msgPrinter.Printf("Voucher \"%s\" successfully downloaded to %s from the SDO owner services.", device, fileName)
+		msgPrinter.Println()
 	} else {
 		// List voucher on screen
 		fmt.Printf("%s\n", respBodyBytes)
@@ -346,7 +349,8 @@ func VoucherImport(org, userCreds string, voucherFile *os.File, example, policyF
 }
 
 func DeprecatedVoucherImport(org, userCreds string, voucherFile *os.File, example, policyFilePath, patternName string) {
-	fmt.Fprintf(os.Stderr, "WARNING: \"hzn voucher import\" is deprecated and will be removed in a future release. Please use \"hzn sdo voucher import\" instead.\n")
+	msgPrinter := i18n.GetMessagePrinter()
+	fmt.Fprintf(os.Stderr, msgPrinter.Sprintf("WARNING: \"hzn voucher import\" is deprecated and will be removed in a future release. Please use \"hzn sdo voucher import\" instead.\n"))
 	VoucherImport(org, userCreds, voucherFile, example, policyFilePath, patternName)
 }
 

--- a/cli/secrets_manager/secrets_manager.go
+++ b/cli/secrets_manager/secrets_manager.go
@@ -46,6 +46,8 @@ func printResponse(resp []byte, structure interface{}) {
 // as long as a 503 is returned. If a code other than 503 is returned, or the number of retries is reached, the code of the final
 // query will be returned.
 func queryWithRetry(query func() int, retryCount, retryInterval int) (httpCode int) {
+	// get message printer
+	msgPrinter := i18n.GetMessagePrinter()
 
 	// on a 503, we want to retry a small number of times
 	for i := 0; i < retryCount; i++ {
@@ -53,7 +55,7 @@ func queryWithRetry(query func() int, retryCount, retryInterval int) (httpCode i
 		if httpCode != 503 {
 			return httpCode
 		}
-		cliutils.Verbose("Vault component not found in the management hub. Retrying...")
+		cliutils.Verbose(msgPrinter.Sprintf("Vault component not found in the management hub. Retrying..."))
 		time.Sleep(time.Duration(retryInterval) * time.Second)
 	}
 

--- a/cli/unregister/unregister.go
+++ b/cli/unregister/unregister.go
@@ -160,7 +160,7 @@ func DeleteHorizonNode(removeNodeUnregister bool, deepClean bool, timeout int) e
 			if timeout != 0 {
 				totalWait = totalWait - channelWait
 				if totalWait <= 0 {
-					return fmt.Errorf("Timeout unregistering the node.")
+					return fmt.Errorf(msgPrinter.Sprintf("Timeout unregistering the node."))
 				}
 				updateStatus := msgPrinter.Sprintf("Timeout in %v seconds ...", totalWait)
 				msgPrinter.Printf("Waiting for Horizon node unregister to complete: %v", updateStatus)

--- a/semanticversion/version.go
+++ b/semanticversion/version.go
@@ -180,7 +180,7 @@ func (self *Version_Expression) Get_end_version() string {
 //
 func (self *Version_Expression) Is_within_range(expr string) (bool, error) {
 	if !IsVersionString(expr) {
-		errorString := fmt.Sprintf("Version_Expression: %v is not a valid version string.", expr)
+		errorString := i18n.GetMessagePrinter().Sprintf("Version_Expression: %v is not a valid version string.", expr)
 		return false, errors.New(errorString)
 	}
 
@@ -247,10 +247,10 @@ func (self *Version_Expression) IntersectsWith(other *Version_Expression) error 
 			return err
 		} else if c == 0 {
 			if !self.start_inclusive && !self.end_inclusive {
-				return fmt.Errorf("No intersection found.")
+				return fmt.Errorf(i18n.GetMessagePrinter().Sprintf("No intersection found."))
 			}
 		} else if c == 1 {
-			return fmt.Errorf("No intersection found.")
+			return fmt.Errorf(i18n.GetMessagePrinter().Sprintf("No intersection found."))
 		}
 	}
 
@@ -263,7 +263,7 @@ func (self *Version_Expression) IntersectsWith(other *Version_Expression) error 
 func (self *Version_Expression) ChangeCeiling(ceiling_version string, inclusive bool) error {
 
 	if len(ceiling_version) == 0 {
-		return fmt.Errorf("The input string is not a version string, it is an empty string.")
+		return fmt.Errorf(i18n.GetMessagePrinter().Sprintf("The input string is not a version string, it is an empty string."))
 	}
 
 	if ceiling_version == INF {
@@ -271,16 +271,16 @@ func (self *Version_Expression) ChangeCeiling(ceiling_version string, inclusive 
 		// always set the false, ignore the inclusive input
 		self.end_inclusive = false
 	} else if !IsVersionString(ceiling_version) {
-		return fmt.Errorf("The input string %v is not a version string.", ceiling_version)
+		return fmt.Errorf(i18n.GetMessagePrinter().Sprintf("The input string %v is not a version string.", ceiling_version))
 	} else {
 
 		if c, err := CompareVersions(ceiling_version, self.start); err != nil {
 			return err
 		} else if c < 0 {
-			return fmt.Errorf("The input ceiling version %v is lower than the start version %v.", ceiling_version, self.start)
+			return fmt.Errorf(i18n.GetMessagePrinter().Sprintf("The input ceiling version %v is lower than the start version %v.", ceiling_version, self.start))
 		} else if c == 0 {
 			if !(inclusive && self.start_inclusive) {
-				return fmt.Errorf("The input ceiling version %v is the same as the start version, but either the start or the end is not inclusive.", ceiling_version)
+				return fmt.Errorf(i18n.GetMessagePrinter().Sprintf("The input ceiling version %v is the same as the start version, but either the start or the end is not inclusive.", ceiling_version))
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Jeff Kinard <jeff@thekinards.com>

## Description

This PR fixes all known instances of English output being printed to console that was not first translated by running through the i18n message printer.

Fixes #3139

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This code is already known to work, so it did not need to be tested. The codebase already runs all hardcoded strings through the message printer, and the changes here do simply that.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

