### PR TITLE
Issue #3151 - Agent removing nmp directory of unsucessful nmps

### DIFF
--- a/nodemanagement/node_management_worker.go
+++ b/nodemanagement/node_management_worker.go
@@ -407,11 +407,11 @@ func (n *NodeManagementWorker) CollectStatus(workingFolderPath string, policyNam
 	if _, err := os.Stat(filePath); err != nil {
 		return fmt.Errorf("Failed to open status file %v for management job %v. Error was: %v", filePath, policyName, err)
 	}
-	if path, err := os.Open(filePath); err != nil {
+	if openPath, err := os.Open(filePath); err != nil {
 		return fmt.Errorf("Failed to open status file %v for management job %v. Errorf was: %v", filePath, policyName, err)
 	} else {
 		contents := exchangecommon.NodeManagementPolicyStatus{}
-		err = json.NewDecoder(path).Decode(&contents)
+		err = json.NewDecoder(openPath).Decode(&contents)
 		if err != nil {
 			return fmt.Errorf("Failed to decode status file %v for management job %v. Error was %v.", filePath, policyName, err)
 		}
@@ -446,10 +446,12 @@ func (n *NodeManagementWorker) CollectStatus(workingFolderPath string, policyNam
 		}
 		eventlog.LogNodeEvent(n.db, persistence.SEVERITY_INFO, persistence.NewMessageMeta(EL_NMP_STATUS_CHANGED, policyName, dbStatus), persistence.EC_NMP_STATUS_UPDATE_NEW, exchange.GetId(n.GetExchangeId()), exchange.GetOrg(n.GetExchangeId()), pattern, configState)
 
+		if dbStatus.AgentUpgrade.Status == exchangecommon.STATUS_SUCCESSFUL {
 		// Status has been read-in and updated sucessfully. Can now remove the working dirctory for the job.
-		err = os.RemoveAll(workingFolderPath)
-		if err != nil {
-			return fmt.Errorf("Failed to remove the working directory for management job %v. Error was: %v", policyName, err)
+			err = os.RemoveAll(path.Join(workingFolderPath,policyName))
+			if err != nil {
+				return fmt.Errorf("Failed to remove the working directory for management job %v. Error was: %v", policyName, err)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested reading in sucessful and unsuccessful status files with e2edev agent

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
