### PR TITLE
Issue 3166 - Add NMP CLI tests to e2edev

### DIFF
--- a/api/path_management_nextjob.go
+++ b/api/path_management_nextjob.go
@@ -30,8 +30,7 @@ func FindManagementNextJobForOutput(jobType, ready string, errorHandler ErrorHan
 			}
 			// Get all statuses
 		} else if ready == "" {
-			var errHandled bool
-			if errHandled, managementStatuses = FindManagementStatusForOutput("", "", errorHandler, db); errHandled {
+			if managementStatuses, err = persistence.FindAllNMPStatus(db); err != nil {
 				return false, nil
 			}
 		} else {

--- a/api/path_management_nextjob_test.go
+++ b/api/path_management_nextjob_test.go
@@ -138,7 +138,7 @@ func create_test_status(status, dir string) *exchangecommon.NodeManagementPolicy
 	case exchangecommon.STATUS_DOWNLOADED:
 		return &exchangecommon.NodeManagementPolicyStatus{
 			AgentUpgrade: &exchangecommon.AgentUpgradePolicyStatus{
-				ScheduledTime:        time.Now().Format(time.RFC3339),
+				ScheduledTime:        time.Now().Format(time.RFC3339Nano),
 				ActualStartTime:      "",
 				CompletionTime:       "",
 				Status:               exchangecommon.STATUS_DOWNLOADED,
@@ -149,7 +149,7 @@ func create_test_status(status, dir string) *exchangecommon.NodeManagementPolicy
 	case exchangecommon.STATUS_NEW:
 		return &exchangecommon.NodeManagementPolicyStatus{
 			AgentUpgrade: &exchangecommon.AgentUpgradePolicyStatus{
-				ScheduledTime:        time.Now().Format(time.RFC3339),
+				ScheduledTime:        time.Now().Format(time.RFC3339Nano),
 				ActualStartTime:      "",
 				CompletionTime:       "",
 				Status:               exchangecommon.STATUS_NEW,
@@ -160,8 +160,8 @@ func create_test_status(status, dir string) *exchangecommon.NodeManagementPolicy
 	case exchangecommon.STATUS_INITIATED:
 		return &exchangecommon.NodeManagementPolicyStatus{
 			AgentUpgrade: &exchangecommon.AgentUpgradePolicyStatus{
-				ScheduledTime:        time.Now().Format(time.RFC3339),
-				ActualStartTime:      time.Now().Format(time.RFC3339),
+				ScheduledTime:        time.Now().Format(time.RFC3339Nano),
+				ActualStartTime:      time.Now().Format(time.RFC3339Nano),
 				CompletionTime:       "",
 				Status:               exchangecommon.STATUS_INITIATED,
 				ErrorMessage:         "",
@@ -171,9 +171,9 @@ func create_test_status(status, dir string) *exchangecommon.NodeManagementPolicy
 	case exchangecommon.STATUS_SUCCESSFUL:
 		return &exchangecommon.NodeManagementPolicyStatus{
 			AgentUpgrade: &exchangecommon.AgentUpgradePolicyStatus{
-				ScheduledTime:        time.Now().Format(time.RFC3339),
-				ActualStartTime:      time.Now().Format(time.RFC3339),
-				CompletionTime:       time.Now().Format(time.RFC3339),
+				ScheduledTime:        time.Now().Format(time.RFC3339Nano),
+				ActualStartTime:      time.Now().Format(time.RFC3339Nano),
+				CompletionTime:       time.Now().Format(time.RFC3339Nano),
 				Status:               exchangecommon.STATUS_SUCCESSFUL,
 				ErrorMessage:         "",
 				BaseWorkingDirectory: dir,
@@ -182,8 +182,8 @@ func create_test_status(status, dir string) *exchangecommon.NodeManagementPolicy
 	case exchangecommon.STATUS_DOWNLOAD_FAILED:
 		return &exchangecommon.NodeManagementPolicyStatus{
 			AgentUpgrade: &exchangecommon.AgentUpgradePolicyStatus{
-				ScheduledTime:        time.Now().Format(time.RFC3339),
-				ActualStartTime:      time.Now().Format(time.RFC3339),
+				ScheduledTime:        time.Now().Format(time.RFC3339Nano),
+				ActualStartTime:      time.Now().Format(time.RFC3339Nano),
 				CompletionTime:       "",
 				Status:               exchangecommon.STATUS_DOWNLOAD_FAILED,
 				ErrorMessage:         "Download failed.",
@@ -193,8 +193,8 @@ func create_test_status(status, dir string) *exchangecommon.NodeManagementPolicy
 	case exchangecommon.STATUS_FAILED_JOB:
 		return &exchangecommon.NodeManagementPolicyStatus{
 			AgentUpgrade: &exchangecommon.AgentUpgradePolicyStatus{
-				ScheduledTime:        time.Now().Format(time.RFC3339),
-				ActualStartTime:      time.Now().Format(time.RFC3339),
+				ScheduledTime:        time.Now().Format(time.RFC3339Nano),
+				ActualStartTime:      time.Now().Format(time.RFC3339Nano),
 				CompletionTime:       "",
 				Status:               exchangecommon.STATUS_FAILED_JOB,
 				ErrorMessage:         "Failed job.",
@@ -204,7 +204,7 @@ func create_test_status(status, dir string) *exchangecommon.NodeManagementPolicy
 	case exchangecommon.STATUS_UNKNOWN:
 		return &exchangecommon.NodeManagementPolicyStatus{
 			AgentUpgrade: &exchangecommon.AgentUpgradePolicyStatus{
-				ScheduledTime:        time.Now().Format(time.RFC3339),
+				ScheduledTime:        time.Now().Format(time.RFC3339Nano),
 				ActualStartTime:      "",
 				CompletionTime:       "",
 				Status:               exchangecommon.STATUS_UNKNOWN,

--- a/cli/exchange/nmp.go
+++ b/cli/exchange/nmp.go
@@ -129,21 +129,22 @@ func NMPAdd(org, credToUse, nmpName, jsonFilePath string, appliesTo, noConstrain
 		//try to update the existing policy
 		httpCode = cliutils.ExchangePutPost("Exchange", http.MethodPut, exchUrl, "orgs/"+nmpOrg+"/managementpolicies"+cliutils.AddSlash(nmpName), cliutils.OrgAndCreds(org, credToUse), []int{201, 404}, nmpFile, nil)
 		if httpCode == 201 {
-			msgPrinter.Printf("Node management policy: %v/%v updated in the Horizon Exchange", nmpOrg, nmpName)
+			msgPrinter.Printf("Node management policy %v/%v updated in the Horizon Exchange", nmpOrg, nmpName)
 			msgPrinter.Println()
 		} else if httpCode == 404 {
 			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Cannot create node management policy %v/%v: %v", nmpOrg, nmpName, resp.Msg))
 		}
 	} else if !cliutils.IsDryRun() {
-		msgPrinter.Printf("Node management policy: %v/%v added in the Horizon Exchange", nmpOrg, nmpName)
+		msgPrinter.Printf("Node management policy %v/%v added in the Horizon Exchange", nmpOrg, nmpName)
 		msgPrinter.Println()
 	}
 	if appliesTo {
 		nodes := determineCompatibleNodes(org, credToUse, nmpName, nmpFile)
+		output := "[]"
 		if nodes != nil && len(nodes) > 0 {
-			output := cliutils.MarshalIndent(nodes, "exchange nmp add")
-			fmt.Printf(output)
+			output = cliutils.MarshalIndent(nodes, "exchange nmp add")
 		}
+		fmt.Printf(output)
 		msgPrinter.Println()
 	}
 }
@@ -165,9 +166,7 @@ func NMPRemove(org, credToUse, nmpName string, force bool) {
 	if httpCode == 404 {
 		cliutils.Fatal(cliutils.NOT_FOUND, msgPrinter.Sprintf("Node management policy %s not found in org %s", nmpName, nmpOrg))
 	} else if httpCode == 204 {
-		msgPrinter.Printf("Removing node management policy %v/%v from the exchange.", nmpOrg, nmpName)
-		msgPrinter.Println()
-		msgPrinter.Printf("Node management policy %v/%v removed", nmpOrg, nmpName)
+		msgPrinter.Printf("Node management policy %v/%v removed from the Horizon Exchange.", nmpOrg, nmpName)
 		msgPrinter.Println()
 	}
 }

--- a/test/gov/apireg.sh
+++ b/test/gov/apireg.sh
@@ -90,6 +90,13 @@ else
     constraint2="$constraint2 || NOK8S == false"
 fi
 
+constraint3=""
+if [ "$NOAGENTAUTO" == "1" ]; then 
+    constraint3="NOAGENTAUTO==true"
+else
+    constraint3="NOAGENTAUTO==false"
+fi
+
 read -d '' newhznpolicy <<EOF
 {
   "deployment": {
@@ -104,6 +111,20 @@ read -d '' newhznpolicy <<EOF
     "constraints": [
       "iame2edev == true",
       "$constraint2"
+    ]
+  },
+  "management": {
+    "properties": [
+      {
+        "name":"purpose","value":"nmp-testing"
+      },
+      {
+        "name":"group","value":"bluenode"
+      }
+    ],
+    "constraints": [
+      "iame2edev == true",
+      "$constraint3"
     ]
   }
 }

--- a/test/gov/gov-combined.sh
+++ b/test/gov/gov-combined.sh
@@ -427,13 +427,13 @@ if [ "$NOSDO" != "1" ] && [ "$TESTFAIL" != "1" ]; then
   fi
 fi
 
-# if [ "$NOAGENTAUTO" != "1" ] && [ "$TESTFAIL" != "1" ]; then
-#   ./hzn_nmp.sh
-#   if [ $? -ne 0 ]; then
-#     echo "Agent Auto Upgrade test using hzn command failure."
-#     exit 1
-#   fi
-# fi
+if [ "$NOAGENTAUTO" != "1" ] && [ "$TESTFAIL" != "1" ]; then
+  ./hzn_nmp.sh
+  if [ $? -ne 0 ]; then
+    echo "Agent Auto Upgrade test using hzn command failure."
+    exit 1
+  fi
+fi
 
 if [ "$NOSURFERR" != "1" ] && [ "$TESTFAIL" != "1" ] && [ ${REMOTE_HUB} -eq 0 ]; then
   if [ "$TEST_PATTERNS" == "sall" ] || [ "$TEST_PATTERNS" == "" ] && [ "$NOLOOP" == "1" ] && [ "$NONS" == "" ] && [ "$NOGPS" == "" ] && [ "$NOPWS" == "" ] && [ "$NOLOC" == "" ] && [ "$NOHELLO" == "" ] && [ "$NOK8S" == "" ]; then

--- a/test/gov/hzn_nmp.sh
+++ b/test/gov/hzn_nmp.sh
@@ -7,23 +7,28 @@ cat <<'EOF' > /tmp/nmp_example_1.json
 {
   "label": "nmp test 1",
   "description": "test nmp 1",
-  "properties": [
-      {
-          "name": "name_value",
-          "value": "value_value"
-      }
-  ],
   "constraints": [
-      "myproperty == myvalue"
+    "purpose==nmp-testing"
+  ],
+  "properties": [
+    {
+	  "name": "iame2edev",
+      "value": true
+	},
+	{
+	  "name": "NOAGENTAUTO",
+	  "value": false
+	}
   ],
   "patterns": [
-      "e2edev@somecomp.com/test_pattern"
+    "e2edev@somecomp.com/test_pattern"
   ],
   "enabled": false,
+  "start": "now",
+  "startWindow": 0,
   "agentUpgradePolicy": {
-      "atLeastVersion": "current",
-      "start": "now",
-      "duration": 0
+	"manifest": "manifest_1.0.0",
+	"allowDowngrade": false
   }
 }
 EOF
@@ -33,19 +38,24 @@ cat <<'EOF' > /tmp/nmp_example_2.json
   "label": "nmp test 2",
   "description": "test nmp 2",
   "properties": [
-      {
-          "name": "name_value",
-          "value": "value_value"
-      }
+	{
+	  "name": "iame2edev",
+      "value": true
+	},
+	{
+	  "name": "NOAGENTAUTO",
+	  "value": false
+	}
   ],
   "constraints": [
-      "myproperty == myvalue"
+    "purpose==nmp-testing"
   ],
   "enabled": true,
+  "start": "now",
+  "startWindow": 0,
   "agentUpgradePolicy": {
-      "atLeastVersion": "current",
-      "start": "now",
-      "duration": 0
+    "manifest": "manifest_2.0.0",
+    "allowDowngrade": false
   }
 }
 EOF
@@ -57,133 +67,163 @@ cat <<'EOF' > /tmp/nmp_example_3.json
 }
 EOF
 
+cat <<'EOF' > /tmp/nmp_example_4.json
+{
+  "label": "",
+  "enabled": false
+}
+EOF
+
 read -r -d '' inspectSampleNMP <<'EOF'
 {
   "label": "",                               /* A short description of the policy. */
   "description": "",                         /* (Optional) A much longer description of the policy. */
+  "constraints": [                           /* (Optional) A list of constraint expressions of the form <property name> <operator> <property value>, */
+    "myproperty == myvalue"                  /* separated by boolean operators AND (&&) or OR (||).*/
+  ],
   "properties": [                            /* (Optional) A list of policy properties that describe this policy. */
     {
       "name": "",
       "value": null
     }
   ],
-  "constraints": [                           /* (Optional) A list of constraint expressions of the form <property name> <operator> <property value>, */
-    "myproperty == myvalue"                  /* separated by boolean operators AND (&&) or OR (||).*/
-  ],
   "patterns": [                              /* (Optional) This policy applies to nodes using one of these patterns. */
     ""
   ],
   "enabled": false,                          /* Is this policy enabled or disabled. */
+  "start": "<RFC3339 timestamp> | now",      /* When to start an upgrade, default "now". */
+  "startWindow": 0,                          /* Enable agents to randomize upgrade start time within start + startWindow, default 0. */
   "agentUpgradePolicy": {                    /* (Optional) Assertions on how the agent should update itself. */
-    "atLeastVersion": "<version> | current", /* Specify the minimum agent version these nodes should have, default "current". */
-    "start": "<RFC3339 timestamp> | now",    /* When to start an upgrade, default "now". */
-    "duration": 0                            /* Enable agents to randomize upgrade start time within start + duration, default 0. */
+    "manifest": "",                          /* The manifest file containing the software, config and cert files to upgrade. */
+    "allowDowngrade": false                  /* Is this policy allowed to perform a downgrade to a previous version. */
   }
 }
 EOF
 
-read -r -d '' inspectSingleExchangeNMP <<'EOF'
+cat <<'EOF' > /tmp/nmp_status_1.json
 {
-  "NMP_ORG_ID/test-nmp-1": {
-    "owner": "NMP_ORG_ID/NMP_USER_AUTH",
-    "label": "nmp test 2",
-    "description": "test nmp 2",
-    "constraints": [
-        "myproperty == myvalue"
-    ],
-    "properties": [
-        {
-            "name": "name_value",
-            "value": "value_value"
-        }
-    ],
-    "patterns": [],
-    "enabled": true,
-    "agentUpgradePolicy": {
-        "atLeastVersion": "current",
-        "start": "now",
-        "duration": 0
+  "agentUpgradePolicyStatus": {
+    "scheduledTime": "0001-01-01T00:00:00Z",
+    "startTime": "",
+    "endTime": "",
+    "upgradedVersions": {
+      "softwareVersion": "1.0.0",
+      "certVersion": "2.0.0",
+      "configVersion": "3.0.0"
     },
-    "lastUpdated":
-EOF
-
-read -r -d '' inspectDoubleExchangeNMP1 <<'EOF'
-{
-  "NMP_ORG_ID/test-nmp-1": {
-    "owner": "NMP_ORG_ID/NMP_USER_AUTH",
-    "label": "nmp test 2",
-    "description": "test nmp 2",
-    "constraints": [
-        "myproperty == myvalue"
-    ],
-    "properties": [
-        {
-            "name": "name_value",
-            "value": "value_value"
-        }
-    ],
-    "patterns": [],
-    "enabled": true,
-    "agentUpgradePolicy": {
-        "atLeastVersion": "current",
-        "start": "now",
-        "duration": 0
-    },
-    "lastUpdated": ""
-}}
-EOF
-
-read -r -d '' inspectDoubleExchangeNMP2 <<'EOF'
-"NMP_ORG_ID/test-nmp-2": {
-    "owner": "NMP_ORG_ID/NMP_USER_AUTH",
-    "label": "nmp test 3",
-    "description": "",
-    "constraints": [],
-    "properties": [],
-    "patterns": [],
-    "enabled": false,
-    "agentUpgradePolicy": {
-        "atLeastVersion": "",
-        "start": "",
-        "duration": 0
-    },
-    "lastUpdated":
+    "status": "waiting",
+    "errorMessage": ""
+  }
+}
 EOF
 
 # Get HZN_ORG_ID and HZN_EXCHANGE_USER_AUTH, if they are set, otherwise set
-# to e2edev defaults
-if [ -z "$HZN_ORG_ID" ]
+# to userdev defaults
+if [[ -z "$HZN_ORG_ID" || "$HZN_ORG_ID" == *"e2edev@somecomp.com"* ]]
 then
-	NMP_ORG_ID="e2edev@somecomp.com"
+	NMP_ORG_ID="userdev"
 else
 	NMP_ORG_ID=$HZN_ORG_ID
 fi
-if [ -z "$HZN_EXCHANGE_USER_AUTH" ]
+if [[ -z "$HZN_EXCHANGE_USER_AUTH" || "$HZN_EXCHANGE_USER_AUTH" == *"e2edevadmin:e2edevadminpw"* ]]
 then
-	NMP_USER_AUTH="e2edevadmin"
+	NMP_EXCHANGE_USER_AUTH="userdevadmin:userdevadminpw"
 else
-	NMP_USER_AUTH=${HZN_EXCHANGE_USER_AUTH#*/}
+	NMP_EXCHANGE_USER_AUTH=${HZN_EXCHANGE_USER_AUTH#*/}
 fi
-
-# fill in key inpections with correct credentials
-inspectSingleExchangeNMP="${inspectSingleExchangeNMP//NMP_ORG_ID/$NMP_ORG_ID}"
-inspectSingleExchangeNMP="${inspectSingleExchangeNMP//NMP_USER_AUTH/${NMP_USER_AUTH%:*}}"
-inspectDoubleExchangeNMP1="${inspectDoubleExchangeNMP1//NMP_ORG_ID/$NMP_ORG_ID}"
-inspectDoubleExchangeNMP1="${inspectDoubleExchangeNMP1//NMP_USER_AUTH/${NMP_USER_AUTH%:*}}"
-inspectDoubleExchangeNMP2="${inspectDoubleExchangeNMP2//NMP_ORG_ID/$NMP_ORG_ID}"
-inspectDoubleExchangeNMP2="${inspectDoubleExchangeNMP2//NMP_USER_AUTH/${NMP_USER_AUTH%:*}}"
+if [[ -z "$HZN_EXCHANGE_URL" ]]
+then
+	HZN_EXCHANGE_URL="http://localhost:3090/v1"
+fi
 
 HZN_ORG_ID_SAVE=$HZN_ORG_ID
 HZN_EXCHANGE_USER_AUTH_SAVE=$HZN_EXCHANGE_USER_AUTH
 HZN_EXCHANGE_URL_SAVE=$HZN_EXCHANGE_URL
 
-cleanup() {
+function cleanup() {
     rm -f /tmp/nmp_example_1.json &> /dev/null
     rm -f /tmp/nmp_example_2.json &> /dev/null
     rm -f /tmp/nmp_example_3.json &> /dev/null
-    hzn ex nmp rm -f test-nmp-1 &> /dev/null
-    hzn ex nmp rm -f test-nmp-2 &> /dev/null
-    hzn ex nmp rm -f test-nmp-3 &> /dev/null
+	rm -f /tmp/nmp_example_4.json &> /dev/null
+	rm -f /tmp/nmp_status_1.json &> /dev/null
+    hzn ex nmp rm -f test-nmp-1 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH &> /dev/null
+    hzn ex nmp rm -f test-nmp-2 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH &> /dev/null
+    hzn ex nmp rm -f test-nmp-3 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH &> /dev/null
+}
+
+function test_env_variables() {
+	local cmd_to_test
+	cmd_to_test=$1
+	local require_exchange_cred
+	require_exchange_cred="$2"
+
+	echo -e "${PREFIX} Testing '$cmd_to_test' without HZN_EXCHANGE_USER_AUTH set"
+	unset HZN_EXCHANGE_USER_AUTH
+	cmdOutput=$($cmd_to_test 2>&1)
+	rc=$?
+	if [[ $rc -eq 0 && $require_exchange_cred == "false" ]] || [[ $rc -ne 0 && $require_exchange_cred == "true" ]]; then
+		echo -e "${PREFIX} completed."
+	else
+		echo -e "${PREFIX} Failed: Wrong error response from '$cmd_to_test' without HZN_EXCHANGE_USER_AUTH set: exit code: $rc, output: $cmdOutput."
+		cleanup
+		exit 1
+	fi
+	export HZN_EXCHANGE_USER_AUTH="$HZN_EXCHANGE_USER_AUTH_SAVE"
+
+	echo -e "${PREFIX} Testing '$cmd_to_test' with incorrect HZN_EXCHANGE_USER_AUTH set"
+	export HZN_EXCHANGE_USER_AUTH=fakeuser:fakepw
+	cmdOutput=$($cmd_to_test 2>&1)
+	rc=$?
+	if [[ $rc -eq 0 && $require_exchange_cred == "false" ]] || [[ $rc -ne 0 && $require_exchange_cred == "true" ]]; then
+		echo -e "${PREFIX} completed."
+	else
+		echo -e "${PREFIX} Failed: Wrong error response from '$cmd_to_test' with incorrect HZN_EXCHANGE_USER_AUTH set: exit code: $rc, output: $cmdOutput."
+		cleanup
+		exit 1
+	fi
+	export HZN_EXCHANGE_USER_AUTH="$HZN_EXCHANGE_USER_AUTH_SAVE"
+
+	echo -e "${PREFIX} Testing '$cmd_to_test' without HZN_ORG_ID set"
+	unset HZN_ORG_ID
+	cmdOutput=$($cmd_to_test 2>&1)
+	rc=$?
+	if [[ $rc -eq 0 && $require_exchange_cred == "false" ]] || [[ $rc -ne 0 && $require_exchange_cred == "true" ]]; then
+		echo -e "${PREFIX} completed."
+	else
+		echo -e "${PREFIX} Failed: Wrong error response from '$cmd_to_test' with incorrect HZN_ORG_ID set: exit code: $rc, output: $cmdOutput."
+		cleanup
+		exit 1
+	fi
+	export HZN_ORG_ID=$HZN_ORG_ID_SAVE
+
+	echo -e "${PREFIX} Testing '$cmd_to_test' with incorrect HZN_ORG_ID set"
+	export HZN_ORG_ID=fakeorg
+	cmdOutput=$($cmd_to_test 2>&1)
+	rc=$?
+	if [[ $rc -eq 0 && $require_exchange_cred == "false" ]] || [[ $rc -ne 0 && $require_exchange_cred == "true" ]]; then
+		echo -e "${PREFIX} completed."
+	else
+		echo -e "${PREFIX} Failed: Wrong error response from '$cmd_to_test' without HZN_ORG_ID set: exit code: $rc, output: $cmdOutput."
+		cleanup
+		exit 1
+	fi
+	export HZN_ORG_ID=$HZN_ORG_ID_SAVE
+
+	echo -e "${PREFIX} Testing '$cmd_to_test' without HZN_EXCHANGE_URL set"
+	unset HZN_EXCHANGE_URL
+	mv /etc/default/horizon /etc/default/horizonOLD &> /dev/null
+	cmdOutput=$($cmd_to_test 2>&1)
+	rc=$?
+	if [[ $rc -eq 0 && $require_exchange_cred == "false" ]] || [[ $rc -ne 0 && $require_exchange_cred == "true" ]]; then
+		echo -e "${PREFIX} completed."
+		mv /etc/default/horizonOLD /etc/default/horizon &> /dev/null
+	else
+		echo -e "${PREFIX} Failed: Wrong error response from '$cmd_to_test' without HZN_EXCHANGE_URL set: exit code: $rc, output: $cmdOutput."
+		mv /etc/default/horizonOLD /etc/default/horizon &> /dev/null
+		cleanup
+		exit 1
+	fi
+	export HZN_EXCHANGE_URL=$HZN_EXCHANGE_URL_SAVE
 }
 
 # -----------------------
@@ -191,74 +231,7 @@ cleanup() {
 # -----------------------
 
 CMD_PREFIX="hzn exchange nmp new"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_EXCHANGE_USER_AUTH set"
-unset HZN_EXCHANGE_USER_AUTH
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 0 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_EXCHANGE_USER_AUTH set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_USER_AUTH="$HZN_EXCHANGE_USER_AUTH_SAVE"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect HZN_EXCHANGE_USER_AUTH set"
-export HZN_EXCHANGE_USER_AUTH=fakeuser:fakepw
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 0 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect HZN_EXCHANGE_USER_AUTH set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_USER_AUTH="$HZN_EXCHANGE_USER_AUTH_SAVE"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_ORG_ID set"
-unset HZN_ORG_ID
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 0 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect HZN_ORG_ID set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_ORG_ID=$HZN_ORG_ID_SAVE
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect HZN_ORG_ID set"
-export HZN_ORG_ID=fakeorg
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 0 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_ORG_ID set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_ORG_ID=$HZN_ORG_ID_SAVE
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_EXCHANGE_URL set"
-unset HZN_EXCHANGE_URL
-mv /etc/default/horizon /etc/default/horizonOLD &> /dev/null
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 0 ]]; then
-	echo -e "${PREFIX} completed."
-	mv /etc/default/horizonOLD /etc/default/horizon &> /dev/null
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_EXCHANGE_URL set: exit code: $rc, output: $cmdOutput."
-	mv /etc/default/horizonOLD /etc/default/horizon &> /dev/null
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_URL=$HZN_EXCHANGE_URL_SAVE
+test_env_variables "$CMD_PREFIX" false
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX'"
 cmdOutput=$($CMD_PREFIX 2>&1)
@@ -266,9 +239,9 @@ rc=$?
 if [[ $rc -eq 0 && "$cmdOutput" == *"$inspectSampleNMP"* ]]; then
 	echo -e "${PREFIX} completed."
 else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX': exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
+ 	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX': exit code: $rc, output: $cmdOutput."
+ 	cleanup
+ 	exit 1
 fi
 
 # -----------------------
@@ -276,77 +249,10 @@ fi
 # -----------------------
 
 CMD_PREFIX="hzn exchange nmp add"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_EXCHANGE_USER_AUTH set"
-unset HZN_EXCHANGE_USER_AUTH
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 1 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_EXCHANGE_USER_AUTH set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_USER_AUTH="$HZN_EXCHANGE_USER_AUTH_SAVE"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect HZN_EXCHANGE_USER_AUTH set"
-export HZN_EXCHANGE_USER_AUTH=fakeuser:fakepw
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 1 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect HZN_EXCHANGE_USER_AUTH set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_USER_AUTH="$HZN_EXCHANGE_USER_AUTH_SAVE"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_ORG_ID set"
-unset HZN_ORG_ID
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 1 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect HZN_ORG_ID set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_ORG_ID=$HZN_ORG_ID_SAVE
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect HZN_ORG_ID set"
-export HZN_ORG_ID=fakeorg
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 1 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_ORG_ID set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_ORG_ID=$HZN_ORG_ID_SAVE
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_EXCHANGE_URL set"
-unset HZN_EXCHANGE_URL
-mv /etc/default/horizon /etc/default/horizonOLD &> /dev/null
-cmdOutput=$($CMD_PREFIX test-nmp -f /tmp/nmp_example_1.json 2>&1)
-rc=$?
-if [[ $rc -eq 7 ]]; then
-	echo -e "${PREFIX} completed."
-	mv /etc/default/horizonOLD /etc/default/horizon &> /dev/null
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_EXCHANGE_URL set: exit code: $rc, output: $cmdOutput."
-	mv /etc/default/horizonOLD /etc/default/horizon &> /dev/null
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_URL=$HZN_EXCHANGE_URL_SAVE
+test_env_variables "$CMD_PREFIX fakenmp -f /tmp/nmp_example_1.json" true
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' when constraints AND pattern(s) are defined"
-cmdOutput=$($CMD_PREFIX test-nmp-1 -f /tmp/nmp_example_1.json 2>&1)
+cmdOutput=$($CMD_PREFIX test-nmp-1 -f /tmp/nmp_example_1.json -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 5 && "$cmdOutput" == *"invalid-input, you can not specify both constraints and patterns"* ]]; then
 	echo -e "${PREFIX} completed."
@@ -357,9 +263,9 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX'"
-cmdOutput=$($CMD_PREFIX test-nmp-2 -f /tmp/nmp_example_2.json 2>&1)
+cmdOutput=$($CMD_PREFIX test-nmp-2 -f /tmp/nmp_example_2.json -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
-if [[ $rc -eq 0 && "$cmdOutput" == *"Node management policy:"*"test-nmp-2"*"in the Horizon Exchange"* ]]; then
+if [[ $rc -eq 0 && "$cmdOutput" == *"Node management policy $NMP_ORG_ID/test-nmp-2 added in the Horizon Exchange"* ]]; then
 	echo -e "${PREFIX} completed."
 else
 	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX': exit code: $rc, output: $cmdOutput."
@@ -368,9 +274,9 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' when given nmp already exists in the Exchange"
-cmdOutput=$($CMD_PREFIX test-nmp-2 -f /tmp/nmp_example_2.json 2>&1)
+cmdOutput=$($CMD_PREFIX test-nmp-2 -f /tmp/nmp_example_2.json -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
-if [[ $rc -eq 0 && "$cmdOutput" == *"Node management policy:"*"test-nmp-2"*"in the Horizon Exchange"* ]]; then
+if [[ $rc -eq 0 && "$cmdOutput" == *"Node management policy $NMP_ORG_ID/test-nmp-2 updated in the Horizon Exchange"* ]]; then
 	echo -e "${PREFIX} completed."
 else
 	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' when given nmp already exists in the Exchange: exit code: $rc, output: $cmdOutput."
@@ -379,9 +285,9 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' without constraints defined and --no-constraints flag set"
-cmdOutput=$($CMD_PREFIX test-nmp-3 -f /tmp/nmp_example_3.json --no-constraints 2>&1)
+cmdOutput=$($CMD_PREFIX test-nmp-3 -f /tmp/nmp_example_3.json --no-constraints -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
-if [[ $rc -eq 0 && "$cmdOutput" == *"Node management policy:"*"test-nmp-3"*"in the Horizon Exchange"* ]]; then
+if [[ $rc -eq 0 && "$cmdOutput" == *"Node management policy $NMP_ORG_ID/test-nmp-3 added in the Horizon Exchange"* ]]; then
 	echo -e "${PREFIX} completed."
 else
 	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without constraints defined and --no-constraints flag set: exit code: $rc, output: $cmdOutput."
@@ -390,7 +296,7 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' without constraints defined and without --no-constraints flag"
-cmdOutput=$($CMD_PREFIX test-nmp-3 -f /tmp/nmp_example_3.json 2>&1)
+cmdOutput=$($CMD_PREFIX test-nmp-3 -f /tmp/nmp_example_3.json -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 1 && "$cmdOutput" == *"Error: The node management policy has no constraints which might result in the management policy being deployed to all nodes. Please specify --no-constraints to confirm that this is acceptable."* ]]; then
 	echo -e "${PREFIX} completed."
@@ -401,7 +307,7 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' without --json-file flag"
-cmdOutput=$($CMD_PREFIX 2>&1)
+cmdOutput=$($CMD_PREFIX -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 1 && "$cmdOutput" == *"rror: required flag --json-file not provided"* ]]; then
 	echo -e "${PREFIX} completed."
@@ -412,7 +318,7 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' without nmp-name argument"
-cmdOutput=$($CMD_PREFIX -f /tmp/nmp_example_2.json 2>&1)
+cmdOutput=$($CMD_PREFIX -f /tmp/nmp_example_2.json -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 1 && "$cmdOutput" == *"rror: required argument"*"not provided"* ]]; then
 	echo -e "${PREFIX} completed."
@@ -422,84 +328,50 @@ else
 	exit 1
 fi
 
+echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect format"
+cmdOutput=$($CMD_PREFIX test-nmp-4 -f /tmp/nmp_example_4.json -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 1 && "$cmdOutput" == *"Incorrect node management policy format"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect format: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --appliesTo"
+cmdOutput=$($CMD_PREFIX test-nmp-2 -f /tmp/nmp_example_2.json --appliesTo --dry-run -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"["*"$NMP_ORG_ID/an12345"*"]"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --appliesTo: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --appliesTo when NMP is not compatible with any nodes"
+cmdOutput=$($CMD_PREFIX test-nmp-3 -f /tmp/nmp_example_3.json --no-constraints --appliesTo --dry-run -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"[]"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --appliesTo when NMP is not compatible with any nodes: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
 # -----------------------
 # ------ NMP REMOVE -----
 # -----------------------
 
 CMD_PREFIX="hzn exchange nmp remove"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_EXCHANGE_USER_AUTH set"
-unset HZN_EXCHANGE_USER_AUTH
-cmdOutput=$($CMD_PREFIX test-nmp -f 2>&1)
-rc=$?
-if [[ $rc -eq 1 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_EXCHANGE_USER_AUTH set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_USER_AUTH="$HZN_EXCHANGE_USER_AUTH_SAVE"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect HZN_EXCHANGE_USER_AUTH set"
-export HZN_EXCHANGE_USER_AUTH=fakeuser:fakepw
-cmdOutput=$($CMD_PREFIX test-nmp -f 2>&1)
-rc=$?
-if [[ $rc -eq 5 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect HZN_EXCHANGE_USER_AUTH set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_USER_AUTH="$HZN_EXCHANGE_USER_AUTH_SAVE"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_ORG_ID set"
-unset HZN_ORG_ID
-cmdOutput=$($CMD_PREFIX test-nmp -f 2>&1)
-rc=$?
-if [[ $rc -eq 1 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect HZN_ORG_ID set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_ORG_ID=$HZN_ORG_ID_SAVE
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect HZN_ORG_ID set"
-export HZN_ORG_ID=fakeorg
-cmdOutput=$($CMD_PREFIX test-nmp -f 2>&1)
-rc=$?
-if [[ $rc -eq 5 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_ORG_ID set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_ORG_ID=$HZN_ORG_ID_SAVE
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_EXCHANGE_URL set"
-unset HZN_EXCHANGE_URL
-mv /etc/default/horizon /etc/default/horizonOLD &> /dev/null
-cmdOutput=$($CMD_PREFIX test-nmp -f 2>&1)
-rc=$?
-if [[ $rc -eq 7 ]]; then
-	echo -e "${PREFIX} completed."
-	mv /etc/default/horizonOLD /etc/default/horizon &> /dev/null
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_EXCHANGE_URL set: exit code: $rc, output: $cmdOutput."
-	mv /etc/default/horizonOLD /etc/default/horizon &> /dev/null
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_URL=$HZN_EXCHANGE_URL_SAVE
+test_env_variables "$CMD_PREFIX fakenmp -f" true
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' -f"
-cmdOutput=$($CMD_PREFIX test-nmp-2 -f 2>&1)
+cmdOutput=$($CMD_PREFIX test-nmp-2 -f -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
-if [[ $rc -eq 0 && "$cmdOutput" == *"Removing node management policy"*"and re-evaluating all agreements"*"Node management policy"*"/test-nmp-2 removed"* ]]; then
+if [[ $rc -eq 0 && "$cmdOutput" == *"Node management policy $NMP_ORG_ID/test-nmp-2 removed from the Horizon Exchange"* ]]; then
 	echo -e "${PREFIX} completed."
 else
 	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX': exit code: $rc, output: $cmdOutput."
@@ -508,9 +380,9 @@ else
 fi
 
 echo -e "${PREFIX} Removing remaining NMP's"
-cmdOutput=$($CMD_PREFIX test-nmp-3 -f 2>&1)
+cmdOutput=$($CMD_PREFIX test-nmp-3 -f -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
-if [[ $rc -eq 0 && "$cmdOutput" == *"Removing node management policy"*"and re-evaluating all agreements"*"Node management policy"*"/test-nmp-3 removed"* ]]; then
+if [[ $rc -eq 0 && "$cmdOutput" == *"Node management policy $NMP_ORG_ID/test-nmp-3 removed from the Horizon Exchange"* ]]; then
 	echo -e "${PREFIX} completed."
 else
 	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX': exit code: $rc, output: $cmdOutput."
@@ -519,7 +391,7 @@ else
 fi
 
 echo -e "${PREFIX} Checking that NMP's have been removed from the Exchange..."
-cmdOutput=$(hzn ex nmp ls 2>&1)
+cmdOutput=$(hzn ex nmp ls -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 0 && "$cmdOutput" == *"[]"* ]]; then
 	echo -e "${PREFIX} completed."
@@ -531,11 +403,16 @@ fi
 echo -e "${PREFIX} done."
 
 echo -e "${PREFIX} adding test nmp to exchange..."
-hzn ex nmp add test-nmp-1 -f /tmp/nmp_example_2.json -v &> /dev/null
+hzn ex nmp add test-nmp-1 -f /tmp/nmp_example_2.json -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH &> /dev/null
+if [[ $? != 0 ]]; then 
+	echo -e "${PREFIX} failed to add test nmp to Exchange"
+	cleanup
+	exit 1
+fi
 echo -e "${PREFIX} done."
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' without -f set and answering 'no'"
-cmdOutput=$(echo "n" | $CMD_PREFIX test-nmp-1 2>&1)
+cmdOutput=$(echo "n" | $CMD_PREFIX test-nmp-1 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 0 && "$cmdOutput" == *"Are you sure you want to remove node management policy test-nmp-1 for org"*"from the Horizon Exchange? [y/N]: Exiting."* ]]; then
 	echo -e "${PREFIX} completed."
@@ -546,9 +423,9 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' without -f set and answering 'yes'"
-cmdOutput=$(yes | $CMD_PREFIX test-nmp-1 2>&1)
+cmdOutput=$(yes | $CMD_PREFIX test-nmp-1 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
-if [[ $rc -eq 0 && "$cmdOutput" == *"Removing node management policy"*"and re-evaluating all agreements"*"Node management policy"*"/test-nmp-1 removed"* ]]; then
+if [[ $rc -eq 0 && "$cmdOutput" == *"Node management policy $NMP_ORG_ID/test-nmp-1 removed from the Horizon Exchange"* ]]; then
 	echo -e "${PREFIX} completed."
 else
 	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without -f set and answering 'yes': exit code: $rc, output: $cmdOutput."
@@ -557,7 +434,7 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect nmp-name"
-cmdOutput=$($CMD_PREFIX fake-nmp -f 2>&1)
+cmdOutput=$($CMD_PREFIX fake-nmp -f -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 8 && "$cmdOutput" == *"Error: Node management policy fake-nmp not found in org"* ]]; then
 	echo -e "${PREFIX} completed."
@@ -572,77 +449,10 @@ fi
 # -----------------------
 
 CMD_PREFIX="hzn exchange nmp list"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_EXCHANGE_USER_AUTH set"
-unset HZN_EXCHANGE_USER_AUTH
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 1 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_EXCHANGE_USER_AUTH set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_USER_AUTH="$HZN_EXCHANGE_USER_AUTH_SAVE"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect HZN_EXCHANGE_USER_AUTH set"
-export HZN_EXCHANGE_USER_AUTH=fakeuser:fakepw
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 5 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect HZN_EXCHANGE_USER_AUTH set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_USER_AUTH="$HZN_EXCHANGE_USER_AUTH_SAVE"
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_ORG_ID set"
-unset HZN_ORG_ID
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 1 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect HZN_ORG_ID set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_ORG_ID=$HZN_ORG_ID_SAVE
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect HZN_ORG_ID set"
-export HZN_ORG_ID=fakeorg
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 5 ]]; then
-	echo -e "${PREFIX} completed."
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_ORG_ID set: exit code: $rc, output: $cmdOutput."
-	cleanup
-	exit 1
-fi
-export HZN_ORG_ID=$HZN_ORG_ID_SAVE
-
-echo -e "${PREFIX} Testing '$CMD_PREFIX' without HZN_EXCHANGE_URL set"
-unset HZN_EXCHANGE_URL
-mv /etc/default/horizon /etc/default/horizonOLD &> /dev/null
-cmdOutput=$($CMD_PREFIX 2>&1)
-rc=$?
-if [[ $rc -eq 7 ]]; then
-	echo -e "${PREFIX} completed."
-	mv /etc/default/horizonOLD /etc/default/horizon &> /dev/null
-else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' without HZN_EXCHANGE_URL set: exit code: $rc, output: $cmdOutput."
-	mv /etc/default/horizonOLD /etc/default/horizon &> /dev/null
-	cleanup
-	exit 1
-fi
-export HZN_EXCHANGE_URL=$HZN_EXCHANGE_URL_SAVE
+test_env_variables "$CMD_PREFIX" true
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' when no nmp's exists in the Exchange"
-cmdOutput=$($CMD_PREFIX 2>&1)
+cmdOutput=$($CMD_PREFIX -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 0 && "$cmdOutput" == *"[]"* ]]; then
 	echo -e "${PREFIX} completed."
@@ -653,7 +463,7 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' --long when no nmp's exists in the Exchange"
-cmdOutput=$($CMD_PREFIX -l 2>&1)
+cmdOutput=$($CMD_PREFIX -l -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 0 && "$cmdOutput" == *"[]"* ]]; then
 	echo -e "${PREFIX} completed."
@@ -664,13 +474,18 @@ else
 fi
 
 echo -e "${PREFIX} adding test nmp to exchange..."
-hzn ex nmp add test-nmp-1 -f /tmp/nmp_example_2.json -v &> /dev/null
+hzn ex nmp add test-nmp-1 -f /tmp/nmp_example_2.json -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH -v &> /dev/null
+if [[ $? != 0 ]]; then 
+	echo -e "${PREFIX} failed to add test nmp to Exchange"
+	cleanup
+	exit 1
+fi
 echo -e "${PREFIX} done."
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' when 1 nmp exists in the Exchange"
-cmdOutput=$($CMD_PREFIX 2>&1)
+cmdOutput=$($CMD_PREFIX -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
-if [[ $rc -eq 0 && "$cmdOutput" == *"["*"$HZN_ORG_ID/test-nmp-1"*"]"* ]]; then
+if [[ $rc -eq 0 && "$cmdOutput" == *"["*"$NMP_ORG_ID/test-nmp-1"*"]"* ]]; then
 	echo -e "${PREFIX} completed."
 else
 	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' when 1 nmp exists in the Exchange: exit code: $rc, output: $cmdOutput."
@@ -678,32 +493,34 @@ else
 	exit 1
 fi
 
-NMP_OUTPUT1="$HZN_ORG_ID/test-nmp-1"*"{"*"\"owner\":"*"\"label\":"*"\"description\":"*"\"constraints\":"*"\"properties\":"*"\"patterns\":"*"\"enabled\":"*"\"agentUpgradePolicy\":"*"\"atLeastVersion\":"*"\"start\":"*"\"duration\":"*"\"lastUpdated\":"*"\"created\":"*"}"
-NMP_OUTPUT2="$HZN_ORG_ID/test-nmp-2"*"{"*"\"owner\":"*"\"label\":"*"\"description\":"*"\"constraints\":"*"\"properties\":"*"\"patterns\":"*"\"enabled\":"*"\"agentUpgradePolicy\":"*"\"atLeastVersion\":"*"\"start\":"*"\"duration\":"*"\"lastUpdated\":"*"\"created\":"*"}"
+USERNAME=$(echo $NMP_EXCHANGE_USER_AUTH | awk -F : '{print $1}')
+NMP_OUTPUT1="$NMP_ORG_ID/test-nmp-1"*"{"*"owner"*"$NMP_ORG_ID/$USERNAME"*"label"*"nmp test 2"*"description"*"test nmp 2"*"constraints"*"purpose==nmp-testing"*"properties"*"name"*"iame2edev"*"value"*"true"*"name"*"NOAGENTAUTO"*"value"*"false"*"patterns"*"[]"*"enabled"*"true"*"start"*"now"*"startWindow"*"0"*"agentUpgradePolicy"*"{"*"manifest"*"manifest_2.0.0"*"allowDowngrade"*"false"*"}"*"}"
+NMP_OUTPUT2="$NMP_ORG_ID/test-nmp-2"*"{"*"owner"*"$NMP_ORG_ID/$USERNAME"*"label"*"nmp test 3"*"description"*"\"\""*"constraints"*"[]"*"properties"*"[]"*"patterns"*"[]"*"enabled"*"false"*"start"*"\"\""*"startWindow"*"0"*"agentUpgradePolicy"*"{"*"manifest"*"\"\""*"allowDowngrade"*"false"*"}"*"}"
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' --long when 1 nmp exists in the Exchange"
-cmdOutput=$($CMD_PREFIX -l 2>&1)
+cmdOutput=$($CMD_PREFIX -l -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 0 && "$cmdOutput" == *"{"*$NMP_OUTPUT1*"}"* ]]; then
 	echo -e "${PREFIX} completed."
 else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --long when 1 nmp exists in the Exchange: exit code: $rc, output: $cmdOutput."
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --long when 1 nmp exists in the Exchange: exit code: $rc, output: $cmdOutput, expected: $NMP_OUTPUT1"
 	cleanup
 	exit 1
 fi
 
 echo -e "${PREFIX} adding second test nmp to exchange..."
-hzn ex nmp add test-nmp-2 -f /tmp/nmp_example_3.json -v --no-constraints &> /dev/null 
+hzn ex nmp add test-nmp-2 -f /tmp/nmp_example_3.json -v --no-constraints -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH &> /dev/null 
 if [[ $? != 0 ]]; then 
-	echo -e "failed to add nm policy"
+	echo -e "${PREFIX} failed to add nm policy"
+	cleanup
 	exit 1
 fi
 echo -e "${PREFIX} done."
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' when 2 nmp's exist in the Exchange"
-cmdOutput=$($CMD_PREFIX 2>&1)
+cmdOutput=$($CMD_PREFIX -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
-if [[ $rc -eq 0 && ("$cmdOutput" == *"["*"$HZN_ORG_ID/test-nmp-1"*"$HZN_ORG_ID/test-nmp-2"*"]"* || "$cmdOutput" == *"["*"$HZN_ORG_ID/test-nmp-2"*"$HZN_ORG_ID/test-nmp-1"*"]"*) ]]; then
+if [[ $rc -eq 0 && ("$cmdOutput" == *"["*"$NMP_ORG_ID/test-nmp-1"*"$NMP_ORG_ID/test-nmp-2"*"]"* || "$cmdOutput" == *"["*"$NMP_ORG_ID/test-nmp-2"*"$NMP_ORG_ID/test-nmp-1"*"]"*) ]]; then
 	echo -e "${PREFIX} completed."
 else
 	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' when 2 nmp's exist in the Exchange: exit code: $rc, output: $cmdOutput."
@@ -712,18 +529,18 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' --long when 2 nmp's exist in the Exchange"
-cmdOutput=$($CMD_PREFIX -l | tr -d '[:space:]' 2>&1)
+cmdOutput=$($CMD_PREFIX -l -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
-if [[ $rc -eq 0 && ("$cmdOutput" == *"{"*$NMP_OUTPUT1*","*$NMP_OUTPUT2*"}"* || "$cmdOutput" == *"{"*$NMP_OUTPUT2*","*$NMP_OUTPUT1*"}"*) ]]; then
+if [[ $rc -eq 0 && ("$cmdOutput" == *"{"*$NMP_OUTPUT1*$NMP_OUTPUT2*"}"* || "$cmdOutput" == *"{"*$NMP_OUTPUT2*$NMP_OUTPUT1*"}"*) ]]; then
 	echo -e "${PREFIX} completed."
 else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' when 2 nmp's exist in the Exchange: exit code: $rc, output: $cmdOutput."
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --long when 2 nmp's exist in the Exchange: exit code: $rc, output: $cmdOutput."
 	cleanup
 	exit 1
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' [<nmp-name>] --long when 2 nmp's exist in the Exchange"
-cmdOutput=$($CMD_PREFIX test-nmp-1 -l 2>&1)
+cmdOutput=$($CMD_PREFIX test-nmp-1 -l -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 0 && "$cmdOutput" == *"{"*$NMP_OUTPUT1*"}"* ]]; then
 	echo -e "${PREFIX} completed."
@@ -734,12 +551,334 @@ else
 fi
 
 echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect nmp-name"
-cmdOutput=$($CMD_PREFIX fake-nmp 2>&1)
+cmdOutput=$($CMD_PREFIX fake-nmp -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 8 && "$cmdOutput" == *"Error: NMP fake-nmp not found in org"* ]]; then
 	echo -e "${PREFIX} completed."
 else
 	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect nmp-name: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+# -----------------------------------
+# ------- NODE MANAGEMENT LIST ------
+# -----------------------------------
+
+CMD_PREFIX="hzn exchange node management list"
+test_env_variables "$CMD_PREFIX fakenode" true
+
+echo -e "${PREFIX} Removing remaining nmp's in the Exchange"
+hzn ex nmp rm test-nmp-1 -f -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH  &> /dev/null
+if [[ $? != 0 ]]; then 
+	echo -e "${PREFIX} failed to remove test-nmp-1"
+	cleanup
+	exit 1
+fi
+hzn ex nmp rm test-nmp-2 -f -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH &> /dev/null
+if [[ $? != 0 ]]; then 
+	echo -e "${PREFIX} failed to remove test-nmp-2"
+	cleanup
+	exit 1
+fi
+echo -e "${PREFIX} done."
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' when no nmp's exists in the Exchange"
+cmdOutput=$($CMD_PREFIX an12345 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"[]"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' when no nmp's exists in the Exchange: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --all when no nmp's exists in the Exchange"
+cmdOutput=$($CMD_PREFIX an12345 --all -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"[]"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --all when no nmp's exists in the Exchange: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} adding test nmp to exchange..."
+hzn ex nmp add test-nmp-1 -f /tmp/nmp_example_2.json -v -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH &> /dev/null
+if [[ $? != 0 ]]; then 
+	echo -e "${PREFIX} failed to add test nmp to Exchange"
+	cleanup
+	exit 1
+fi
+echo -e "${PREFIX} done."
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' when 1 nmp exists in the Exchange"
+cmdOutput=$($CMD_PREFIX an12345 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*"$NMP_ORG_ID/test-nmp-1"*"enabled"*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' when 1 nmp exists in the Exchange: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --all when 1 nmp exists in the Exchange"
+cmdOutput=$($CMD_PREFIX an12345 --all -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*"$NMP_ORG_ID/test-nmp-1"*"enabled"*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --all when 1 nmp exists in the Exchange: exit code: $rc, output: $cmdOutput, expected: $NMP_OUTPUT1"
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} adding second test nmp to exchange..."
+sed -i 's/\"enabled\": true/\"enabled\": false/g' /tmp/nmp_example_2.json
+hzn ex nmp add test-nmp-2 -f /tmp/nmp_example_2.json -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH &> /dev/null 
+if [[ $? != 0 ]]; then 
+	echo -e "${PREFIX} failed to add nm policy"
+	cleanup
+	exit 1
+fi
+echo -e "${PREFIX} done."
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' when 2 nmp's exist in the Exchange and 1 is disabled"
+cmdOutput=$($CMD_PREFIX an12345 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*"$NMP_ORG_ID/test-nmp-1"*"enabled"*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' when 2 nmp's exist in the Exchange and 1 is disabled: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --all when 2 nmp's exist in the Exchange"
+cmdOutput=$($CMD_PREFIX an12345 --all -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && ("$cmdOutput" == *"{"*"$NMP_ORG_ID/test-nmp-1"*"enabled"*"$NMP_ORG_ID/test-nmp-2"*"disabled"*"}"* || "$cmdOutput" == *"{"*"$NMP_ORG_ID/test-nmp-2"*"disabled"*"$NMP_ORG_ID/test-nmp-1"*"enabled"*"}"*"}"*) ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --all when 2 nmp's exist in the Exchange: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect node name"
+cmdOutput=$($CMD_PREFIX fakenode -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 8 && "$cmdOutput" == *"Error: node 'fakenode' not found in org $NMP_ORG_ID"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect node name: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+# -------------------------
+# ------- NMP STATUS ------
+# -------------------------
+
+CMD_PREFIX="hzn exchange nmp status"
+test_env_variables "$CMD_PREFIX fakenmp" true
+
+# Manually add status to Exchange in case worker hasn't added it yet
+echo -e "${PREFIX} adding test nmp status to exchange..."
+curl -X PUT -u $NMP_ORG_ID/$NMP_EXCHANGE_USER_AUTH "$HZN_EXCHANGE_URL/orgs/userdev/nodes/an12345/managementStatus/test-nmp-1" -H "Content-Type: application/json" -d "$(cat /tmp/nmp_status_1.json)" &> /dev/null 
+if [[ $? != 0 ]]; then 
+	echo -e "${PREFIX} failed to add status for test-nmp-1"
+	cleanup
+	exit 1
+fi
+echo -e "${PREFIX} done."
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' with disabled nmp"
+cmdOutput=$($CMD_PREFIX test-nmp-2 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 8 && "$cmdOutput" == *"Error: Status for NMP test-nmp-2 not found in org $NMP_ORG_ID"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with disabled nmp: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' with enabled nmp"
+cmdOutput=$($CMD_PREFIX test-nmp-1 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*"\"$NMP_ORG_ID/an12345\": \""*"\""*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with enabled nmp: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+STATUS_OUTPUT="{"*"$NMP_ORG_ID/test-nmp-1"*"{"*"agentUpgradePolicyStatus"*"{"*"scheduledTime"*"0001-01-01T00:00:00Z"*"upgradedVersions"*"{"*"softwareVersion"*"1.0.0"*"certVersion"*"2.0.0"*"configVersion"*"3.0.0"*"}"*"status"*"waiting"*"}"*"}"*"}"
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --long with enabled nmp"
+cmdOutput=$($CMD_PREFIX test-nmp-1 --long -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*$STATUS_OUTPUT*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --long with enabled nmp: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+# -------------------------------------
+# ------- NODE MANAGEMENT STATUS ------
+# -------------------------------------
+
+CMD_PREFIX="hzn exchange node management status"
+test_env_variables "$CMD_PREFIX fakenode" true
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' with incorrect node name"
+cmdOutput=$($CMD_PREFIX fakenode -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 8 && "$cmdOutput" == *"Error: Statuses for node fakenode not found in org $NMP_ORG_ID"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' with incorrect node name: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX'"
+cmdOutput=$($CMD_PREFIX an12345 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*"\"$NMP_ORG_ID/test-nmp-1\": \""*"\""*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX': exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+STATUS_OUTPUT="$NMP_ORG_ID/test-nmp-1"*"{"*"agentUpgradePolicyStatus"*"{"*"scheduledTime"*"0001-01-01T00:00:00Z"*"upgradedVersions"*"{"*"softwareVersion"*"1.0.0"*"certVersion"*"2.0.0"*"configVersion"*"3.0.0"*"}"*"status"*"waiting"*"}"*"}"
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --long"
+cmdOutput=$($CMD_PREFIX an12345 --long -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*$STATUS_OUTPUT*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --long: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --policy"
+cmdOutput=$($CMD_PREFIX an12345 --policy test-nmp-1 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*"\"$NMP_ORG_ID/test-nmp-1\": \""*"\""*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --policy: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --policy with disabled policy"
+cmdOutput=$($CMD_PREFIX an12345 --policy test-nmp-2 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 8 && "$cmdOutput" == *"Error: Node an12345 does not contain a status for test-nmp-2 in org $NMP_ORG_ID"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --policy with disabled policy: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --long --policy"
+cmdOutput=$($CMD_PREFIX an12345 --policy test-nmp-1 --long -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*$STATUS_OUTPUT*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --long: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+# Enable the other NMP to create status path in Exchange
+echo -e "${PREFIX} enabling second test nmp in exchange..."
+sed -i 's/\"enabled\": false/\"enabled\": true/g' /tmp/nmp_example_2.json
+hzn ex nmp add test-nmp-2 -f /tmp/nmp_example_2.json -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH &> /dev/null 
+if [[ $? != 0 ]]; then 
+	echo -e "${PREFIX} failed to add nm policy"
+	cleanup
+	exit 1
+fi
+echo -e "${PREFIX} done."
+
+echo -e "${PREFIX} adding test nmp status to exchange..."
+curl -X PUT -u $NMP_ORG_ID/$NMP_EXCHANGE_USER_AUTH "$HZN_EXCHANGE_URL/orgs/userdev/nodes/an12345/managementStatus/test-nmp-2" -H "Content-Type: application/json" -d "$(cat /tmp/nmp_status_1.json)" &> /dev/null 
+if [[ $? != 0 ]]; then 
+	echo -e "${PREFIX} failed to add status for test-nmp-2"
+	cleanup
+	exit 1
+fi
+echo -e "${PREFIX} done."
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' when there are 2 status objects in the Exchange"
+cmdOutput=$($CMD_PREFIX an12345 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && ("$cmdOutput" == *"{"*"\"$NMP_ORG_ID/test-nmp-1\": \""*"\""*"\"$NMP_ORG_ID/test-nmp-2\": \""*"\""*"}"* || "$cmdOutput" == *"{"*"\"$NMP_ORG_ID/test-nmp-2\": \""*"\""*"\"$NMP_ORG_ID/test-nmp-1\": \""*"\""*"}"*) ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' when there are 2 status objects in the Exchange: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+STATUS_OUTPUT1="$NMP_ORG_ID/test-nmp-1"*"{"*"agentUpgradePolicyStatus"*"{"*"scheduledTime"*"0001-01-01T00:00:00Z"*"upgradedVersions"*"{"*"softwareVersion"*"1.0.0"*"certVersion"*"2.0.0"*"configVersion"*"3.0.0"*"}"*"status"*"waiting"*"}"*"}"
+STATUS_OUTPUT2="$NMP_ORG_ID/test-nmp-2"*"{"*"agentUpgradePolicyStatus"*"{"*"scheduledTime"*"0001-01-01T00:00:00Z"*"upgradedVersions"*"{"*"softwareVersion"*"1.0.0"*"certVersion"*"2.0.0"*"configVersion"*"3.0.0"*"}"*"status"*"waiting"*"}"*"}"
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --long when there are 2 status objects in the Exchange"
+cmdOutput=$($CMD_PREFIX an12345 --long -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && ("$cmdOutput" == *"{"*$STATUS_OUTPUT1*$STATUS_OUTPUT2*"}"* || "$cmdOutput" == *"{"*$STATUS_OUTPUT2*$STATUS_OUTPUT1*"}"*) ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --long when there are 2 status objects in the Exchange: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --policy when there are 2 status objects in the Exchange"
+cmdOutput=$($CMD_PREFIX an12345 --policy test-nmp-1 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*"\"$NMP_ORG_ID/test-nmp-1\": \""*"\""*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --policy when there are 2 status objects in the Exchange: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --long --policy when there are 2 status objects in the Exchange"
+cmdOutput=$($CMD_PREFIX an12345 --policy test-nmp-1 --long -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$cmdOutput" == *"{"*$STATUS_OUTPUT*"}"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --long when there are 2 status objects in the Exchange: exit code: $rc, output: $cmdOutput."
+	cleanup
+	exit 1
+fi
+
+cleanup
+
+echo -e "${PREFIX} Testing '$CMD_PREFIX' when there are no status objects in the Exchange"
+cmdOutput=$($CMD_PREFIX an12345 -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+rc=$?
+if [[ $rc -eq 8 && "$cmdOutput" == *"Error: Statuses for node an12345 not found in org $NMP_ORG_ID"* ]]; then
+	echo -e "${PREFIX} completed."
+else
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' when there are no status objects in the Exchange: exit code: $rc, output: $cmdOutput."
 	cleanup
 	exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Jeff Kinard <jeff@thekinards.com>

## Description

This PR adds tests for the `hzn exchange nmp` set of CLI commands. It also fixes an intermittent timing issue with the go tests on the API module.

Fixes #3166 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This PR is tests, so testing simply involved running the tests and making sure they do not fail or give unexpected output.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
