### PR TITLE
Bug: k8s cronjob does rollback even no status file is found

### DIFF
--- a/anax-in-k8s/cronjobs/auto-upgrade-cronjob.sh
+++ b/anax-in-k8s/cronjobs/auto-upgrade-cronjob.sh
@@ -373,7 +373,7 @@ function get_status_path() {
     local no_active_jobs
     test -f $STATUS_PATH 2>&1
     no_active_jobs=$?
-    if [ "$no_active_jobs" -eq "1" ]; then
+    if [[ "$STATUS_PATH" == "" || "$no_active_jobs" -eq "1" ]]; then
         log_info "There are no active auto upgrade jobs."
         write_logs
         exit 0


### PR DESCRIPTION
Signed-off-by: zhangl <zhangl@us.ibm.com>

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
