### PR TITLE
Issue 3103 - more translation message drop for 2Q2022

### DIFF
--- a/i18n_translation/hzn.out.gotext.json
+++ b/i18n_translation/hzn.out.gotext.json
@@ -4308,8 +4308,8 @@
     "translation": "When to start an upgrade, default \"now\"."
   },
   {
-    "id": "Enable agents to randomize upgrade start time within start + startWindow, default 0.",
-    "translation": "Enable agents to randomize upgrade start time within start + startWindow, default 0."
+    "id": "Enable agents to randomize upgrade start time within start + startWindow seconds, default 0.",
+    "translation": "Enable agents to randomize upgrade start time within start + startWindow seconds, default 0."
   },
   {
     "id": "(Optional) Assertions on how the agent should update itself.",

--- a/i18n_translation/original/hzn.out.gotext.json.auto
+++ b/i18n_translation/original/hzn.out.gotext.json.auto
@@ -14172,9 +14172,9 @@
             "fuzzy": true
         },
         {
-            "id": "Enable agents to randomize upgrade start time within start + startWindow, default 0.",
-            "message": "Enable agents to randomize upgrade start time within start + startWindow, default 0.",
-            "translation": "Enable agents to randomize upgrade start time within start + startWindow, default 0.",
+            "id": "Enable agents to randomize upgrade start time within start + startWindow seconds, default 0.",
+            "message": "Enable agents to randomize upgrade start time within start + startWindow seconds, default 0.",
+            "translation": "Enable agents to randomize upgrade start time within start + startWindow seconds, default 0.",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },


### PR DESCRIPTION
Signed-off-by: linggao <linggao@us.ibm.com>

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
