### PR TITLE
Issue #3259 - Bug: NMPs applied in incorrect order

### DIFF
--- a/download/download_worker.go
+++ b/download/download_worker.go
@@ -390,7 +390,10 @@ func findBestMatchingVersion(availibleVers []string, preferredVers string) (stri
 	})
 
 	if preferredVers == LATESTVERSION {
-		return availibleVers[0], nil
+		if len(availibleVers) > 0 {
+			return availibleVers[0], nil
+		}
+		return "", fmt.Errorf("Version keyword \"%v\" specified but no availible versions found in exchange.", LATESTVERSION)
 	} else if semanticversion.IsVersionString(preferredVers) {
 		return preferredVers, nil
 	} else if prefVers, err := semanticversion.Version_Expression_Factory(preferredVers); err == nil {

--- a/exchangecommon/node_management_status.go
+++ b/exchangecommon/node_management_status.go
@@ -160,7 +160,12 @@ func StatusFromNewPolicy(policy ExchangeNodeManagementPolicy, workingDir string)
 	if policy.AgentAutoUpgradePolicy != nil {
 		startTime, _ := time.Parse(time.RFC3339, policy.PolicyUpgradeTime)
 		if policy.PolicyUpgradeTime == TIME_NOW_KEYWORD {
-			startTime = time.Now()
+			// This format string is the time format the exchange uses
+			if lastUpdatedTime, err := time.Parse("2006-01-02T15:04:05.000000Z[UTC]", policy.LastUpdated); err == nil {
+				startTime = lastUpdatedTime
+			} else {
+				startTime = time.Now()
+			}
 		}
 		realStartTime := startTime.Unix()
 		if policy.UpgradeWindowDuration > 0 {

--- a/nodemanagement/node_management_worker_test.go
+++ b/nodemanagement/node_management_worker_test.go
@@ -53,7 +53,7 @@ func Test_ProcessAllNMPS(t *testing.T) {
 
 	// matches mgmt policy
 	nmp1 := exchangecommon.ExchangeNodeManagementPolicy{
-		Patterns:               []string{"userdev/pattern1", "userdev/pattern2", "userdev/pattern3"},
+		Patterns:               []string{},
 		Enabled:                true,
 		PolicyUpgradeTime:      "now",
 		AgentAutoUpgradePolicy: &exchangecommon.ExchangeAgentUpgradePolicy{Manifest: "manifest", AllowDowngrade: false},
@@ -63,7 +63,7 @@ func Test_ProcessAllNMPS(t *testing.T) {
 
 	// matches dep policy
 	nmp2 := exchangecommon.ExchangeNodeManagementPolicy{
-		Patterns:               []string{"userdev/pattern1", "userdev/pattern2", "userdev/pattern3"},
+		Patterns:               []string{},
 		Enabled:                true,
 		PolicyUpgradeTime:      "now",
 		AgentAutoUpgradePolicy: &exchangecommon.ExchangeAgentUpgradePolicy{Manifest: "manifest", AllowDowngrade: false},
@@ -73,7 +73,7 @@ func Test_ProcessAllNMPS(t *testing.T) {
 
 	// matches mgmt policy  but disabled
 	nmp3 := exchangecommon.ExchangeNodeManagementPolicy{
-		Patterns:               []string{"userdev/pattern1", "userdev/pattern2", "userdev/pattern3"},
+		Patterns:               []string{},
 		Enabled:                false,
 		PolicyUpgradeTime:      "now",
 		AgentAutoUpgradePolicy: &exchangecommon.ExchangeAgentUpgradePolicy{Manifest: "manifest", AllowDowngrade: false},
@@ -125,26 +125,26 @@ func Test_getEarliest(t *testing.T) {
 	status3 := exchangecommon.NodeManagementPolicyStatus{AgentUpgradeInternal: &exchangecommon.AgentUpgradeInternalStatus{ScheduledUnixTime: time.Unix(1649112221, 0)}}
 	statusList := &map[string]*exchangecommon.NodeManagementPolicyStatus{"status1": &status1, "status2": &status2, "status3": &status3}
 
-	nextName, _ := getEarliest(statusList)
-	if nextName != "status3" {
-		t.Errorf("The next nmp to run should have been \"status3\": found %s instead.", nextName)
+	nextName, _ := getLatest(statusList)
+	if nextName != "status1" {
+		t.Errorf("The next nmp to run should have been \"status1\": found %s instead.", nextName)
 	} else if len(*statusList) != 2 {
 		t.Errorf("The status list should contain 2 remaining statuses. Found  %v.", statusList)
 	}
-	nextName, _ = getEarliest(statusList)
+	nextName, _ = getLatest(statusList)
 	if nextName != "status2" {
 		t.Errorf("The next nmp to run should have been \"status2\": found %s instead.", nextName)
 	} else if len(*statusList) != 1 {
 		t.Errorf("The status list should contain 1 remaining statuses. Found  %v.", statusList)
 	}
-	nextName, _ = getEarliest(statusList)
-	if nextName != "status1" {
-		t.Errorf("The next nmp to run should have been \"status1\": found %s instead.", nextName)
+	nextName, _ = getLatest(statusList)
+	if nextName != "status3" {
+		t.Errorf("The next nmp to run should have been \"status3\": found %s instead.", nextName)
 	} else if len(*statusList) != 0 {
 		t.Errorf("The status list should contain 0 remaining statuses. Found  %v.", statusList)
 	}
 
-	nextName, _ = getEarliest(statusList)
+	nextName, _ = getLatest(statusList)
 	if nextName != "" {
 		t.Errorf("The next nmp to run should have been \"\": found %s instead.", nextName)
 	} else if len(*statusList) != 0 {
@@ -152,7 +152,7 @@ func Test_getEarliest(t *testing.T) {
 	}
 
 	statusList = nil
-	nextName, _ = getEarliest(statusList)
+	nextName, _ = getLatest(statusList)
 	if nextName != "" {
 		t.Errorf("The next nmp to run should have been \"\": found %s instead.", nextName)
 	} else if statusList != nil {


### PR DESCRIPTION
Signed-off-by: Max McAdam <max@fredcom.com>

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
