### PR TITLE
Issue 3294 - Change --appliesTo flag to --applies-to on hzn exchange nmp add CLI command

### DIFF
--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -349,7 +349,7 @@ Environment Variables:
 	exNMPListLong := exNMPListCmd.Flag("long", msgPrinter.Sprintf("Display detailed output about the node management policies.")).Short('l').Bool()
 	exNMPListNodes := exNMPListCmd.Flag("nodes", msgPrinter.Sprintf("List all the nodes that apply for the given node management policy.")).Bool()
 	exNMPAddCmd := exNMPCmd.Command("add", msgPrinter.Sprintf("Add or replace a node management policy in the Horizon Exchange. Use 'hzn exchange nmp new' for an empty node management policy template."))
-	exNMPAddAppliesTo := exNMPAddCmd.Flag("appliesTo", msgPrinter.Sprintf("List all the nodes that will be compatible with this node management policy. Use this flag with --dry-run to list nodes without publishing the policy to the Exchange.")).Bool()
+	exNMPAddAppliesTo := exNMPAddCmd.Flag("applies-to", msgPrinter.Sprintf("List all the nodes that will be compatible with this node management policy. Use this flag with --dry-run to list nodes without publishing the policy to the Exchange.")).Bool()
 	exNMPAddName := exNMPAddCmd.Arg("nmp-name", msgPrinter.Sprintf("The name of the node management policy to add or overwrite.")).Required().String()
 	exNMPAddJsonFile := exNMPAddCmd.Flag("json-file", msgPrinter.Sprintf("The path of a JSON file containing the metadata necessary to create/update the node management policy in the Horizon Exchange. Specify -f- to read from stdin.")).Short('f').Required().String()
 	exNMPAddNoConstraint := exNMPAddCmd.Flag("no-constraints", msgPrinter.Sprintf("Allow this node management policy to be published even though it does not have any constraints.")).Bool()

--- a/docs/node_management_policy.md
+++ b/docs/node_management_policy.md
@@ -65,7 +65,7 @@ hzn exchange nmp add <nmp-name> --json-file <path-to-nmp>
 
 * `--no-constraints`: This flag must be specified if the patterns field is omitted and the constraints field is omitted. By specifying this flag, the user is verifying that this NMP should apply to all nodes that also omitted constraints in their node policy, as well as the nodes who have contraints that match this NMP's properties.
 
-* `--appliesTo`: This flag will output a list of nodes that are compatible with this NMP. If the `--dry-run` flag is also specified, the NMP will not be added to the Exchange - this is useful when checking the compatiility of an NMP without the risk of deploying to unintended nodes.
+* `--applies-to`: This flag will output a list of nodes that are compatible with this NMP. If the `--dry-run` flag is also specified, the NMP will not be added to the Exchange - this is useful when checking the compatiility of an NMP without the risk of deploying to unintended nodes.
 
 ## Listing NMP's currently stored in the Exchange
 To list all the NMP's that exist in the Exchange, use the following command:

--- a/test/gov/hzn_nmp.sh
+++ b/test/gov/hzn_nmp.sh
@@ -339,24 +339,24 @@ else
 	exit 1
 fi
 
-echo -e "${PREFIX} Testing '$CMD_PREFIX' --appliesTo"
-cmdOutput=$($CMD_PREFIX test-nmp-2 -f /tmp/nmp_example_2.json --appliesTo --dry-run -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --applies-to"
+cmdOutput=$($CMD_PREFIX test-nmp-2 -f /tmp/nmp_example_2.json --applies-to --dry-run -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 0 && "$cmdOutput" == *"["*"$NMP_ORG_ID/an12345"*"]"* ]]; then
 	echo -e "${PREFIX} completed."
 else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --appliesTo: exit code: $rc, output: $cmdOutput."
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --applies-to: exit code: $rc, output: $cmdOutput."
 	cleanup
 	exit 1
 fi
 
-echo -e "${PREFIX} Testing '$CMD_PREFIX' --appliesTo when NMP is not compatible with any nodes"
-cmdOutput=$($CMD_PREFIX test-nmp-3 -f /tmp/nmp_example_3.json --no-constraints --appliesTo --dry-run -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
+echo -e "${PREFIX} Testing '$CMD_PREFIX' --applies-to when NMP is not compatible with any nodes"
+cmdOutput=$($CMD_PREFIX test-nmp-3 -f /tmp/nmp_example_3.json --no-constraints --applies-to --dry-run -o $NMP_ORG_ID -u $NMP_EXCHANGE_USER_AUTH 2>&1)
 rc=$?
 if [[ $rc -eq 0 && "$cmdOutput" == *"[]"* ]]; then
 	echo -e "${PREFIX} completed."
 else
-	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --appliesTo when NMP is not compatible with any nodes: exit code: $rc, output: $cmdOutput."
+	echo -e "${PREFIX} Failed: Wrong error response from '$CMD_PREFIX' --applies-to when NMP is not compatible with any nodes: exit code: $rc, output: $cmdOutput."
 	cleanup
 	exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Jeff Kinard <jeff@thekinards.com>

# Pull Request Template

## Description

This PR changes the `--appliesTo` flag for the `hzn ex nmp add` command to `--applies-to` to stay consistent with all other CLI command flags.

The documentation for the NMP CLI commands has also been updated to reflect this change.

Fixes #3294

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

This was tested by running the command with the new flag and making sure it still runs as expected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
