### PR TITLE
Issue 3275 - Bug: hzn cli doesn't check for valid RFC3339 format in NMP start time

### DIFF
--- a/cli/exchange/nmp.go
+++ b/cli/exchange/nmp.go
@@ -109,8 +109,7 @@ func NMPAdd(org, credToUse, nmpName, jsonFilePath string, appliesTo, noConstrain
 	}
 
 	// validate the format of the nmp
-	err = nmpFile.Validate()
-	if err != nil {
+	if err = nmpFile.Validate(); err != nil {
 		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Incorrect node management policy format in file %s: %v", jsonFilePath, err))
 	}
 

--- a/exchangecommon/node_management_policy.go
+++ b/exchangecommon/node_management_policy.go
@@ -5,6 +5,7 @@ import (
 	"github.com/open-horizon/anax/externalpolicy"
 	"github.com/open-horizon/anax/i18n"
 	"strings"
+	"time"
 )
 
 // Node management policy as represented in the exchange
@@ -33,6 +34,13 @@ func (e ExchangeNodeManagementPolicy) String() string {
 func (e *ExchangeNodeManagementPolicy) Validate() error {
 	// get message printer
 	msgPrinter := i18n.GetMessagePrinter()
+
+	// Validate the timestamp
+	if e.PolicyUpgradeTime != "now" && e.PolicyUpgradeTime != "" {
+		if _, err := time.Parse(time.RFC3339, e.PolicyUpgradeTime); err != nil {
+			return fmt.Errorf(msgPrinter.Sprintf("The start time must be in RFC3339 format or set to \"now\"."))
+		}
+	}
 
 	// Validate the PropertyList.
 	if e != nil && len(e.Properties) != 0 {


### PR DESCRIPTION
Signed-off-by: Jeff Kinard <jeff@thekinards.com>

## Description

This PR adds a check to the NMP validation function to ensure the timestamp given for the start time is actually in RFC3339 format (or "now").

Fixes #3275

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This was tested by trying NMP's with the following cases:
- With start omitted (start set to "")
- With start set to "now"
- With start set to various valid RFC3339 timestamps
- With start set to invalid timestamps


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
