### PR TITLE
Issue_3306 - Correct retries for download_worker

### DIFF
--- a/exchange/css.go
+++ b/exchange/css.go
@@ -311,9 +311,6 @@ func GetObjectData(ec ExchangeContext, org string, objType string, objId string,
 	retryInterval := ec.GetHTTPFactory().GetRetryInterval()
 	for {
 		response, err := ec.GetHTTPFactory().NewHTTPClient(nil).Do(request)
-		if err != nil {
-			return fmt.Errorf("Failed to get object data : %v\n", err)
-		}
 
 		if response != nil && response.Body != nil {
 			defer response.Body.Close()
@@ -330,7 +327,7 @@ func GetObjectData(ec ExchangeContext, org string, objType string, objId string,
 				return fmt.Errorf("Exceeded %v retries for error: %v", ec.GetHTTPFactory().RetryCount, err)
 			}
 		} else if err != nil {
-			return fmt.Errorf("Received non-transport error: %v", err)
+			return fmt.Errorf("Failed to get object data : %v\n", err)
 		}
 
 		err = os.MkdirAll(filePath, 0755)
@@ -385,9 +382,6 @@ func GetObjectDataByChunk(ec ExchangeContext, org string, objType string, objId 
 	retryInterval := ec.GetHTTPFactory().GetRetryInterval()
 	for {
 		response, err := ec.GetHTTPFactory().NewHTTPClient(nil).Do(request)
-		if err != nil {
-			return false, fmt.Errorf("Failed to get object data from %d-%d : %v\n", startOffset, endOffset, err)
-		}
 
 		if response != nil && response.Body != nil {
 			defer response.Body.Close()
@@ -405,7 +399,7 @@ func GetObjectDataByChunk(ec ExchangeContext, org string, objType string, objId 
 			}
 
 		} else if err != nil {
-			return false, fmt.Errorf("Received non-transport error: %v", err)
+			return false, fmt.Errorf("Failed to get object data from %d-%d : %v\n", startOffset, endOffset, err)
 		}
 
 		if response != nil && response.StatusCode == http.StatusPartialContent {


### PR DESCRIPTION
Signed-off-by: Doug Larson <larsond@us.ibm.com>

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # #3306

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ x] I have checked my code and corrected any misspellings
- [ x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
