### PR TITLE
Issue 3313 - Bug: Creating an NMP doesn't default to start=now like help says

### DIFF
--- a/cli/exchange/nmp.go
+++ b/cli/exchange/nmp.go
@@ -111,6 +111,11 @@ func NMPAdd(org, credToUse, nmpName, jsonFilePath string, appliesTo, noConstrain
 		cliutils.Fatal(cliutils.JSON_PARSING_ERROR, msgPrinter.Sprintf("failed to unmarshal json input file %s: %v", jsonFilePath, err))
 	}
 
+	// set default value for start field, if left blank
+	if nmpFile.PolicyUpgradeTime == "" {
+		nmpFile.PolicyUpgradeTime = "now"
+	}
+
 	// validate the format of the nmp
 	if err = nmpFile.Validate(); err != nil {
 		cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("Incorrect node management policy format in file %s: %v", jsonFilePath, err))
@@ -126,7 +131,7 @@ func NMPAdd(org, credToUse, nmpName, jsonFilePath string, appliesTo, noConstrain
 
 		// Ensure that a manifest was specified
 		fullManifest := nmpFile.AgentAutoUpgradePolicy.Manifest
-		if fullManifest == ""{
+		if fullManifest == "" {
 			cliutils.Fatal(cliutils.CLI_INPUT_ERROR, msgPrinter.Sprintf("An AgentAutoUpgradePolicy was defined, but a manifest was not defined. Please specify a manifest that is stored in the CSS before attempting to add an NMP with an AgentAutoUpgradePolicy."))
 		}
 

--- a/exchangecommon/node_management_policy.go
+++ b/exchangecommon/node_management_policy.go
@@ -36,7 +36,7 @@ func (e *ExchangeNodeManagementPolicy) Validate() error {
 	msgPrinter := i18n.GetMessagePrinter()
 
 	// Validate the timestamp
-	if e.PolicyUpgradeTime != "now" && e.PolicyUpgradeTime != "" {
+	if e.PolicyUpgradeTime != "now" {
 		if _, err := time.Parse(time.RFC3339, e.PolicyUpgradeTime); err != nil {
 			return fmt.Errorf(msgPrinter.Sprintf("The start time must be in RFC3339 format or set to \"now\"."))
 		}


### PR DESCRIPTION
Signed-off-by: Jeff Kinard <jeff@thekinards.com>

# Pull Request Template

## Description

This PR adds a line of code to set the start time of an NMP to "now" when adding the NMP to the exchange if it was set to blank or if it was omitted.

Fixes #3313

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This was tested by adding an NMP without the start time defined and making sure it gets set to "now".

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
