### PR TITLE
Issue 3312 - Bug: NMP isn't checked before checking each nodes status

### DIFF
--- a/cli/exchange/nmp.go
+++ b/cli/exchange/nmp.go
@@ -252,9 +252,16 @@ func NMPStatus(org, credToUse, nmpName, nodeName string, long bool) {
 	// Get message printer
 	msgPrinter := i18n.GetMessagePrinter()
 
+	// Check to make sure NMP actually exists
+	var nmpList exchange.ExchangeNodeManagementPolicyResponse
+	httpCode := cliutils.ExchangeGet("Exchange", cliutils.GetExchangeUrl(), "orgs/"+nmpOrg+"/managementpolicies"+cliutils.AddSlash(nmpName), cliutils.OrgAndCreds(org, credToUse), []int{200, 404}, &nmpList)
+	if httpCode == 404 {
+		cliutils.Fatal(cliutils.NOT_FOUND, msgPrinter.Sprintf("NMP %s not found in org %s", nmpName, nmpOrg))
+	}
+
 	// Get names of nodes user can access from the Exchange
 	var resp ExchangeNodes
-	httpCode := cliutils.ExchangeGet("Exchange", cliutils.GetExchangeUrl(), "orgs/"+nmpOrg+"/nodes"+cliutils.AddSlash(nodeName), cliutils.OrgAndCreds(org, credToUse), []int{200, 404}, &resp)
+	httpCode = cliutils.ExchangeGet("Exchange", cliutils.GetExchangeUrl(), "orgs/"+nmpOrg+"/nodes"+cliutils.AddSlash(nodeName), cliutils.OrgAndCreds(org, credToUse), []int{200, 404}, &resp)
 	if httpCode == 404 {
 		cliutils.Fatal(cliutils.NOT_FOUND, msgPrinter.Sprintf("Node %s not found in org %s", nodeName, nmpOrg))
 	}


### PR DESCRIPTION
Signed-off-by: Jeff Kinard <jeff@thekinards.com>

# Pull Request Template

## Description

This PR adds logic to the `hzn exchange nmp status` CLI command to check that the NMP given as an argument actually exists in the Exchange before polling every node.

Fixes #3312 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This was tested by giving the command an NMP that does not exists in the Exchange, and making sure it returns a fatal error. It was then tested with NMP's that do exist as a regression test to make sure they still get polled across all nodes in the user's scope.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
