### PR TITLE
Issue3305 - change podman logic in rpm spec

### DIFF
--- a/pkg/rpm/horizon/horizon.spec
+++ b/pkg/rpm/horizon/horizon.spec
@@ -64,14 +64,11 @@ if [[ ! -f /etc/default/horizon ]]; then
 fi
 
 DOCKER_ENGINE="docker"
-command -v docker >/dev/null 2>&1
+# Check podman first since there is a podman-docker package that responds to docker
+command -v podman >/dev/null 2>&1
 rc=$?
-if [[ $rc -ne 0 ]]; then
-   command -v podman >/dev/null 2>&1
-   rc=$?
-   if [[ $rc -eq 0 ]]; then
-      DOCKER_ENGINE="podman"
-   fi
+if [[ $rc -eq 0 ]]; then
+   DOCKER_ENGINE="podman"
 fi
 
 #if podman, DockerEndpoint needs to change


### PR DESCRIPTION
Signed-off-by: Doug Larson <larsond@us.ibm.com>

# Pull Request Template

## Description
For the rpm spec file, check for podman first so that we can start the podman service if needed... If podman-docker is installed, we never started the podman service

Fixes # #3305 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] This change requires a documentation update

## How Has This Been Tested?

Built an RPM package; installed horizon; and made sure podman service was restart

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ x] I have checked my code and corrected any misspellings
- [ x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
