### PR TITLE
Issue 3318 - Bug: Manifests published by hzn man add CLI command not being digitally signed

### DIFF
--- a/cli/hzn.go
+++ b/cli/hzn.go
@@ -636,6 +636,10 @@ Environment Variables:
 	nmManifestAddType := nmManifestAddCmd.Flag("type", msgPrinter.Sprintf("The type of manifest to add. Valid values include 'agent_upgrade_manifests'.")).Required().Short('t').String()
 	nmManifestAddId := nmManifestAddCmd.Flag("id", msgPrinter.Sprintf("The id of the manifest to add.")).Required().Short('i').String()
 	nmManifestAddFile := nmManifestAddCmd.Flag("json-file", msgPrinter.Sprintf("The path of a JSON file containing the manifest data. Specify -f- to read from stdin.")).Short('f').Required().String()
+	nmManifestAddDSHashAlgo := nmManifestAddCmd.Flag("hashAlgo", msgPrinter.Sprintf("The hash algorithm used to hash the manifest data before signing it, ensuring data integrity during upload and download. Supported hash algorithms are SHA1 or SHA256, the default is SHA1. It is mutually exclusive with the --noIntegrity flag")).Short('a').String()
+	nmManifestAddDSHash := nmManifestAddCmd.Flag("hash", msgPrinter.Sprintf("The hash of the manifest data being uploaded or downloaded. Use this flag if you want to provide the hash instead of allowing the command to automatically calculate the hash. The hash must be generated using either the SHA1 or SHA256 algorithm. The -a flag must be specified if the hash was generated using SHA256. This flag is mutually exclusive with --noIntegrity.")).String()
+	nmManifestAddPrivKeyFile := nmManifestAddCmd.Flag("private-key-file", msgPrinter.Sprintf("The path of a private key file to be used to sign the manifest. The corresponding public key will be stored in the MMS to ensure integrity of the manifest. If not specified, the environment variable HZN_PRIVATE_KEY_FILE will be used to find a private key. If not set, ~/.hzn/keys/service.private.key will be used. If it does not exist, an RSA key pair is generated only for this publish operation and then the private key is discarded.")).Short('k').ExistingFile()
+	nmManifestAddSkipIntegrityCheck := nmManifestAddCmd.Flag("noIntegrity", msgPrinter.Sprintf("The publish command will not perform a data integrity check on the uploaded manifest data. It is mutually exclusive with --hashAlgo and --hash")).Bool()
 	nmManifestListCmd := nmManifestCmd.Command("list | ls", msgPrinter.Sprintf("Display a list of manifest files stored in the management hub.")).Alias("ls").Alias("list")
 	nmManifestListType := nmManifestListCmd.Flag("type", msgPrinter.Sprintf("The type of manifest to list. Valid values include 'agent_upgrade_manifests'.")).Short('t').String()
 	nmManifestListId := nmManifestListCmd.Flag("id", msgPrinter.Sprintf("The id of the manifest to list. Must specify --type flag.")).Short('i').String()
@@ -1321,7 +1325,7 @@ Environment Variables:
 	case nmManifestListCmd.FullCommand():
 		node_management.ManifestList(*nmOrg, *nmUserPw, *nmManifestListId, *nmManifestListType, *nmManifestListLong)
 	case nmManifestAddCmd.FullCommand():
-		node_management.ManifestAdd(*nmOrg, *nmUserPw, *nmManifestAddFile, *nmManifestAddId, *nmManifestAddType)
+		node_management.ManifestAdd(*nmOrg, *nmUserPw, *nmManifestAddFile, *nmManifestAddId, *nmManifestAddType, *nmManifestAddDSHashAlgo, *nmManifestAddDSHash, *nmManifestAddPrivKeyFile, *nmManifestAddSkipIntegrityCheck)
 	case nmManifestNewCmd.FullCommand():
 		node_management.ManifestNew()
 	case nmManifestRemoveCmd.FullCommand():


### PR DESCRIPTION
Signed-off-by: Jeff Kinard <jeff@thekinards.com>

# Pull Request Template

## Description

This PR adds digital signing to manifest uploads to the CSS. This was a feature already implemented for model uploads, so it was refactored to support manifests as well.

Fixes #3318 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This was tested by uploading a manifest using the `hzn nm man add` command (which now has digital signing), and running a NMP upgrade to make sure it did not break the NMP process. The `hzn mms obj pub` command was also tested to make sure it worked as before.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
