### PR TITLE
Issue 3320 - Bug: Publishing a new agent config or cert file causes N…

### DIFF
--- a/cli/exchange/nmp.go
+++ b/cli/exchange/nmp.go
@@ -293,10 +293,10 @@ func NMPStatus(org, credToUse, nmpName, nodeName string, long bool) {
 
 	// Create result object so that the status object can be associated back to the correct node when found on a thread
 	type nmpResult struct {
-		nodeName string
-		nmpStatus string
+		nodeName         string
+		nmpStatus        string
 		nmpStatusObjects map[string]*exchangecommon.NodeManagementPolicyStatus
-	}	
+	}
 
 	c := make(chan nmpResult)
 
@@ -366,7 +366,7 @@ func determineCompatibleNodes(org, credToUse, nmpName string, nmpPolicy exchange
 	nodeMap := make(map[string]exchange.Device, 0)
 	batchNum := 1
 	for nodeNameEx, node := range exchangeNodes.Nodes {
-		if batchNum % batchSize == 0 {
+		if batchNum%batchSize == 0 {
 			batches = append(batches, nodeMap)
 			nodeMap = make(map[string]exchange.Device, 0)
 		}

--- a/events/events.go
+++ b/events/events.go
@@ -2157,11 +2157,12 @@ func NewNMPStartDownloadMessage(id EventId, message StartDownloadMessage) *NMPSt
 }
 
 type NMPDownloadCompleteMessage struct {
-	event    Event
-	Status   string
-	NMPName  string
-	Versions *exchangecommon.AgentUpgradeVersions
-	Latests  *exchangecommon.AgentUpgradeLatest
+	event        Event
+	Status       string
+	ErrorMessage string
+	NMPName      string
+	Versions     *exchangecommon.AgentUpgradeVersions
+	Latests      *exchangecommon.AgentUpgradeLatest
 }
 
 func (n *NMPDownloadCompleteMessage) Event() Event {
@@ -2169,22 +2170,23 @@ func (n *NMPDownloadCompleteMessage) Event() Event {
 }
 
 func (n *NMPDownloadCompleteMessage) String() string {
-	return fmt.Sprintf("event: %v, Status: %v", n.event, n.Status)
+	return fmt.Sprintf("event: %v, Status: %v, ErrorMessage: %v", n.event, n.Status, n.ErrorMessage)
 }
 
 func (n *NMPDownloadCompleteMessage) ShortString() string {
 	return n.String()
 }
 
-func NewNMPDownloadCompleteMessage(id EventId, status string, name string, vers *exchangecommon.AgentUpgradeVersions, latest *exchangecommon.AgentUpgradeLatest) *NMPDownloadCompleteMessage {
+func NewNMPDownloadCompleteMessage(id EventId, status string, errMsg string, name string, vers *exchangecommon.AgentUpgradeVersions, latest *exchangecommon.AgentUpgradeLatest) *NMPDownloadCompleteMessage {
 	return &NMPDownloadCompleteMessage{
 		event: Event{
 			Id: id,
 		},
-		Status:   status,
-		NMPName:  name,
-		Versions: vers,
-		Latests:  latest,
+		Status:       status,
+		ErrorMessage: errMsg,
+		NMPName:      name,
+		Versions:     vers,
+		Latests:      latest,
 	}
 }
 

--- a/exchange/css.go
+++ b/exchange/css.go
@@ -348,7 +348,7 @@ func GetObjectData(ec ExchangeContext, org string, objType string, objId string,
 // set CloseRequest to true if this is the last chunk
 // return true, nil if response code is 200 -- get all the object data
 // return false, nil if response code is 206 -- get data in range of bytes {startOffset} - {endOffset}
-func GetObjectDataByChunk(ec ExchangeContext, org string, objType string, objId string, startOffset int64, endOffset int64, closeRequest bool, filePath string, fileName string,  saveToTempFile bool) (bool, error) {
+func GetObjectDataByChunk(ec ExchangeContext, org string, objType string, objId string, startOffset int64, endOffset int64, closeRequest bool, filePath string, fileName string, saveToTempFile bool) (bool, error) {
 	url := path.Join("/api/v1/objects", org, objType, objId, "data")
 	url = ec.GetCSSURL() + url
 

--- a/nodemanagement/messages.go
+++ b/nodemanagement/messages.go
@@ -5,8 +5,9 @@ import (
 )
 
 const (
-	EL_NMP_STATUS_CREATED = "New node management policy status created for policy %v."
-	EL_NMP_STATUS_CHANGED = "Node management status for %v changed to %v."
+	EL_NMP_STATUS_CREATED            = "New node management policy status created for policy %v."
+	EL_NMP_STATUS_CHANGED            = "Node management status for %v changed to %v."
+	EL_NMP_STATUS_CHANGED_WITH_ERROR = "Node management status for %v changed to %v. Error message: %v"
 )
 
 // This is does nothing useful at run time.

--- a/persistence/eventlog_const.go
+++ b/persistence/eventlog_const.go
@@ -48,6 +48,7 @@ const (
 	EC_NMP_STATUS_DOWNLOAD_SUCCESSFUL = "node_management_status_download_success"
 	EC_NMP_STATUS_DOWNLOAD_FAILED     = "node_management_status_download_failed"
 	EC_NMP_STATUS_UPDATE_COMPLETE     = "node_management_status_update_complete"
+	EC_NMP_STATUS_CHANGED             = "node_management_status_changed"
 
 	// node pattern
 	EC_NODE_PATTERN_CHANGED            = "node_pattern_changed"


### PR DESCRIPTION
…MPs for software upgrades to be evaluated

Signed-off-by: linggao <linggao@us.ibm.com>

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

1. Fixes #3270 
2. Fixes #3320
3. Fixes a problem that did not download the agent-install.sh from CSS if it is listed in the manifest.
4. New behavior: If the agent/cert/config has the same version as specified in the manifest, the agent will do nothing even if the "AllowDowngrade" is set to true in a NMP. The old behavior was that the agent would download the package of the same versions and reinstall if "AllowDowngrade" is true. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
