### PR TITLE
Issue 3360: Fix typos in service.go

### DIFF
--- a/cli/exchange/service.go
+++ b/cli/exchange/service.go
@@ -575,7 +575,7 @@ func ServiceAddPolicy(org string, credToUse string, service string, jsonFilePath
 	// Set default built in properties before publishing to the exchange
 	msgPrinter.Printf("Adding built-in property values...")
 	msgPrinter.Println()
-	msgPrinter.Printf("The following property value will be overriden: service.url, service.name, service.org, service.version, service.arch")
+	msgPrinter.Printf("The following property values will be overridden: service.url, service.name, service.org, service.version, service.arch")
 	msgPrinter.Println()
 
 	properties := policyFile.Properties
@@ -594,7 +594,7 @@ func ServiceAddPolicy(org string, credToUse string, service string, jsonFilePath
 	}
 
 	// add/replace service policy
-	msgPrinter.Printf("Updating Service policy  and re-evaluating all agreements based on this Service policy. Existing agreements might be cancelled and re-negotiated.")
+	msgPrinter.Printf("Updating Service policy and re-evaluating all agreements based on this Service policy. Existing agreements might be cancelled and re-negotiated.")
 	msgPrinter.Println()
 	cliutils.ExchangePutPost("Exchange", http.MethodPut, exchUrl, "orgs/"+svcorg+"/services/"+service+"/policy", cliutils.OrgAndCreds(org, credToUse), []int{201}, policyFile, nil)
 
@@ -669,7 +669,7 @@ func SaveOpYamlToFile(sId string, clusterDeployment string, filePath string, for
 	msgPrinter.Println()
 }
 
-// This function getst the operator yaml archive (in .tat.gz format) from the clusterDeployment
+// This function gets the operator yaml archive (in .tar.gz format) from the clusterDeployment
 // string from a service
 func GetOpYamlArchiveFromClusterDepl(deploymentConfig string) []byte {
 	// get message printer


### PR DESCRIPTION
Signed-off-by: John Walicki <johnwalicki@gmail.com>

# Pull Request Template

## Description

Typos :

-   overriden should be spelled overridden in cli/exchange/service.go
-  There is an extra space in the string Updating Service policy and re-evaluating in cli/exchange/service.go

Run this command:
```
hzn exchange service addpolicy -f horizon/service.policy.json org/myservice_1.0.0_amd64
Adding built-in property values...
The following property value will be overriden: service.url, service.name, service.org, service.version, service.arch
Updating Service policy  and re-evaluating all agreements based on this Service policy. Existing agreements might be cancelled and re-negotiated.
Service policy updated.
```

Fixes #3360

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.