### PR TITLE
Issue-3408: Changed copy docs GHA dst-owner to joewxboy

### DIFF
--- a/.github/workflows/copydocs.yml
+++ b/.github/workflows/copydocs.yml
@@ -18,7 +18,7 @@ jobs:
         personal_token: ${{ secrets.PERSONAL_TOKEN }}
         src_path: docs
         dst_path: /docs/anax
-        dst_owner: open-horizon
+        dst_owner: joewxboy
         dst_repo_name: open-horizon.github.io
         dst_branch: master
         src_branch: master


### PR DESCRIPTION
Signed-off-by: Joe Pearson <joewxboy@users.noreply.github.com>

# Pull Request Template

## Description

CHanged copy docs GHA `dst_owner` to an actual account, and `secrets.PERSONAL_TOKEN` to a personal access token with least privileged permissions.

Fixes #3408 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Read the fine manual when I discovered that the GHA was failing silently, realized we had never done it right and wondered how it ever worked.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->

FYI ... @johnwalicki and @dabooz 