### PR TITLE
Issue2698 - Agbot reuse http conns

### DIFF
--- a/cli/cliutils/cliutils.go
+++ b/cli/cliutils/cliutils.go
@@ -1991,7 +1991,7 @@ func GetHTTPClient(timeout int) *http.Client {
 			ResponseHeaderTimeout: time.Duration(responseTimeout) * time.Second,
 			ExpectContinueTimeout: time.Duration(expectContinue) * time.Second,
 			MaxIdleConns:          config.MaxHTTPIdleConnections,
-			IdleConnTimeout:       config.HTTPIdleConnectionTimeoutS * time.Second,
+			IdleConnTimeout:       config.HTTPIdleConnectionTimeout * time.Millisecond, // ms since we don't want cli to hold onto connections for very long
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: skipSSL,
 			},

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	ExchangeURL                      string
 	AgbotURL                         string
 	DefaultHTTPClientTimeoutS        uint
+	HTTPIdleConnectionTimeout        uint      // Will be seconds for agbot and milliseconds for agent
 	PolicyPath                       string
 	ExchangeHeartbeat                int       // Seconds between heartbeats
 	ExchangeVersionCheckIntervalM    int64     // Exchange version check interval in minutes. The default is 720. This is now deprecated with the usage of /changes API which returns exchange version on every call.
@@ -381,6 +382,7 @@ func Read(file string) (*HorizonConfig, error) {
 		// instantiate mostly empty which will be filled. Values here are defaults that can be overridden by the user
 		config := HorizonConfig{
 			Edge: Config{
+				HTTPIdleConnectionTimeout:      HTTPIdleConnectionTimeout,
 				DefaultHTTPClientTimeoutS:      HTTPRequestTimeoutS,
 				ExchangeMessageDynamicPoll:     true,
 				ExchangeMessagePollInterval:    ExchangeMessagePollInterval_DEFAULT,
@@ -508,6 +510,7 @@ func (con *Config) String() string {
 		", ExchangeURL: %v"+
 		", AgbotURL: %v"+
 		", DefaultHTTPClientTimeoutS: %v"+
+		", HTTPIdleConnectionTimeout: %v"+
 		", PolicyPath: %v"+
 		", ExchangeHeartbeat: %v"+
 		", AgreementTimeoutS: %v"+
@@ -533,7 +536,7 @@ func (con *Config) String() string {
 		", BlockchainDirectoryAddress %v",
 		con.ServiceStorage, con.APIListen, con.DBPath, con.DockerEndpoint, con.DockerCredFilePath, con.DefaultCPUSet,
 		con.DefaultServiceRegistrationRAM, con.StaticWebContent, con.PublicKeyPath, con.TrustSystemCACerts, con.CACertsPath, con.ExchangeURL, con.AgbotURL,
-		con.DefaultHTTPClientTimeoutS, con.PolicyPath, con.ExchangeHeartbeat, con.AgreementTimeoutS,
+		con.DefaultHTTPClientTimeoutS, con.HTTPIdleConnectionTimeout, con.PolicyPath, con.ExchangeHeartbeat, con.AgreementTimeoutS,
 		con.DVPrefix, con.RegistrationDelayS, con.ExchangeMessageTTL, con.ExchangeMessageDynamicPoll, con.ExchangeMessagePollInterval,
 		con.ExchangeMessagePollMaxInterval, con.ExchangeMessagePollIncrement, con.UserPublicKeyPath, con.ReportDeviceStatus,
 		con.TrustCertUpdatesFromOrg, con.TrustDockerAuthFromOrg, con.ServiceUpgradeCheckIntervalS, con.MultipleAnaxInstances,

--- a/config/constants.go
+++ b/config/constants.go
@@ -11,14 +11,20 @@ const MICROSERVICE_EXEC_TIMEOUT = 180
 // MaxHTTPIdleConnections see https://golang.org/pkg/net/http/
 const MaxHTTPIdleConnections = 20
 
+// MaxHTTPIdleConnsPerHost see https://golang.org/pkg/net/http/
+const MaxHTTPIdleConnsPerHost = 20
+
+// MaxHTTPIdleConnsPerHost see https://golang.org/pkg/net/http/
+const MaxHTTPIdleConnsPerHost_Agent = 1
+
 // HTTPRequestTimeoutS see https://golang.org/pkg/net/http/
 const HTTPRequestTimeoutS = 30
 
 // HTTPRequestTimeoutOverride environment variable
 const HTTPRequestTimeoutOverride = "HZN_HTTP_TIMEOUT"
 
-// HTTPIdleConnectionTimeoutS see https://golang.org/pkg/net/http/
-const HTTPIdleConnectionTimeoutS = 120
+// HTTPIdleConnectionTimeout see https://golang.org/pkg/net/http/
+const HTTPIdleConnectionTimeout = 60     // Will be in seconds for agbot and milliseconds for agent
 
 const HZN_VAR_BASE_DEFAULT = "/var/horizon"
 

--- a/css/horizonAuthenticate.go
+++ b/css/horizonAuthenticate.go
@@ -460,7 +460,9 @@ func (auth *HorizonAuthenticate) invokeExchange(url string, user string, pw stri
 	// Add the basic auth header so that the exchange will authenticate.
 	req.SetBasicAuth(user, pw)
 	req.Header.Add("Accept", "application/json")
-	req.Close = true
+
+	// Remove the req.Close so that connections from CSS to Exchange can be reused
+	//req.Close = true 
 
 	// Send the request to verify the user.
 	resp, err := auth.httpClient.Do(req)
@@ -558,7 +560,11 @@ func newHTTPClient(certPath string) (*http.Client, error) {
 			TLSHandshakeTimeout:   20 * time.Second,
 			ResponseHeaderTimeout: 20 * time.Second,
 			ExpectContinueTimeout: 8 * time.Second,
+
+			// Guidance from https://www.loginradius.com/blog/engineering/tune-the-go-http-client-for-high-performance/
 			MaxIdleConns:          20,
+			MaxConnsPerHost:       20,
+			MaxIdleConnsPerHost:   20,
 			IdleConnTimeout:       120 * time.Second,
 			TLSClientConfig:       &tlsConf,
 		},

--- a/exchange/rpc.go
+++ b/exchange/rpc.go
@@ -107,7 +107,12 @@ func InvokeExchange(httpClient *http.Client, method string, urlPath string, user
 	if req, err := http.NewRequest(method, urlObj.String(), requestBody); err != nil {
 		return errors.New(fmt.Sprintf("Invocation of %v at %v with %v failed creating HTTP request, error: %v", method, urlPath, requestBody, err)), nil
 	} else {
-		req.Close = true // work around to ensure that Go doesn't get connections confused. Supposed to be fixed in Go 1.6.
+                /*
+                 * "req.Close  = true" code commented out so that agbot can reuse connections on the management hub.
+                 * In order to support 10's of thousands of agents though there is a different behavior between agbot and agent where the agbot sets
+                 * a IdleConnTimeout in seconds and the agent sets the IdleConnTimeout in milliseconds so it frees up quickly after a request/response
+                 */
+                //req.Close = true // work around to ensure that Go doesn't get connections confused. Supposed to be fixed in Go 1.6.
 		req.Header.Add("Accept", "application/json")
 		if method != "GET" {
 			req.Header.Add("Content-Type", "application/json")


### PR DESCRIPTION
Signed-off-by: Doug Larson <larsond@us.ibm.com>

# Pull Request Template

## Description

Change for anax (running as agbot) to reuse HTTP connections to the Exchange which will be much more efficient when SSL to the exchange is enabled 

Fixes https://github.com/open-horizon/anax/issues/2698

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran and monitored running as an agent and as agbots

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ x] I have checked my code and corrected any misspellings
- [ x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
