### PR TITLE
Issue #3473 - decrease pollInterval on node policy change

### DIFF
--- a/changes/changes_worker.go
+++ b/changes/changes_worker.go
@@ -23,11 +23,11 @@ const (
 	UPDATE_TYPE_ALERT       = "ALERT"       // set the poll interval to (min + max)/POLL_INTERVAL_ALERT_LEVEL
 	UPDATE_TYPE_NEW_CONFIG  = "NEW_CONFIG"  // adjust the poll interval according to the new configuration
 	UPDATE_TYPE_NO_CHANGES  = "NO_CHANGES"  // increate poll interval because there are no changes
-	UPDATE_TYPE_HB_FAILED   = "HB_FAILED"   // set poll interval to minimum until hb succeds
+	UPDATE_TYPE_HB_FAILED   = "HB_FAILED"   // set poll interval to minimum until hb succeeds
 	UPDATE_TYPE_HB_RESTORED = "HB_RESTORED" // set poll interval back to what it was before failing
 
 	// alert level
-	POLL_INTERVAL_ALERT_LEVEL = 2
+	POLL_INTERVAL_ALERT_LEVEL = 4
 )
 
 type ChangesWorker struct {
@@ -38,7 +38,7 @@ type ChangesWorker struct {
 	pollMinInterval        int    // The minimum time to wait between polls to the exchange.
 	pollMaxInterval        int    // The maximum time to wait between polls to the exchange.
 	pollAdjustment         int    // The amount to increase the polling time, each time it is increased.
-	pollInitTime           int64  // THe time when the polling starts 10sec interval
+	pollInitTime           int64  // The time when the polling starts 10sec interval.
 	agreementReached       bool   // True when ths node has seen at least one agreement.
 	noMsgCount             int    // How many consecutive polls have returned no changes.
 	changeID               uint64 // The current change Id in the exchange.
@@ -240,11 +240,11 @@ func (w *ChangesWorker) findAndProcessChanges() {
 
 	w.noworkDispatch = time.Now().Unix()
 
-	// If there is no last known change id, then we havent initialized yet,so do nothing.
+	// If there is no last known change id, then we havent initialized yet, so do nothing.
 	maxRecords := 1000
 	if w.changeID == 0 {
 		if err := w.getChangeId(); err != nil {
-			glog.Errorf(chglog(fmt.Sprintf("Failed to get the max change id. %v", err)))
+			glog.Errorf(chglog(fmt.Sprintf("Failed to get the max change ID. %v", err)))
 			return
 		} else if w.changeID == 0 {
 			glog.Warningf(chglog(fmt.Sprintf("No starting change ID")))
@@ -430,7 +430,7 @@ func (w *ChangesWorker) handleHeartbeatStateAndError(changes *exchange.ExchangeC
 }
 
 // Setting up the new polling interval according to the updateType:
-// 	 UPDATE_TYPE_RESET:  set the poll interval to min
+// 	UPDATE_TYPE_RESET:  set the poll interval to min
 //	 UPDATE_TYPE_ALERT:  set the poll interval to (min + max)/POLL_INTERVAL_ALERT_LEVEL
 //	 UPDATE_TYPE_NEW_CONFIG: adjust the poll interval according to the new configuration from node or node org
 //	 UPDATE_TYPE_NO_CHANGES: increate poll interval because there are no changes
@@ -438,7 +438,7 @@ func (w *ChangesWorker) handleHeartbeatStateAndError(changes *exchange.ExchangeC
 func (w *ChangesWorker) updatePollingInterval(updateType string) {
 
 	if updateType == UPDATE_TYPE_RESET {
-		// set the polling interval to minial. This is the case where agreement negotiation started when the node needs to
+		// set the polling interval to minimal. This is the case where agreement negotiation started when the node needs to
 		// watch the upcoming messages more closely.
 		if w.pollInterval != w.pollMinInterval {
 			w.pollInterval = w.pollMinInterval
@@ -450,7 +450,7 @@ func (w *ChangesWorker) updatePollingInterval(updateType string) {
 	} else if updateType == UPDATE_TYPE_ALERT {
 		// This is the case when the node should be watching the changes more often than max but not as frequent as min.
 		// It is called alert.
-		// For excample: node policy changed, node userinput changed, node itself changed, service changed,
+		// For example: node policy changed, node userinput changed, node itself changed, service changed,
 		// agreement canceled etc.
 		// Set the polling interval to (min + max)/POLL_INTERVAL_ALERT_LEVEL.
 		// If the current pollInterval is smaller than the alert value, keep the current because it may
@@ -612,7 +612,7 @@ func (w *ChangesWorker) getHeartbeatIntervals() bool {
 	if updated {
 		// make sure that the min interval is not greater than the max
 		if w.pollMaxInterval < w.pollMinInterval {
-			glog.V(3).Infof(chglog(fmt.Sprintf("Max poll interval %v cannot be samller than the min %v. Will make max poll interval equals to then min poll interval.", w.pollMaxInterval, w.pollMinInterval)))
+			glog.V(3).Infof(chglog(fmt.Sprintf("Max poll interval %v cannot be smaller than the min %v. Will make max poll interval equal to the min poll interval.", w.pollMaxInterval, w.pollMinInterval)))
 			w.pollMaxInterval = w.pollMinInterval
 		}
 

--- a/changes/changes_worker.go
+++ b/changes/changes_worker.go
@@ -27,7 +27,7 @@ const (
 	UPDATE_TYPE_HB_RESTORED = "HB_RESTORED" // set poll interval back to what it was before failing
 
 	// alert level
-	POLL_INTERVAL_ALERT_LEVEL = 4
+	POLL_INTERVAL_ALERT_LEVEL = 2
 )
 
 type ChangesWorker struct {
@@ -154,7 +154,7 @@ func (w *ChangesWorker) NewEvent(incoming events.Message) {
 		w.Commands <- NewUpdateIntervalCommand(UPDATE_TYPE_RESET)
 
 	case *events.NodePolicyMessage:
-		w.Commands <- NewUpdateIntervalCommand(UPDATE_TYPE_ALERT)
+		w.Commands <- NewUpdateIntervalCommand(UPDATE_TYPE_RESET)
 
 	case *events.NodeUserInputMessage:
 		w.Commands <- NewUpdateIntervalCommand(UPDATE_TYPE_ALERT)
@@ -430,10 +430,10 @@ func (w *ChangesWorker) handleHeartbeatStateAndError(changes *exchange.ExchangeC
 }
 
 // Setting up the new polling interval according to the updateType:
-// 	UPDATE_TYPE_RESET:  set the poll interval to min
-//	 UPDATE_TYPE_ALERT:  set the poll interval to (min + max)/POLL_INTERVAL_ALERT_LEVEL
-//	 UPDATE_TYPE_NEW_CONFIG: adjust the poll interval according to the new configuration from node or node org
-//	 UPDATE_TYPE_NO_CHANGES: increate poll interval because there are no changes
+//   UPDATE_TYPE_RESET:  set the poll interval to min
+//   UPDATE_TYPE_ALERT:  set the poll interval to (min + max)/POLL_INTERVAL_ALERT_LEVEL
+//   UPDATE_TYPE_NEW_CONFIG: adjust the poll interval according to the new configuration from node or node org
+//   UPDATE_TYPE_NO_CHANGES: increate poll interval because there are no changes
 
 func (w *ChangesWorker) updatePollingInterval(updateType string) {
 
@@ -445,7 +445,6 @@ func (w *ChangesWorker) updatePollingInterval(updateType string) {
 			w.SetNoWorkInterval(w.pollInterval)
 			glog.V(3).Infof(chglog(fmt.Sprintf("Resetting poll interval to %v, max interval is %v, increment is %v.", w.pollInterval, w.pollMaxInterval, w.pollAdjustment)))
 		}
-
 		w.noMsgCount = 0
 	} else if updateType == UPDATE_TYPE_ALERT {
 		// This is the case when the node should be watching the changes more often than max but not as frequent as min.

--- a/changes/changes_worker.go
+++ b/changes/changes_worker.go
@@ -440,6 +440,7 @@ func (w *ChangesWorker) updatePollingInterval(updateType string) {
 	if updateType == UPDATE_TYPE_RESET {
 		// set the polling interval to minimal. This is the case where agreement negotiation started when the node needs to
 		// watch the upcoming messages more closely.
+		// Also when the node policy changed and an agreement negotiation will likely need to start
 		if w.pollInterval != w.pollMinInterval {
 			w.pollInterval = w.pollMinInterval
 			w.SetNoWorkInterval(w.pollInterval)
@@ -449,8 +450,7 @@ func (w *ChangesWorker) updatePollingInterval(updateType string) {
 	} else if updateType == UPDATE_TYPE_ALERT {
 		// This is the case when the node should be watching the changes more often than max but not as frequent as min.
 		// It is called alert.
-		// For example: node policy changed, node userinput changed, node itself changed, service changed,
-		// agreement canceled etc.
+		// For example: node userinput changed, node itself changed, service changed, agreement canceled etc.
 		// Set the polling interval to (min + max)/POLL_INTERVAL_ALERT_LEVEL.
 		// If the current pollInterval is smaller than the alert value, keep the current because it may
 		// be in the middle of the agreement negotiation.


### PR DESCRIPTION
Signed-off-by: John Walicki <johnwalicki@gmail.com>

# Pull Request Template

## Description

Change the `POLL_INTERVAL_ALERT_LEVEL` from `2` to `4` 
This will decrease the pollInterval when there is a pending node policy change from 70 seconds to 35 seconds

I also fixed a variety of minor spelling issues in the comments and strings.

Fixes #3473

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Run `hzn policy update --input-file=/tmp/changes.json` and watch the logs.
...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.