### PR TITLE
Issue3528 - Use docker volume for /ess-store for anax-in-container

### DIFF
--- a/anax-in-container/script/anax.service
+++ b/anax-in-container/script/anax.service
@@ -106,10 +106,6 @@ defaultEnv() {
 	anaxJson=$(jq ".Edge.NodeMgmtWorkDirectory = \"${base_host_dir}/nmp\" " <<< $anaxJson)
 	checkrc $? "change NodeMgmtWorkDirectory"
 
-	# always add this directory. Agent will create it.
-	anaxJson=$(jq ".Edge.FileSyncService.PersistencePath = \"${base_host_dir}/ess-store\" " <<< $anaxJson)
-	checkrc $? "change PersistencePath"
-
 	# Write the new json back to the file
 	echo "$anaxJson" > $anaxJsonFile
 	checkrc $? "write anax.json"


### PR DESCRIPTION
Signed-off-by: Doug Larson <larsond@us.ibm.com>

# Pull Request Template

## Description

Revert previous change to go back to using a docker volume for /ess-store when running in anax-in-container

Fixes # https://github.com/open-horizon/anax/issues/3528

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Built and run on a samsung phone

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ x] I have checked my code and corrected any misspellings
- [ x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
