### PR TITLE
Issue #3554 - fix error msg typo

### DIFF
--- a/kube_operator/kubeworker.go
+++ b/kube_operator/kubeworker.go
@@ -118,7 +118,7 @@ func (w *KubeWorker) CommandHandler(command worker.Command) bool {
 
 		kdc, ok := cmd.Deployment.(*persistence.KubeDeploymentConfig)
 		if !ok {
-			glog.Warningf(kwlog(fmt.Sprintf("ignoring non-Kube maintenence command: %v", cmd)))
+			glog.Warningf(kwlog(fmt.Sprintf("ignoring non-Kube maintenance command: %v", cmd)))
 		} else if err := w.operatorStatus(kdc, "Running", cmd.AgreementId); err != nil {
 			glog.Errorf(kwlog(fmt.Sprintf("%v", err)))
 			w.Messages() <- events.NewWorkloadMessage(events.EXECUTION_FAILED, cmd.AgreementProtocol, cmd.AgreementId, kdc)


### PR DESCRIPTION
Signed-off-by: John Walicki <johnwalicki@gmail.com>

Fixes #3554 

Fixes a typo `s/maintenence/maintenance/g`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x ] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.