### PR TITLE
Issue open-horizon#3843 - Failed to decompress agent image tarball du…

### DIFF
--- a/clusterupgrade/cluster_install_files.go
+++ b/clusterupgrade/cluster_install_files.go
@@ -419,6 +419,13 @@ func decompress(tarGZFilePath, targetFolder string) error {
 	}
 	defer uncompressStream.Close()
 
+	// create the target folder if it is not exist
+	if _, err := os.Stat(targetFolder); err != nil {
+		if err := os.MkdirAll(targetFolder, 0755); err != nil {
+			return err
+		}
+	}
+
 	tarReader := tar.NewReader(uncompressStream)
 	for {
 		header, err := tarReader.Next()


### PR DESCRIPTION
…ring cluster agent auto-upgrade

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
