### PR TITLE
open-horizon#3896 - Second translation message drop for 3Q2023

### DIFF
--- a/cli/locales/fr/messages.gotext.json
+++ b/cli/locales/fr/messages.gotext.json
@@ -1826,6 +1826,30 @@
       "fuzzy": true
     },
     {
+      "id": "Name, or Org is empty string.",
+      "message": "Name, or Org is empty string.",
+      "translation": "Le nom ou l'organisation est une chaîne vide.",
+      "fuzzy": true
+    },
+    {
+      "id": "The serviceVersions array is empty.",
+      "message": "The serviceVersions array is empty.",
+      "translation": "Le tableau serviceVersions est vide.",
+      "fuzzy": true
+    },
+    {
+      "id": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+      "message": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+      "translation": "retry_durations et retries ne peuvent pas être égales à zéro si priority_value est défini sur une valeur différente de zéro",
+      "fuzzy": true
+    },
+    {
+      "id": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+      "message": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+      "translation": "retry_durations, retries et verified_durations ne peuvent pas avoir une valeur différente de zéro si priority_value est égale à zéro ou n'est pas définie",
+      "fuzzy": true
+    },
+    {
       "id": "properties contains an invalid property: {Err}",
       "message": "properties contains an invalid property: {Err}",
       "translation": "Les propriétés comportent une propriété non valide : {Err}",
@@ -17202,6 +17226,38 @@
       "fuzzy": true
     },
     {
+      "id": "failed to unmarshal ClusterDeployment in 'hzn exchange service list' output: {Err}",
+      "message": "failed to unmarshal ClusterDeployment in 'hzn exchange service list' output: {Err}",
+      "translation": "Echec de la désérialisation de ClusterDeployment dans la sortie 'hzn exchange service list' : {Err}",
+      "placeholders": [
+        {
+          "id": "Err",
+          "string": "%[1]v",
+          "type": "error",
+          "underlyingType": "interface{Error() string}",
+          "argNum": 1,
+          "expr": "err"
+        }
+      ],
+      "fuzzy": true
+    },
+    {
+      "id": "failed to marshal truncked ClusterDeployment in 'hzn exchange service list' output: {Err}",
+      "message": "failed to marshal truncked ClusterDeployment in 'hzn exchange service list' output: {Err}",
+      "translation": "Echec de la sérialisation de ClusterDeployment tronqué dans la sortie 'hzn exchange service list' : {Err}",
+      "placeholders": [
+        {
+          "id": "Err",
+          "string": "%[1]v",
+          "type": "error",
+          "underlyingType": "interface{Error() string}",
+          "argNum": 1,
+          "expr": "err"
+        }
+      ],
+      "fuzzy": true
+    },
+    {
       "id": "Ignoring -f because the clusterDeployment attribute is empty for this service.",
       "message": "Ignoring -f because the clusterDeployment attribute is empty for this service.",
       "translation": "-f est ignoré car l'attribut clusterDeployment est vide pour ce service.",
@@ -27697,22 +27753,6 @@
       "fuzzy": true
     },
     {
-      "id": "Node type '{NodeType}' does not support secret binding check.",
-      "message": "Node type '{NodeType}' does not support secret binding check.",
-      "translation": "Le type de noeud '{NodeType}' ne prend pas en charge la vérification de liaison de secret.",
-      "placeholders": [
-        {
-          "id": "NodeType",
-          "string": "%[1]v",
-          "type": "string",
-          "underlyingType": "string",
-          "argNum": 1,
-          "expr": "nodeType"
-        }
-      ],
-      "fuzzy": true
-    },
-    {
       "id": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
       "message": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
       "translation": "Aucune version de service avec l'architecture {NodeArch} n'est spécifiée dans la règle de déploiement ou le pattern.",
@@ -27744,6 +27784,30 @@
       "id": "Type Incompatible",
       "message": "Type Incompatible",
       "translation": "Type incompatible",
+      "fuzzy": true
+    },
+    {
+      "id": "{Msgcompatible}, Warning: {Reason}",
+      "message": "{Msgcompatible}, Warning: {Reason}",
+      "translation": "{Msgcompatible}, Avertissement : {Reason}",
+      "placeholders": [
+        {
+          "id": "Msgcompatible",
+          "string": "%[1]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 1,
+          "expr": "msg_compatible"
+        },
+        {
+          "id": "Reason",
+          "string": "%[2]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 2,
+          "expr": "reason"
+        }
+      ],
       "fuzzy": true
     },
     {
@@ -27907,12 +27971,6 @@
       "fuzzy": true
     },
     {
-      "id": "Secret binding for a cluster service is not supported.",
-      "message": "Secret binding for a cluster service is not supported.",
-      "translation": "La liaison de secret pour un service de cluster n'est pas prise en charge.",
-      "fuzzy": true
-    },
-    {
       "id": "No secret binding found for the following service secrets: {NbArray}.",
       "message": "No secret binding found for the following service secrets: {NbArray}.",
       "translation": "Aucune liaison de secret n'a été trouvée pour les secrets de service suivants : {NbArray}.",
@@ -28045,6 +28103,22 @@
       "fuzzy": true
     },
     {
+      "id": "{Err}, use non node-level secret",
+      "message": "{Err}, use non node-level secret",
+      "translation": "{Err}, utilisent un secret qui n'est pas au niveau du noeud",
+      "placeholders": [
+        {
+          "id": "Err",
+          "string": "%[1]v",
+          "type": "error",
+          "underlyingType": "interface{Error() string}",
+          "argNum": 1,
+          "expr": "err"
+        }
+      ],
+      "fuzzy": true
+    },
+    {
       "id": "Error parsing secret name in the secret binding. {Errparse}",
       "message": "Error parsing secret name in the secret binding. {Errparse}",
       "translation": "Erreur lors de l'analyse syntaxique du nom de secret dans la liaison de secret. {Errparse}",
@@ -28056,6 +28130,38 @@
           "underlyingType": "interface{Error() string}",
           "argNum": 1,
           "expr": "err_parse"
+        }
+      ],
+      "fuzzy": true
+    },
+    {
+      "id": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+      "message": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+      "translation": "Erreur lors de la vérification du secret {VaultSecretName} pour le noeud {NName} dans le gestionnaire de secrets. {Err}",
+      "placeholders": [
+        {
+          "id": "VaultSecretName",
+          "string": "%[1]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 1,
+          "expr": "vaultSecretName"
+        },
+        {
+          "id": "NName",
+          "string": "%[2]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 2,
+          "expr": "nName"
+        },
+        {
+          "id": "Err",
+          "string": "%[3]v",
+          "type": "error",
+          "underlyingType": "interface{Error() string}",
+          "argNum": 3,
+          "expr": "err"
         }
       ],
       "fuzzy": true
@@ -28080,6 +28186,30 @@
           "underlyingType": "interface{Error() string}",
           "argNum": 2,
           "expr": "err"
+        }
+      ],
+      "fuzzy": true
+    },
+    {
+      "id": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+      "message": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+      "translation": "Le secret au niveau du noeud {VaultSecretName} n'existe pas pour le noeud {NName}",
+      "placeholders": [
+        {
+          "id": "VaultSecretName",
+          "string": "%[1]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 1,
+          "expr": "vaultSecretName"
+        },
+        {
+          "id": "NName",
+          "string": "%[2]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 2,
+          "expr": "nName"
         }
       ],
       "fuzzy": true

--- a/i18n_translation/anax.out.gotext.json
+++ b/i18n_translation/anax.out.gotext.json
@@ -472,6 +472,22 @@
     "translation": "Error converting the selections into Selectors: {Err}"
   },
   {
+    "id": "Name, or Org is empty string.",
+    "translation": "Name, or Org is empty string."
+  },
+  {
+    "id": "The serviceVersions array is empty.",
+    "translation": "The serviceVersions array is empty."
+  },
+  {
+    "id": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+    "translation": "retry_durations and retries cannot be zero if priority_value is set to non-zero value"
+  },
+  {
+    "id": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+    "translation": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set"
+  },
+  {
     "id": "properties contains an invalid property: {Err}",
     "translation": "properties contains an invalid property: {Err}"
   },
@@ -1316,10 +1332,6 @@
     "translation": "The SecretBindingCheck input cannot be null"
   },
   {
-    "id": "Node type '{NodeType}' does not support secret binding check.",
-    "translation": "Node type '{NodeType}' does not support secret binding check."
-  },
-  {
     "id": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
     "translation": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern."
   },
@@ -1334,6 +1346,10 @@
   {
     "id": "Type Incompatible",
     "translation": "Type Incompatible"
+  },
+  {
+    "id": "{Msgcompatible}, Warning: {Reason}",
+    "translation": "{Msgcompatible}, Warning: {Reason}"
   },
   {
     "id": "Error getting services for all archetctures for {ServiceOrg}/{ServiceURL} version {Version}. {Err}",
@@ -1372,10 +1388,6 @@
     "translation": "Failed to find the dependent services for {Org}/{URL} {Arch} {Version}. {Err}"
   },
   {
-    "id": "Secret binding for a cluster service is not supported.",
-    "translation": "Secret binding for a cluster service is not supported."
-  },
-  {
     "id": "No secret binding found for the following service secrets: {NbArray}.",
     "translation": "No secret binding found for the following service secrets: {NbArray}."
   },
@@ -1400,12 +1412,24 @@
     "translation": "Secret {VaultSecretName} does not exist in the secret manager for either org level or user level."
   },
   {
+    "id": "{Err}, use non node-level secret",
+    "translation": "{Err}, use non node-level secret"
+  },
+  {
     "id": "Error parsing secret name in the secret binding. {Errparse}",
     "translation": "Error parsing secret name in the secret binding. {Errparse}"
   },
   {
+    "id": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+    "translation": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}"
+  },
+  {
     "id": "Error checking secret {VaultSecretName} in the secret manager. {Err}",
     "translation": "Error checking secret {VaultSecretName} in the secret manager. {Err}"
+  },
+  {
+    "id": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+    "translation": "Node level secret {VaultSecretName} doesn't exist for node {NName}"
   },
   {
     "id": "The binding secret name cannot be an empty string. The valid formats are: '<secretname>' for the organization level secret and 'user/<username>/<secretname>' for the user level secret.",

--- a/i18n_translation/hzn.out.gotext.json
+++ b/i18n_translation/hzn.out.gotext.json
@@ -404,6 +404,22 @@
     "translation": "Error converting the selections into Selectors: {Err}"
   },
   {
+    "id": "Name, or Org is empty string.",
+    "translation": "Name, or Org is empty string."
+  },
+  {
+    "id": "The serviceVersions array is empty.",
+    "translation": "The serviceVersions array is empty."
+  },
+  {
+    "id": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+    "translation": "retry_durations and retries cannot be zero if priority_value is set to non-zero value"
+  },
+  {
+    "id": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+    "translation": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set"
+  },
+  {
     "id": "properties contains an invalid property: {Err}",
     "translation": "properties contains an invalid property: {Err}"
   },
@@ -5368,6 +5384,14 @@
     "translation": "service '{Service}' not found in org {SvcOrg}"
   },
   {
+    "id": "failed to unmarshal ClusterDeployment in 'hzn exchange service list' output: {Err}",
+    "translation": "failed to unmarshal ClusterDeployment in 'hzn exchange service list' output: {Err}"
+  },
+  {
+    "id": "failed to marshal truncked ClusterDeployment in 'hzn exchange service list' output: {Err}",
+    "translation": "failed to marshal truncked ClusterDeployment in 'hzn exchange service list' output: {Err}"
+  },
+  {
     "id": "Ignoring -f because the clusterDeployment attribute is empty for this service.",
     "translation": "Ignoring -f because the clusterDeployment attribute is empty for this service."
   },
@@ -8092,10 +8116,6 @@
     "translation": "The SecretBindingCheck input cannot be null"
   },
   {
-    "id": "Node type '{NodeType}' does not support secret binding check.",
-    "translation": "Node type '{NodeType}' does not support secret binding check."
-  },
-  {
     "id": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
     "translation": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern."
   },
@@ -8110,6 +8130,10 @@
   {
     "id": "Type Incompatible",
     "translation": "Type Incompatible"
+  },
+  {
+    "id": "{Msgcompatible}, Warning: {Reason}",
+    "translation": "{Msgcompatible}, Warning: {Reason}"
   },
   {
     "id": "Error getting services for all archetctures for {ServiceOrg}/{ServiceURL} version {Version}. {Err}",
@@ -8148,10 +8172,6 @@
     "translation": "Failed to find the dependent services for {Org}/{URL} {Arch} {Version}. {Err}"
   },
   {
-    "id": "Secret binding for a cluster service is not supported.",
-    "translation": "Secret binding for a cluster service is not supported."
-  },
-  {
     "id": "No secret binding found for the following service secrets: {NbArray}.",
     "translation": "No secret binding found for the following service secrets: {NbArray}."
   },
@@ -8176,12 +8196,24 @@
     "translation": "Secret {VaultSecretName} does not exist in the secret manager for either org level or user level."
   },
   {
+    "id": "{Err}, use non node-level secret",
+    "translation": "{Err}, use non node-level secret"
+  },
+  {
     "id": "Error parsing secret name in the secret binding. {Errparse}",
     "translation": "Error parsing secret name in the secret binding. {Errparse}"
   },
   {
+    "id": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+    "translation": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}"
+  },
+  {
     "id": "Error checking secret {VaultSecretName} in the secret manager. {Err}",
     "translation": "Error checking secret {VaultSecretName} in the secret manager. {Err}"
+  },
+  {
+    "id": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+    "translation": "Node level secret {VaultSecretName} doesn't exist for node {NName}"
   },
   {
     "id": "The binding secret name cannot be an empty string. The valid formats are: '<secretname>' for the organization level secret and 'user/<username>/<secretname>' for the user level secret.",

--- a/i18n_translation/original/anax.out.gotext.json.auto
+++ b/i18n_translation/original/anax.out.gotext.json.auto
@@ -2288,6 +2288,34 @@
             "fuzzy": true
         },
         {
+            "id": "Name, or Org is empty string.",
+            "message": "Name, or Org is empty string.",
+            "translation": "Name, or Org is empty string.",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "The serviceVersions array is empty.",
+            "message": "The serviceVersions array is empty.",
+            "translation": "The serviceVersions array is empty.",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+            "message": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+            "translation": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+            "message": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+            "translation": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
             "id": "properties contains an invalid property: {Err}",
             "message": "properties contains an invalid property: {Err}",
             "translation": "properties contains an invalid property: {Err}",
@@ -6505,23 +6533,6 @@
             "fuzzy": true
         },
         {
-            "id": "Node type '{NodeType}' does not support secret binding check.",
-            "message": "Node type '{NodeType}' does not support secret binding check.",
-            "translation": "Node type '{NodeType}' does not support secret binding check.",
-            "translatorComment": "Copied from source.",
-            "placeholders": [
-                {
-                    "id": "NodeType",
-                    "string": "%[1]v",
-                    "type": "string",
-                    "underlyingType": "string",
-                    "argNum": 1,
-                    "expr": "nodeType"
-                }
-            ],
-            "fuzzy": true
-        },
-        {
             "id": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
             "message": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
             "translation": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
@@ -6557,6 +6568,31 @@
             "message": "Type Incompatible",
             "translation": "Type Incompatible",
             "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "{Msgcompatible}, Warning: {Reason}",
+            "message": "{Msgcompatible}, Warning: {Reason}",
+            "translation": "{Msgcompatible}, Warning: {Reason}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Msgcompatible",
+                    "string": "%[1]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "msg_compatible"
+                },
+                {
+                    "id": "Reason",
+                    "string": "%[2]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 2,
+                    "expr": "reason"
+                }
+            ],
             "fuzzy": true
         },
         {
@@ -6729,13 +6765,6 @@
             "fuzzy": true
         },
         {
-            "id": "Secret binding for a cluster service is not supported.",
-            "message": "Secret binding for a cluster service is not supported.",
-            "translation": "Secret binding for a cluster service is not supported.",
-            "translatorComment": "Copied from source.",
-            "fuzzy": true
-        },
-        {
             "id": "No secret binding found for the following service secrets: {NbArray}.",
             "message": "No secret binding found for the following service secrets: {NbArray}.",
             "translation": "No secret binding found for the following service secrets: {NbArray}.",
@@ -6874,6 +6903,23 @@
             "fuzzy": true
         },
         {
+            "id": "{Err}, use non node-level secret",
+            "message": "{Err}, use non node-level secret",
+            "translation": "{Err}, use non node-level secret",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Err",
+                    "string": "%[1]v",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 1,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
             "id": "Error parsing secret name in the secret binding. {Errparse}",
             "message": "Error parsing secret name in the secret binding. {Errparse}",
             "translation": "Error parsing secret name in the secret binding. {Errparse}",
@@ -6886,6 +6932,39 @@
                     "underlyingType": "interface{Error() string}",
                     "argNum": 1,
                     "expr": "err_parse"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+            "message": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+            "translation": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "VaultSecretName",
+                    "string": "%[1]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "vaultSecretName"
+                },
+                {
+                    "id": "NName",
+                    "string": "%[2]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 2,
+                    "expr": "nName"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[3]v",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 3,
+                    "expr": "err"
                 }
             ],
             "fuzzy": true
@@ -6911,6 +6990,31 @@
                     "underlyingType": "interface{Error() string}",
                     "argNum": 2,
                     "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+            "message": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+            "translation": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "VaultSecretName",
+                    "string": "%[1]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "vaultSecretName"
+                },
+                {
+                    "id": "NName",
+                    "string": "%[2]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 2,
+                    "expr": "nName"
                 }
             ],
             "fuzzy": true

--- a/i18n_translation/original/hzn.out.gotext.json.auto
+++ b/i18n_translation/original/hzn.out.gotext.json.auto
@@ -1927,6 +1927,34 @@
             "fuzzy": true
         },
         {
+            "id": "Name, or Org is empty string.",
+            "message": "Name, or Org is empty string.",
+            "translation": "Name, or Org is empty string.",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "The serviceVersions array is empty.",
+            "message": "The serviceVersions array is empty.",
+            "translation": "The serviceVersions array is empty.",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+            "message": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+            "translation": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+            "message": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+            "translation": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
             "id": "properties contains an invalid property: {Err}",
             "message": "properties contains an invalid property: {Err}",
             "translation": "properties contains an invalid property: {Err}",
@@ -18544,6 +18572,40 @@
             "fuzzy": true
         },
         {
+            "id": "failed to unmarshal ClusterDeployment in 'hzn exchange service list' output: {Err}",
+            "message": "failed to unmarshal ClusterDeployment in 'hzn exchange service list' output: {Err}",
+            "translation": "failed to unmarshal ClusterDeployment in 'hzn exchange service list' output: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Err",
+                    "string": "%[1]v",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 1,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "failed to marshal truncked ClusterDeployment in 'hzn exchange service list' output: {Err}",
+            "message": "failed to marshal truncked ClusterDeployment in 'hzn exchange service list' output: {Err}",
+            "translation": "failed to marshal truncked ClusterDeployment in 'hzn exchange service list' output: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Err",
+                    "string": "%[1]v",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 1,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
             "id": "Ignoring -f because the clusterDeployment attribute is empty for this service.",
             "message": "Ignoring -f because the clusterDeployment attribute is empty for this service.",
             "translation": "Ignoring -f because the clusterDeployment attribute is empty for this service.",
@@ -29720,23 +29782,6 @@
             "fuzzy": true
         },
         {
-            "id": "Node type '{NodeType}' does not support secret binding check.",
-            "message": "Node type '{NodeType}' does not support secret binding check.",
-            "translation": "Node type '{NodeType}' does not support secret binding check.",
-            "translatorComment": "Copied from source.",
-            "placeholders": [
-                {
-                    "id": "NodeType",
-                    "string": "%[1]v",
-                    "type": "string",
-                    "underlyingType": "string",
-                    "argNum": 1,
-                    "expr": "nodeType"
-                }
-            ],
-            "fuzzy": true
-        },
-        {
             "id": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
             "message": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
             "translation": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
@@ -29772,6 +29817,31 @@
             "message": "Type Incompatible",
             "translation": "Type Incompatible",
             "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "{Msgcompatible}, Warning: {Reason}",
+            "message": "{Msgcompatible}, Warning: {Reason}",
+            "translation": "{Msgcompatible}, Warning: {Reason}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Msgcompatible",
+                    "string": "%[1]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "msg_compatible"
+                },
+                {
+                    "id": "Reason",
+                    "string": "%[2]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 2,
+                    "expr": "reason"
+                }
+            ],
             "fuzzy": true
         },
         {
@@ -29944,13 +30014,6 @@
             "fuzzy": true
         },
         {
-            "id": "Secret binding for a cluster service is not supported.",
-            "message": "Secret binding for a cluster service is not supported.",
-            "translation": "Secret binding for a cluster service is not supported.",
-            "translatorComment": "Copied from source.",
-            "fuzzy": true
-        },
-        {
             "id": "No secret binding found for the following service secrets: {NbArray}.",
             "message": "No secret binding found for the following service secrets: {NbArray}.",
             "translation": "No secret binding found for the following service secrets: {NbArray}.",
@@ -30089,6 +30152,23 @@
             "fuzzy": true
         },
         {
+            "id": "{Err}, use non node-level secret",
+            "message": "{Err}, use non node-level secret",
+            "translation": "{Err}, use non node-level secret",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Err",
+                    "string": "%[1]v",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 1,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
             "id": "Error parsing secret name in the secret binding. {Errparse}",
             "message": "Error parsing secret name in the secret binding. {Errparse}",
             "translation": "Error parsing secret name in the secret binding. {Errparse}",
@@ -30101,6 +30181,39 @@
                     "underlyingType": "interface{Error() string}",
                     "argNum": 1,
                     "expr": "err_parse"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+            "message": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+            "translation": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "VaultSecretName",
+                    "string": "%[1]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "vaultSecretName"
+                },
+                {
+                    "id": "NName",
+                    "string": "%[2]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 2,
+                    "expr": "nName"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[3]v",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 3,
+                    "expr": "err"
                 }
             ],
             "fuzzy": true
@@ -30126,6 +30239,31 @@
                     "underlyingType": "interface{Error() string}",
                     "argNum": 2,
                     "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+            "message": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+            "translation": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "VaultSecretName",
+                    "string": "%[1]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "vaultSecretName"
+                },
+                {
+                    "id": "NName",
+                    "string": "%[2]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 2,
+                    "expr": "nName"
                 }
             ],
             "fuzzy": true

--- a/i18n_translation/translated/anax.out.gotext_fr.json
+++ b/i18n_translation/translated/anax.out.gotext_fr.json
@@ -472,6 +472,22 @@
     "translation": "Erreur lors de la conversion des sélections en sélecteurs : {Err}"
   },
   {
+    "id": "Name, or Org is empty string.",
+    "translation": "Le nom ou l'organisation est une chaîne vide."
+  },
+  {
+    "id": "The serviceVersions array is empty.",
+    "translation": "Le tableau serviceVersions est vide."
+  },
+  {
+    "id": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+    "translation": "retry_durations et retries ne peuvent pas être égales à zéro si priority_value est défini sur une valeur différente de zéro"
+  },
+  {
+    "id": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+    "translation": "retry_durations, retries et verified_durations ne peuvent pas avoir une valeur différente de zéro si priority_value est égale à zéro ou n'est pas définie"
+  },
+  {
     "id": "properties contains an invalid property: {Err}",
     "translation": "Les propriétés comportent une propriété non valide : {Err}"
   },
@@ -1316,10 +1332,6 @@
     "translation": "L'entrée SecretBindingCheck ne peut pas avoir pour valeur NULL"
   },
   {
-    "id": "Node type '{NodeType}' does not support secret binding check.",
-    "translation": "Le type de noeud '{NodeType}' ne prend pas en charge la vérification de liaison de secret."
-  },
-  {
     "id": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
     "translation": "Aucune version de service avec l'architecture {NodeArch} n'est spécifiée dans la règle de déploiement ou le pattern."
   },
@@ -1334,6 +1346,10 @@
   {
     "id": "Type Incompatible",
     "translation": "Type incompatible"
+  },
+  {
+    "id": "{Msgcompatible}, Warning: {Reason}",
+    "translation": "{Msgcompatible}, Avertissement : {Reason}"
   },
   {
     "id": "Error getting services for all archetctures for {ServiceOrg}/{ServiceURL} version {Version}. {Err}",
@@ -1372,10 +1388,6 @@
     "translation": "Les services dépendants sont introuvables pour {Org}/{URL} {Arch} {Version}. {Err}"
   },
   {
-    "id": "Secret binding for a cluster service is not supported.",
-    "translation": "La liaison de secret pour un service de cluster n'est pas prise en charge."
-  },
-  {
     "id": "No secret binding found for the following service secrets: {NbArray}.",
     "translation": "Aucune liaison de secret n'a été trouvée pour les secrets de service suivants : {NbArray}."
   },
@@ -1400,12 +1412,24 @@
     "translation": "Le secret {VaultSecretName} n'existe pas dans le gestionnaire de secrets au niveau de l'organisation ou de l'utilisateur."
   },
   {
+    "id": "{Err}, use non node-level secret",
+    "translation": "{Err}, utilisent un secret qui n'est pas au niveau du noeud"
+  },
+  {
     "id": "Error parsing secret name in the secret binding. {Errparse}",
     "translation": "Erreur lors de l'analyse syntaxique du nom de secret dans la liaison de secret. {Errparse}"
   },
   {
+    "id": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+    "translation": "Erreur lors de la vérification du secret {VaultSecretName} pour le noeud {NName} dans le gestionnaire de secrets. {Err}"
+  },
+  {
     "id": "Error checking secret {VaultSecretName} in the secret manager. {Err}",
     "translation": "Erreur lors de la vérification du secret {VaultSecretName} dans le gestionnaire de secrets. {Err}"
+  },
+  {
+    "id": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+    "translation": "Le secret au niveau du noeud {VaultSecretName} n'existe pas pour le noeud {NName}"
   },
   {
     "id": "The binding secret name cannot be an empty string. The valid formats are: '<secretname>' for the organization level secret and 'user/<username>/<secretname>' for the user level secret.",

--- a/i18n_translation/translated/hzn.out.gotext_fr.json
+++ b/i18n_translation/translated/hzn.out.gotext_fr.json
@@ -404,6 +404,22 @@
     "translation": "Erreur lors de la conversion des sélections en sélecteurs : {Err}"
   },
   {
+    "id": "Name, or Org is empty string.",
+    "translation": "Le nom ou l'organisation est une chaîne vide."
+  },
+  {
+    "id": "The serviceVersions array is empty.",
+    "translation": "Le tableau serviceVersions est vide."
+  },
+  {
+    "id": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+    "translation": "retry_durations et retries ne peuvent pas être égales à zéro si priority_value est défini sur une valeur différente de zéro"
+  },
+  {
+    "id": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+    "translation": "retry_durations, retries et verified_durations ne peuvent pas avoir une valeur différente de zéro si priority_value est égale à zéro ou n'est pas définie"
+  },
+  {
     "id": "properties contains an invalid property: {Err}",
     "translation": "Les propriétés comportent une propriété non valide : {Err}"
   },
@@ -5368,6 +5384,14 @@
     "translation": "Service '{Service}' introuvable dans l'organisation {SvcOrg}"
   },
   {
+    "id": "failed to unmarshal ClusterDeployment in 'hzn exchange service list' output: {Err}",
+    "translation": "Echec de la désérialisation de ClusterDeployment dans la sortie 'hzn exchange service list' : {Err}"
+  },
+  {
+    "id": "failed to marshal truncked ClusterDeployment in 'hzn exchange service list' output: {Err}",
+    "translation": "Echec de la sérialisation de ClusterDeployment tronqué dans la sortie 'hzn exchange service list' : {Err}"
+  },
+  {
     "id": "Ignoring -f because the clusterDeployment attribute is empty for this service.",
     "translation": "-f est ignoré car l'attribut clusterDeployment est vide pour ce service."
   },
@@ -8092,10 +8116,6 @@
     "translation": "L'entrée SecretBindingCheck ne peut pas avoir pour valeur NULL"
   },
   {
-    "id": "Node type '{NodeType}' does not support secret binding check.",
-    "translation": "Le type de noeud '{NodeType}' ne prend pas en charge la vérification de liaison de secret."
-  },
-  {
     "id": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
     "translation": "Aucune version de service avec l'architecture {NodeArch} n'est spécifiée dans la règle de déploiement ou le pattern."
   },
@@ -8110,6 +8130,10 @@
   {
     "id": "Type Incompatible",
     "translation": "Type incompatible"
+  },
+  {
+    "id": "{Msgcompatible}, Warning: {Reason}",
+    "translation": "{Msgcompatible}, Avertissement : {Reason}"
   },
   {
     "id": "Error getting services for all archetctures for {ServiceOrg}/{ServiceURL} version {Version}. {Err}",
@@ -8148,10 +8172,6 @@
     "translation": "Les services dépendants sont introuvables pour {Org}/{URL} {Arch} {Version}. {Err}"
   },
   {
-    "id": "Secret binding for a cluster service is not supported.",
-    "translation": "La liaison de secret pour un service de cluster n'est pas prise en charge."
-  },
-  {
     "id": "No secret binding found for the following service secrets: {NbArray}.",
     "translation": "Aucune liaison de secret n'a été trouvée pour les secrets de service suivants : {NbArray}."
   },
@@ -8176,12 +8196,24 @@
     "translation": "Le secret {VaultSecretName} n'existe pas dans le gestionnaire de secrets au niveau de l'organisation ou de l'utilisateur."
   },
   {
+    "id": "{Err}, use non node-level secret",
+    "translation": "{Err}, utilisent un secret qui n'est pas au niveau du noeud"
+  },
+  {
     "id": "Error parsing secret name in the secret binding. {Errparse}",
     "translation": "Erreur lors de l'analyse syntaxique du nom de secret dans la liaison de secret. {Errparse}"
   },
   {
+    "id": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+    "translation": "Erreur lors de la vérification du secret {VaultSecretName} pour le noeud {NName} dans le gestionnaire de secrets. {Err}"
+  },
+  {
     "id": "Error checking secret {VaultSecretName} in the secret manager. {Err}",
     "translation": "Erreur lors de la vérification du secret {VaultSecretName} dans le gestionnaire de secrets. {Err}"
+  },
+  {
+    "id": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+    "translation": "Le secret au niveau du noeud {VaultSecretName} n'existe pas pour le noeud {NName}"
   },
   {
     "id": "The binding secret name cannot be an empty string. The valid formats are: '<secretname>' for the organization level secret and 'user/<username>/<secretname>' for the user level secret.",

--- a/locales/fr/messages.gotext.json
+++ b/locales/fr/messages.gotext.json
@@ -2170,6 +2170,30 @@
       "fuzzy": true
     },
     {
+      "id": "Name, or Org is empty string.",
+      "message": "Name, or Org is empty string.",
+      "translation": "Le nom ou l'organisation est une chaîne vide.",
+      "fuzzy": true
+    },
+    {
+      "id": "The serviceVersions array is empty.",
+      "message": "The serviceVersions array is empty.",
+      "translation": "Le tableau serviceVersions est vide.",
+      "fuzzy": true
+    },
+    {
+      "id": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+      "message": "retry_durations and retries cannot be zero if priority_value is set to non-zero value",
+      "translation": "retry_durations et retries ne peuvent pas être égales à zéro si priority_value est défini sur une valeur différente de zéro",
+      "fuzzy": true
+    },
+    {
+      "id": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+      "message": "retry_durations, retries and verified_durations cannot be non-zero value if priority_value is zero or not set",
+      "translation": "retry_durations, retries et verified_durations ne peuvent pas avoir une valeur différente de zéro si priority_value est égale à zéro ou n'est pas définie",
+      "fuzzy": true
+    },
+    {
       "id": "properties contains an invalid property: {Err}",
       "message": "properties contains an invalid property: {Err}",
       "translation": "Les propriétés comportent une propriété non valide : {Err}",
@@ -6176,22 +6200,6 @@
       "fuzzy": true
     },
     {
-      "id": "Node type '{NodeType}' does not support secret binding check.",
-      "message": "Node type '{NodeType}' does not support secret binding check.",
-      "translation": "Le type de noeud '{NodeType}' ne prend pas en charge la vérification de liaison de secret.",
-      "placeholders": [
-        {
-          "id": "NodeType",
-          "string": "%[1]v",
-          "type": "string",
-          "underlyingType": "string",
-          "argNum": 1,
-          "expr": "nodeType"
-        }
-      ],
-      "fuzzy": true
-    },
-    {
       "id": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
       "message": "No service versions with architecture {NodeArch} specified in the deployment policy or pattern.",
       "translation": "Aucune version de service avec l'architecture {NodeArch} n'est spécifiée dans la règle de déploiement ou le pattern.",
@@ -6223,6 +6231,30 @@
       "id": "Type Incompatible",
       "message": "Type Incompatible",
       "translation": "Type incompatible",
+      "fuzzy": true
+    },
+    {
+      "id": "{Msgcompatible}, Warning: {Reason}",
+      "message": "{Msgcompatible}, Warning: {Reason}",
+      "translation": "{Msgcompatible}, Avertissement : {Reason}",
+      "placeholders": [
+        {
+          "id": "Msgcompatible",
+          "string": "%[1]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 1,
+          "expr": "msg_compatible"
+        },
+        {
+          "id": "Reason",
+          "string": "%[2]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 2,
+          "expr": "reason"
+        }
+      ],
       "fuzzy": true
     },
     {
@@ -6386,12 +6418,6 @@
       "fuzzy": true
     },
     {
-      "id": "Secret binding for a cluster service is not supported.",
-      "message": "Secret binding for a cluster service is not supported.",
-      "translation": "La liaison de secret pour un service de cluster n'est pas prise en charge.",
-      "fuzzy": true
-    },
-    {
       "id": "No secret binding found for the following service secrets: {NbArray}.",
       "message": "No secret binding found for the following service secrets: {NbArray}.",
       "translation": "Aucune liaison de secret n'a été trouvée pour les secrets de service suivants : {NbArray}.",
@@ -6524,6 +6550,22 @@
       "fuzzy": true
     },
     {
+      "id": "{Err}, use non node-level secret",
+      "message": "{Err}, use non node-level secret",
+      "translation": "{Err}, utilisent un secret qui n'est pas au niveau du noeud",
+      "placeholders": [
+        {
+          "id": "Err",
+          "string": "%[1]v",
+          "type": "error",
+          "underlyingType": "interface{Error() string}",
+          "argNum": 1,
+          "expr": "err"
+        }
+      ],
+      "fuzzy": true
+    },
+    {
       "id": "Error parsing secret name in the secret binding. {Errparse}",
       "message": "Error parsing secret name in the secret binding. {Errparse}",
       "translation": "Erreur lors de l'analyse syntaxique du nom de secret dans la liaison de secret. {Errparse}",
@@ -6535,6 +6577,38 @@
           "underlyingType": "interface{Error() string}",
           "argNum": 1,
           "expr": "err_parse"
+        }
+      ],
+      "fuzzy": true
+    },
+    {
+      "id": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+      "message": "Error checking secret {VaultSecretName} for node {NName} in the secret manager. {Err}",
+      "translation": "Erreur lors de la vérification du secret {VaultSecretName} pour le noeud {NName} dans le gestionnaire de secrets. {Err}",
+      "placeholders": [
+        {
+          "id": "VaultSecretName",
+          "string": "%[1]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 1,
+          "expr": "vaultSecretName"
+        },
+        {
+          "id": "NName",
+          "string": "%[2]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 2,
+          "expr": "nName"
+        },
+        {
+          "id": "Err",
+          "string": "%[3]v",
+          "type": "error",
+          "underlyingType": "interface{Error() string}",
+          "argNum": 3,
+          "expr": "err"
         }
       ],
       "fuzzy": true
@@ -6559,6 +6633,30 @@
           "underlyingType": "interface{Error() string}",
           "argNum": 2,
           "expr": "err"
+        }
+      ],
+      "fuzzy": true
+    },
+    {
+      "id": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+      "message": "Node level secret {VaultSecretName} doesn't exist for node {NName}",
+      "translation": "Le secret au niveau du noeud {VaultSecretName} n'existe pas pour le noeud {NName}",
+      "placeholders": [
+        {
+          "id": "VaultSecretName",
+          "string": "%[1]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 1,
+          "expr": "vaultSecretName"
+        },
+        {
+          "id": "NName",
+          "string": "%[2]v",
+          "type": "string",
+          "underlyingType": "string",
+          "argNum": 2,
+          "expr": "nName"
         }
       ],
       "fuzzy": true


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
