### PR TITLE
Revert "open-horizon#3931 - Bug: e2edev failed since move to Docker 24.0.7"

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -1436,7 +1436,7 @@ func (b *ContainerWorker) ResourcesCreate(agreementId string, agreementProtocol 
 
 		if existingContainer == nil {
 			// only create container if there wasn't one
-			servicePair.serviceConfig.HostConfig.NetworkMode = "bridge"
+			servicePair.serviceConfig.HostConfig.NetworkMode = bridgeName
 			if err := serviceStart(b.client, agreementId, containerName, shareLabel, servicePair.serviceConfig, eps, ms_sharedendpoints, &postCreateContainers, fail, true); err != nil {
 				return nil, err
 			}
@@ -1481,7 +1481,7 @@ func (b *ContainerWorker) ResourcesCreate(agreementId string, agreementProtocol 
 	// every one of these gets wired to both the agBridge and every shared bridge from this agreement
 	for serviceName, servicePair := range private {
 		if servicePair.serviceConfig.HostConfig.NetworkMode == "" {
-			servicePair.serviceConfig.HostConfig.NetworkMode = "bridge" // custom bridge has agreementId as name, same as endpoint key
+			servicePair.serviceConfig.HostConfig.NetworkMode = agreementId // custom bridge has agreementId as name, same as endpoint key
 		}
 		var endpoints map[string]*docker.EndpointConfig
 		if servicePair.serviceConfig.HostConfig.NetworkMode != "host" {


### PR DESCRIPTION
Reverts open-horizon/anax#3932. It wasn't fully tested before being merged.