### PR TITLE
fix #4072 : minor_version of kubectl calculated by stripping '+' correctly

### DIFF
--- a/agent-install/agent-install.sh
+++ b/agent-install/agent-install.sh
@@ -1564,7 +1564,7 @@ function get_kubernetes_version() {
     major_version=$($KUBECTL version -o json | jq '.serverVersion.major' | sed s/\"//g)
     minor_version=$($KUBECTL version -o json | jq '.serverVersion.minor' | sed s/\"//g)
     if [ "${minor_version:0-1}" == "+" ]; then
-        minor_version=${minor_version::-1}
+        minor_version=${minor_version::$((${#minor_version} - 1))}
     fi
 
     full_version="$major_version.$minor_version"


### PR DESCRIPTION
# Pull Request Template

## Description

below calculation of minor_version of kubectl corrected. This will work for both macosx bash and other linux bash shells

```
minor_version=${minor_version::-1}
```
above code is changed to

```
minor_version=${minor_version::$((${#minor_version} - 1))}
```

Fixes: #4072

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Checked by running the agent_install.sh script in macosx bash shell

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
