### PR TITLE
Issue #4151 - update MAINTAINER emeritus list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,12 @@ See the information about [community membership roles](https://wiki.lfedge.org/d
 | Joe Pearson  | joewxboy    | <joe.pearson@us.ibm.com> |
 | John Walicki | johnwalicki | <johnwalicki@gmail.com>  |
 | Lily Zhang   | liilyZhang  | <zhangl@us.ibm.com>      |
-| Ling Gao     | linggao     | <linggao@us.ibm.com>     |
 | Max McAdam   | maxmcadam   | <maxwell.mcAdam@ibm.com> |
 | Doug Larson  | dlarson04   | <larsond@us.ibm.com>     |
+
+# Emeritus Maintainers
+
+The emeritus maintainers of this repository are:
+| Name         | GitHub      | email                    |
+| ------------ | ----------- | ------------------------ |
+| Ling Gao     | linggao     |                          |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,6 @@ See the information about [community membership roles](https://wiki.lfedge.org/d
 | Joe Pearson  | joewxboy    | <joe.pearson@us.ibm.com> |
 | John Walicki | johnwalicki | <johnwalicki@gmail.com>  |
 | Lily Zhang   | liilyZhang  | <zhangl@us.ibm.com>      |
-| Max McAdam   | maxmcadam   | <maxwell.mcAdam@ibm.com> |
 | Doug Larson  | dlarson04   | <larsond@us.ibm.com>     |
 
 # Emeritus Maintainers
@@ -18,3 +17,4 @@ The emeritus maintainers of this repository are:
 | Name         | GitHub      | email                    |
 | ------------ | ----------- | ------------------------ |
 | Ling Gao     | linggao     |                          |
+| Max McAdam   | maxmcadam   |                          |


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes #4151 

## Type of change

Move Ling Gao to an Emiterus maintainer.
This matters for LF Edge maintainer surveys in the future.

- [x] This change requires a documentation update

- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.
