### PR TITLE
Improve output log clarity for palmctl uninstall openhorizon

### DIFF
--- a/agent-install/agent-uninstall.sh
+++ b/agent-install/agent-uninstall.sh
@@ -231,7 +231,7 @@ function removeNodeFromLocalAndManagementHub() {
     log_debug "removeNodeFromLocalAndManagementHub() begin"
     log_info "Check node status for agent pod: ${POD_ID}"
 
-    NODE_INFO=$($KUBECTL exec -it ${POD_ID} -n ${AGENT_NAMESPACE} -- bash -c "hzn node list")
+    NODE_INFO=$($KUBECTL exec ${POD_ID} -n ${AGENT_NAMESPACE} -c "anax" -- bash -c "hzn node list")
     NODE_STATE=$(echo $NODE_INFO | jq -r .configstate.state | sed 's/[^a-z]*//g')
     NODE_ID=$(echo $NODE_INFO | jq -r .id | sed 's/\r//g')
     log_debug "NODE config state for ${NODE_ID} is ${NODE_STATE}"
@@ -274,11 +274,11 @@ function unregister() {
     fi
 
     set +e
-    $KUBECTL exec -it ${POD_ID} -n ${AGENT_NAMESPACE} -- bash -c "${HZN_UNREGISTER_CMD}"
+    $KUBECTL exec ${POD_ID} -n ${AGENT_NAMESPACE} -c "anax" -- bash -c "${HZN_UNREGISTER_CMD}"
     set -e
 
     # verify the node is unregistered
-    NODE_STATE=$($KUBECTL exec -it ${POD_ID} -n ${AGENT_NAMESPACE} -- bash -c "hzn node list | jq -r .configstate.state" | sed 's/[^a-z]*//g')
+    NODE_STATE=$($KUBECTL exec ${POD_ID} -n ${AGENT_NAMESPACE} -c "anax" -- bash -c "hzn node list | jq -r .configstate.state" | sed 's/[^a-z]*//g')
     log_debug "NODE config state is ${NODE_STATE}"
 
     if [[ "$NODE_STATE" != "unconfigured" ]] && [[ "$NODE_STATE" != "unconfiguring" ]]; then
@@ -303,7 +303,7 @@ function deleteNodeFromManagementHub() {
     log_info "Deleting node ${node_id} from the management hub..."
 
     set +e
-    $KUBECTL exec -it ${POD_ID} -n ${AGENT_NAMESPACE} -- bash -c "${EXPORT_EX_USER_AUTH_CMD}; hzn exchange node remove ${node_id} -f"
+    $KUBECTL exec ${POD_ID} -n ${AGENT_NAMESPACE} -c "anax" -- bash -c "${EXPORT_EX_USER_AUTH_CMD}; hzn exchange node remove ${node_id} -f"
     set -e
 
     log_debug "deleteNodeFromManagementHub() end"
@@ -319,7 +319,7 @@ function verifyNodeRemovedFromManagementHub() {
     log_info "Verifying node ${node_id} is removed from the management hub..."
 
     set +e
-    $KUBECTL exec -it ${POD_ID} -n ${AGENT_NAMESPACE} -- bash -c "${EXPORT_EX_USER_AUTH_CMD}; hzn exchange node list ${node_id}" >/dev/null 2>&1
+    $KUBECTL exec ${POD_ID} -n ${AGENT_NAMESPACE} -c "anax" -- bash -c "${EXPORT_EX_USER_AUTH_CMD}; hzn exchange node list ${node_id}" >/dev/null 2>&1
     if [ $? -ne 8 ]; then
 	    log_warning "Node was not removed from the management hub"
     fi


### PR DESCRIPTION
## Bug description 
Palmctl uninstall openhorizon working but outputting errors:
```
2024-12-05T15:17:32Z [ERROR] Defaulted container "anax" out of: anax, initcontainer (init)
Unable to use a TTY - input is not a terminal or the right kind of file
 
2024-12-05T15:17:34Z [ERROR] Defaulted container "anax" out of: anax, initcontainer (init)
Unable to use a TTY - input is not a terminal or the right kind of file
```

Fixes https://github.com/open-horizon/anax/issues/4181