### PR TITLE
Keep agent in sync after startup

### DIFF
--- a/agreement/agreement.go
+++ b/agreement/agreement.go
@@ -710,7 +710,14 @@ func (w *AgreementWorker) syncOnInit() error {
 							glog.Errorf(logString(fmt.Sprintf("cannot record agreement %v state %v, error: %v", ag.CurrentAgreementId, state, err)))
 						}
 					}
-				}
+                                } else {
+                                        //Setting this as potentially failed enables governAgreements func in governance/governance.go to use the same mechanism as used in heartbeat restored
+					//to verify the agreement is still valid or else cancels it to keep agent and hub in sync
+                                        _, err := persistence.SetFailedVerAttempts(w.db, ag.CurrentAgreementId, ag.AgreementProtocol, ag.FailedVerAttempts+1)
+                                        if err != nil {
+                                                glog.Errorf(logString(fmt.Sprintf("encountered error updating agreement %v, error %v", ag.CurrentAgreementId, err)))
+                                        }
+                                }
 				glog.V(3).Infof(logString(fmt.Sprintf("added agreement %v to policy agreement counter.", ag.CurrentAgreementId)))
 			}
 		}


### PR DESCRIPTION
# Pull Request Template

## Description

Trigger mechanism to check if agreement is valid after startup as used when heartbeat is restored

Fixes # https://github.com/open-horizon/anax/issues/4211

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran test where agreement changed and didn't change when agent was not running and had desired effect

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
