### PR TITLE
CWE-732: Insecure Directory Permissions 

### DIFF
--- a/cli/dev/dependency.go
+++ b/cli/dev/dependency.go
@@ -238,7 +238,7 @@ func DependenciesExists(directory string, okToCreate bool) (bool, error) {
 		return false, err
 	} else if !exists && okToCreate {
 		newDir := path.Join(directory, DEFAULT_DEPENDENCY_DIR)
-		if err := os.MkdirAll(newDir, 0755); err != nil {
+		if err := os.MkdirAll(newDir, 0o755); err != nil {
 			return false, errors.New(i18n.GetMessagePrinter().Sprintf("could not create dependency directory %v, error: %v", newDir, err))
 		}
 	} else if !exists {

--- a/cli/dev/utils.go
+++ b/cli/dev/utils.go
@@ -76,7 +76,7 @@ func CreateWorkingDir(dir string) error {
 	// Create the working directory with the dependencies and pattern directories in one shot. If it already exists, just keep going.
 	newDepDir := path.Join(dir, DEFAULT_DEPENDENCY_DIR)
 	if _, err := os.Stat(newDepDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(newDepDir, 0755); err != nil {
+		if err := os.MkdirAll(newDepDir, 0o755); err != nil {
 			return errors.New(msgPrinter.Sprintf("could not create directory %v, error: %v", newDepDir, err))
 		}
 	} else if err != nil {
@@ -399,7 +399,7 @@ func createEnvVarMap(agreementId string,
 func createContainerWorker() (*container.ContainerWorker, error) {
 
 	workloadStorageDir := "/tmp/hzn"
-	if err := os.MkdirAll(workloadStorageDir, 0755); err != nil {
+	if err := os.MkdirAll(workloadStorageDir, 0o755); err != nil {
 		return nil, err
 	}
 
@@ -418,7 +418,7 @@ func createContainerWorker() (*container.ContainerWorker, error) {
 	}
 
 	// Create the folder for SSL certificates (under authentication path)
-	if err := os.MkdirAll(config.GetESSSSLClientCertPath(), 0755); err != nil {
+	if err := os.MkdirAll(config.GetESSSSLClientCertPath(), 0o755); err != nil {
 		return nil, err
 	}
 

--- a/clusterupgrade/cluster_install_files.go
+++ b/clusterupgrade/cluster_install_files.go
@@ -151,7 +151,7 @@ func createNMPStatusFile(workDir string, status string) error {
 
 	if _, err := os.Stat(workDir); os.IsNotExist(err) {
 		glog.Infof(cuwlog(fmt.Sprintf("Work dir %v does not exist, create it...", workDir)))
-		if err = os.MkdirAll(workDir, 755); err != nil {
+		if err = os.MkdirAll(workDir, 0o755); err != nil {
 			glog.Infof(cuwlog(fmt.Sprintf("Failed to create dir %v, err: %v", workDir, err)))
 			return err
 		}
@@ -441,7 +441,7 @@ func extractImageManifest(tarballPath, targetFolder string) error {
 
 	// create the target folder if it is not exist
 	if _, err := os.Stat(targetFolder); err != nil {
-		if err := os.MkdirAll(targetFolder, 0755); err != nil {
+		if err := os.MkdirAll(targetFolder, 0o755); err != nil {
 			return err
 		}
 	}

--- a/exchange/css.go
+++ b/exchange/css.go
@@ -337,7 +337,7 @@ func GetObjectData(ec ExchangeContext, org string, objType string, objId string,
 			return fmt.Errorf("Failed to get object data : %v\n", err)
 		}
 
-		err = os.MkdirAll(filePath, 0755)
+		err = os.MkdirAll(filePath, 0o0755)
 		if err != nil {
 			return fmt.Errorf("Failed to create folder %v for agent upgrade files: %s\n", filePath, err)
 		}
@@ -370,7 +370,7 @@ func GetObjectDataByChunk(ec ExchangeContext, org string, objType string, objId 
 		request.Close = true
 	}
 
-	err = os.MkdirAll(filePath, 0755)
+	err = os.MkdirAll(filePath, 0o755)
 	if err != nil {
 		return false, fmt.Errorf("Failed to create folder %v for agent upgrade files: %s\n", filePath, err)
 	}

--- a/imagefetch/image_process_int_test.go
+++ b/imagefetch/image_process_int_test.go
@@ -120,7 +120,7 @@ func init() {
 
 func tConfig(t *testing.T, dir string) *config.HorizonConfig {
 	workloadStorageDir := path.Join(dir, "workload_storage")
-	if err := os.MkdirAll(workloadStorageDir, 0755); err != nil {
+	if err := os.MkdirAll(workloadStorageDir, 0o755); err != nil {
 		panic(err)
 	}
 
@@ -200,7 +200,7 @@ func setup(t *testing.T) (string, *bolt.DB, error) {
 	}
 
 	certpath := path.Join(dir, "userkeys")
-	if err := os.MkdirAll(certpath, 0755); err != nil {
+	if err := os.MkdirAll(certpath, 0o755); err != nil {
 		panic(err)
 	}
 

--- a/policy/policy_file.go
+++ b/policy/policy_file.go
@@ -913,7 +913,7 @@ func CreatePolicyFile(filepath string, org string, name string, p *Policy) (stri
 	// Store the policy on the filesystem in an org based hierarchy
 	fullFilePath := fmt.Sprintf("%v%v/", filepath, org)
 	fullFileName := fmt.Sprintf("%v%v.policy", fullFilePath, name)
-	if err := os.MkdirAll(fullFilePath, 0764); err != nil {
+	if err := os.MkdirAll(fullFilePath, 0o764); err != nil {
 		return "", errors.New(fmt.Sprintf("Error writing policy file, cannot create file path %v", fullFilePath))
 	} else if err := WritePolicyFile(p, fullFileName); err != nil {
 		return "", errors.New(fmt.Sprintf("Error writing out policy file %v, to %v, error: %v", *p, fullFileName, err))

--- a/resource/certificate.go
+++ b/resource/certificate.go
@@ -41,7 +41,7 @@ func CreateCertificate(org string, keyPath string, certPath string) error {
 
 	glog.V(5).Infof(reslog(fmt.Sprintf("creating self signed cert in %v", common.Configuration.ServerCertificate)))
 
-	if err := os.MkdirAll(certPath, 0755); err != nil {
+	if err := os.MkdirAll(certPath, 0o755); err != nil {
 		return errors.New(msgPrinter.Sprintf("unable to make directory for self signed MMS API certificate, error %v", err))
 	}
 

--- a/resource/resource_manager.go
+++ b/resource/resource_manager.go
@@ -94,7 +94,7 @@ func (r ResourceManager) setupFileSyncService(am *AuthenticationManager) error {
 		listenAddrPath := r.config.GetFileSyncServiceAPIUnixDomainSocketPath()
 		if listenAddrPath != "" {
 			if _, err := os.Stat(listenAddrPath); os.IsNotExist(err) {
-				os.MkdirAll(listenAddrPath, 0755)
+				os.MkdirAll(listenAddrPath, 0o755)
 			}
 		}
 


### PR DESCRIPTION
## Description
CWE-732: Insecure Directory Permissions
A sensitive sink functions were discovered. It causes a High severity Insecure Directory Permissions vulnerability.

The permission mode  is passed as an integer to the **os.MkdirAll** function, which can lead to unintended permissions. The issue stems from how the permissions are specified in Go. The resulting permissions may be interpreted incorrectly.
**To prevent unintended permissions, you should specify the mode in octal format.**

Fixes #[ (issue)](https://github.com/open-horizon/anax/issues/4222)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Run Mend SAST and check that vulnerabilities were fixed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

