### PR TITLE
Use ubi-micro instead of ubi-minimal to reduce the threat surface attack area.

### DIFF
--- a/anax-in-container/Dockerfile.alpine.amd64
+++ b/anax-in-container/Dockerfile.alpine.amd64
@@ -11,6 +11,7 @@ ARG DOCKER_VER=19.03.8
 # install docker cli
 # make required directories
 RUN microdnf update -y --nodocs && microdnf clean all && microdnf install --nodocs -y shadow-utils \
+    && microdnf install -y curl \
     && microdnf install --nodocs -y openssl ca-certificates \
     && microdnf install -y wget iptables vim-minimal procps tar \
     && wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \

--- a/anax-in-container/Dockerfile.ubi.amd64
+++ b/anax-in-container/Dockerfile.ubi.amd64
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent in a general purpose container."
 LABEL description="A container which holds the edge node agent, to be used in environments where there is no operating system package that can install the agent natively."
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 ARG DOCKER_VER=26.1.4
 
@@ -15,6 +30,7 @@ ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal 
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf upgrade -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager krb5-libs \
+  && microdnf install -y curl \
   && curl -4fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz \
   && tar xzvf docker-${DOCKER_VER}.tgz --strip 1 -C /usr/bin docker/docker \
   && rm docker-${DOCKER_VER}.tgz \

--- a/anax-in-container/Dockerfile.ubi.arm64
+++ b/anax-in-container/Dockerfile.ubi.arm64
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent in a general purpose container."
 LABEL description="A container which holds the edge node agent, to be used in environments where there is no operating system package that can install the agent natively."
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 ARG DOCKER_VER=24.0.9
 
@@ -14,6 +29,7 @@ ARG DOCKER_VER=24.0.9
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng tar gzip"
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
+  && microdnf install -y curl \
   && curl -4fsSLO https://download.docker.com/linux/static/stable/aarch64/docker-${DOCKER_VER}.tgz \
   && tar xzvf docker-${DOCKER_VER}.tgz --strip 1 -C /usr/bin docker/docker \
   && rm docker-${DOCKER_VER}.tgz \

--- a/anax-in-container/Dockerfile.ubi.ppc64el
+++ b/anax-in-container/Dockerfile.ubi.ppc64el
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent in a general purpose container."
 LABEL description="A container which holds the edge node agent, to be used in environments where there is no operating system package that can install the agent natively."
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 ARG DOCKER_VER=18.06.3-ce
 
@@ -19,6 +34,7 @@ RUN  microdnf clean all \
   && rm -rf /var/cache/dnf /var/cache/PackageKit \
   && microdnf update -y --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
+  && microdnf install -y curl \
   && curl -4fsSLO https://download.docker.com/linux/static/stable/ppc64le/docker-${DOCKER_VER}.tgz \
   && tar xzvf docker-${DOCKER_VER}.tgz --strip 1 -C /usr/bin docker/docker \
   && rm docker-${DOCKER_VER}.tgz \

--- a/anax-in-container/Dockerfile.ubi.s390x
+++ b/anax-in-container/Dockerfile.ubi.s390x
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent in a general purpose container."
 LABEL description="A container which holds the edge node agent, to be used in environments where there is no operating system package that can install the agent natively."
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 ARG DOCKER_VER=18.06.3-ce
 
@@ -14,6 +29,7 @@ ARG DOCKER_VER=18.06.3-ce
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng tar gzip"
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
+  && microdnf install -y curl \
   && curl -4fsSLO https://download.docker.com/linux/static/stable/s390x/docker-${DOCKER_VER}.tgz \
   && tar xzvf docker-${DOCKER_VER}.tgz --strip 1 -C /usr/bin docker/docker \
   && rm docker-${DOCKER_VER}.tgz \

--- a/anax-in-container/Dockerfile_agbot.ubi
+++ b/anax-in-container/Dockerfile_agbot.ubi
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The deployment engine."
 LABEL description="The Agbot scans all the edge nodes in the system initiating deployment of services and model to all eligible nodes."
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 # The anax binary (secrets manager code) shells out to groupadd, groupdel (from shadow-utils), pkill (from procps-ng)
 # The anax.service calls jq (from jq) and killall (from psmisc)
@@ -12,6 +27,7 @@ LABEL description="The Agbot scans all the edge nodes in the system initiating d
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng gettext"
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+  && microdnf install -y curl \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf upgrade -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager krb5-libs \
   && microdnf clean all --disableplugin=subscription-manager \

--- a/anax-in-k8s/Dockerfile.ubi.amd64
+++ b/anax-in-k8s/Dockerfile.ubi.amd64
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent for edge clusters."
 LABEL description="The agent in a container that is used solely for the purpose of running the agent in a kubernetes edge cluster."
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 # The anax binary (secrets manager code) shells out to groupadd, groupdel (from shadow-utils), pkill (from procps-ng)
 # The anax.service calls jq (from jq) and killall (from psmisc)
@@ -10,6 +25,7 @@ LABEL description="The agent in a container that is used solely for the purpose 
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng tar"
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+  && microdnf install -y curl \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/anax-in-k8s/Dockerfile.ubi.arm64
+++ b/anax-in-k8s/Dockerfile.ubi.arm64
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent for edge clusters."
 LABEL description="The agent in a container that is used solely for the purpose of running the agent in a kubernetes edge cluster."
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 # The anax binary (secrets manager code) shells out to groupadd, groupdel (from shadow-utils), pkill (from procps-ng)
 # The anax.service calls jq (from jq) and killall (from psmisc)
@@ -10,6 +25,7 @@ LABEL description="The agent in a container that is used solely for the purpose 
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng tar"
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+  && microdnf install -y curl \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.amd64
+++ b/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.amd64
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent auto upgrade cron job for edge clusters."
 LABEL description=""
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 # The build calls adduser (from shadow-utils)
 # The auto-upgrade-cronjob.sh calls jq (from jq)
@@ -13,6 +28,7 @@ ARG REQUIRED_RPMS="shadow-utils jq"
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
+  && microdnf install -y curl \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \
   && curl -4LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
   && chmod +x ./kubectl \

--- a/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.arm64
+++ b/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.arm64
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent auto upgrade cron job for edge clusters."
 LABEL description=""
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 # The build calls adduser (from shadow-utils)
 # The auto-upgrade-cronjob.sh calls jq (from jq)
@@ -13,6 +28,7 @@ ARG REQUIRED_RPMS="shadow-utils jq"
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
+  && microdnf install -y curl \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \
   && curl -4LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/arm64/kubectl \
   && chmod +x ./kubectl \

--- a/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.ppc64el
+++ b/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.ppc64el
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent auto upgrade cron job for edge clusters."
 LABEL description=""
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 # add EPEL repo with jq pkg and all deps
 COPY EPEL.repo /etc/yum.repos.d
@@ -18,6 +33,7 @@ RUN microdnf clean all \
   && microdnf update -y --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \ 
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
+  && microdnf install -y curl \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \
   && curl -4LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/ppc64le/kubectl \
   && chmod +x ./kubectl \

--- a/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.s390x
+++ b/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.s390x
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent auto upgrade cron job for edge clusters."
 LABEL description=""
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 # add EPEL repo with jq pkg and all deps
 COPY EPEL.repo /etc/yum.repos.d
@@ -16,6 +31,7 @@ ARG REQUIRED_RPMS="shadow-utils jq"
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
+  && microdnf install -y curl \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \
   && curl -4LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/s390x/kubectl \
   && chmod +x ./kubectl \

--- a/anax-in-k8s/Dockerfile.ubi.ppc64el
+++ b/anax-in-k8s/Dockerfile.ubi.ppc64el
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent for edge clusters."
 LABEL description="The agent in a container that is used solely for the purpose of running the agent in a kubernetes edge cluster."
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 # add EPEL repo with jq pkg and all deps
 COPY EPEL.repo /etc/yum.repos.d
@@ -15,6 +30,7 @@ ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal 
 RUN microdnf clean all \
   && rm -rf /var/cache/dnf /var/cache/PackageKit \
   && microdnf update -y --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \ 
+  && microdnf install -y curl \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/anax-in-k8s/Dockerfile.ubi.s390x
+++ b/anax-in-k8s/Dockerfile.ubi.s390x
@@ -1,8 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="The agent for edge clusters."
 LABEL description="The agent in a container that is used solely for the purpose of running the agent in a kubernetes edge cluster."
+
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
 
 # add EPEL repo with jq pkg and all deps
 COPY EPEL.repo /etc/yum.repos.d
@@ -13,6 +28,7 @@ COPY EPEL.repo /etc/yum.repos.d
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng"
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+  && microdnf install -y curl \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/css/image/cloud-sync-service-amd64/Dockerfile.ubi
+++ b/css/image/cloud-sync-service-amd64/Dockerfile.ubi
@@ -1,13 +1,29 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="Object model storage and APIs in the management hub."
 LABEL description="Provides the management hub side of the Model Management System, which stores object models and provides APIs for admins and edge nodes to access the object models."
 
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
+
 # shadow-utils contains groupadd and adduser commands
 # css_start.sh calls envsubst (from gettext)
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils gettext"
 RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+  && microdnf install -y curl \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && groupadd -g 1000 cssuser && adduser -u 1000 -g cssuser cssuser \

--- a/ess/image/edge-sync-service-amd64/Dockerfile.ubi
+++ b/ess/image/edge-sync-service-amd64/Dockerfile.ubi
@@ -1,11 +1,27 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="Edge node Model Management System."
 LABEL description="Provides the edge node side of the Model Management System to be used by the CLI service test tools when also testing object models."
 
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
+
 # yum is not installed, use microdnf instead
 RUN microdnf update -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+	&& microdnf install -y curl \
 	&& microdnf install -y --nodocs openssl ca-certificates --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf clean all --disableplugin=subscription-manager \
 	&& rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/ess/image/edge-sync-service-arm64/Dockerfile.ubi
+++ b/ess/image/edge-sync-service-arm64/Dockerfile.ubi
@@ -1,11 +1,27 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="Edge node Model Management System."
 LABEL description="Provides the edge node side of the Model Management System to be used by the CLI service test tools when also testing object models."
 
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
+
 # yum is not installed, use microdnf instead
 RUN microdnf update -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+	&& microdnf install -y curl \
 	&& microdnf install -y --nodocs openssl ca-certificates --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf clean all --disableplugin=subscription-manager \
 	&& rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/ess/image/edge-sync-service-ppc64el/Dockerfile.ubi
+++ b/ess/image/edge-sync-service-ppc64el/Dockerfile.ubi
@@ -1,13 +1,29 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="Edge node Model Management System."
 LABEL description="Provides the edge node side of the Model Management System to be used by the CLI service test tools when also testing object models."
 
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
+
 # yum is not installed, use microdnf instead
 RUN microdnf clean all \
   	&& rm -rf /var/cache/dnf /var/cache/PackageKit \
   	&& microdnf update -y --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+	&& microdnf install -y curl \
 	&& microdnf install -y --nodocs openssl ca-certificates --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf clean all --disableplugin=subscription-manager \
 	&& rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/ess/image/edge-sync-service-s390x/Dockerfile.ubi
+++ b/ess/image/edge-sync-service-s390x/Dockerfile.ubi
@@ -1,11 +1,27 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+# Building microdnf from ubi9-minimal base
+FROM registry.access.redhat.com/ubi9-minimal:latest AS base
+
+#---------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9-micro:latest AS runtime
 
 LABEL vendor="IBM"
 LABEL summary="Edge node Model Management System."
 LABEL description="Provides the edge node side of the Model Management System to be used by the CLI service test tools when also testing object models."
 
+# Copy microdnf necessary files from the base stage
+COPY --from=base /usr/bin/microdnf /usr/bin/
+COPY --from=base /usr/bin/gpg /usr/bin/
+COPY --from=base /usr/bin/gpg2 /usr/bin/
+COPY --from=base /lib64 /lib64/
+COPY --from=base /usr/lib64 /usr/lib64/
+COPY --from=base /usr/lib/rpm /usr/lib/rpm/
+COPY --from=base /etc/dnf /etc/dnf/
+COPY --from=base /etc/rpm /etc/rpm/
+COPY --from=base /etc/pki /etc/pki/
+
 # yum is not installed, use microdnf instead
 RUN microdnf update -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+	&& microdnf install -y curl \
 	&& microdnf install -y --nodocs openssl ca-certificates --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf clean all --disableplugin=subscription-manager \
 	&& rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \


### PR DESCRIPTION
## Description

Use ubi-micro instead of ubi-minimal to reduce the threat surface attack area.

Fixes # ([issue](https://github.com/open-horizon/anax/issues/4227))

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran make docker for different architectures, like "amd64" ,"ppc64el", "s390x", "arm64" .
```
make ess-docker-image
make auto-upgrade-cronjob-k8s-image
make css-docker-image
make anax-k8s-image
make anax-image
make agbot-image
```
<img width="1094" alt="Screenshot 2025-01-15 at 09 37 17" src="https://github.com/user-attachments/assets/5c7033f8-868b-421f-8e25-4126281941a8" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

