### PR TITLE
Issue #4239 - Fix CWE-732: Insecure File Permissions

### DIFF
--- a/api/path_publickey.go
+++ b/api/path_publickey.go
@@ -111,7 +111,7 @@ func UploadPublicKey(filename string,
 		return errorhandler(NewAPIUserInputError(fmt.Sprintf("provided public key or cert is not valid; error: %v", err), "trusted cert file"))
 	} else if err := os.MkdirAll(targetPath, 0644); err != nil {
 		return errorhandler(NewSystemError(fmt.Sprintf("unable to create trusted cert directory %v, error: %v", targetPath, err)))
-	} else if err := ioutil.WriteFile(targetFile, inBytes, 0644); err != nil {
+	} else if err := os.WriteFile(targetFile, inBytes, 0644); err != nil {
 		return errorhandler(NewSystemError(fmt.Sprintf("unable to write uploaded trusted cert file %v, error: %v", targetFile, err)))
 	}
 	return false

--- a/cli/dev/utils.go
+++ b/cli/dev/utils.go
@@ -129,7 +129,7 @@ func CreateFile(directory string, fileName string, obj interface{}) error {
 	filePath := path.Join(directory, fileName)
 	if jsonBytes, err := json.MarshalIndent(obj, "", "    "); err != nil {
 		return errors.New(msgPrinter.Sprintf("failed to create json object for %v, error: %v", fileName, err))
-	} else if err := ioutil.WriteFile(filePath, jsonBytes, 0664); err != nil {
+	} else if err := os.WriteFile(filePath, jsonBytes, 0664); err != nil {
 		return errors.New(msgPrinter.Sprintf("unable to write json object for %v to file %v, error: %v", fileName, filePath, err))
 	} else {
 		return nil
@@ -142,7 +142,7 @@ func CreateUserInputFile(directory string, ui *common.UserInputFile) error {
 	filePath := path.Join(directory, USERINPUT_FILE)
 	if bytes, err := ui.GetOutputJsonBytes(false); err != nil {
 		return err
-	} else if err := ioutil.WriteFile(filePath, bytes, 0664); err != nil {
+	} else if err := os.WriteFile(filePath, bytes, 0664); err != nil {
 		return errors.New(i18n.GetMessagePrinter().Sprintf("unable to write json object for userinput to file %v, error: %v", filePath, err))
 	}
 	return nil

--- a/cli/register/register.go
+++ b/cli/register/register.go
@@ -3,6 +3,13 @@ package register
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/open-horizon/anax/api"
 	"github.com/open-horizon/anax/apicommon"
 	"github.com/open-horizon/anax/cli/cliconfig"
@@ -19,14 +26,7 @@ import (
 	"github.com/open-horizon/anax/persistence"
 	"github.com/open-horizon/anax/policy"
 	"github.com/open-horizon/anax/semanticversion"
-	"io/ioutil"
 	"k8s.io/client-go/rest"
-	"net/http"
-	"os"
-	"regexp"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // read the user input file that contains the global attributes and service userinput settings.
@@ -936,7 +936,7 @@ func CreateInputFile(nodeOrg, pattern, arch, nodeIdTok, inputFile string) {
 		cliutils.Fatal(cliutils.INTERNAL_ERROR, msgPrinter.Sprintf("failed to marshal the user input template file: %v", err))
 	}
 
-	if err := ioutil.WriteFile(inputFile, jsonBytes, 0644); err != nil {
+	if err := os.WriteFile(inputFile, jsonBytes, 0644); err != nil {
 		cliutils.Fatal(cliutils.FILE_IO_ERROR, msgPrinter.Sprintf("problem writing the user input template file: %v", err))
 	}
 
@@ -959,7 +959,7 @@ func CreateInputFile(nodeOrg, pattern, arch, nodeIdTok, inputFile string) {
 		if err != nil {
 			cliutils.Fatal(cliutils.INTERNAL_ERROR, msgPrinter.Sprintf("failed to marshal the example node policy file: %v", err))
 		}
-		if err := ioutil.WriteFile(nodePolicySampleFile, jsonBytes, 0644); err != nil {
+		if err := os.WriteFile(nodePolicySampleFile, jsonBytes, 0644); err != nil {
 			cliutils.Fatal(cliutils.FILE_IO_ERROR, msgPrinter.Sprintf("problem writing the example node policy file: %v", err))
 		} else {
 			msgPrinter.Printf("One or more of services contain privileged in the deployment string. Make sure your node policy file allows privileged. A sample node policy file has been created: %s", nodePolicySampleFile)

--- a/clusterupgrade/cluster_install_files.go
+++ b/clusterupgrade/cluster_install_files.go
@@ -7,6 +7,14 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -15,13 +23,6 @@ import (
 	"github.com/open-horizon/anax/exchange"
 	"github.com/open-horizon/anax/exchangecommon"
 	"github.com/open-horizon/anax/nodemanagement"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"path"
-	"strings"
-	"time"
 )
 
 const DOCKER_MANIFEST_FILE = "manifest.json"
@@ -173,7 +174,7 @@ func createNMPStatusFile(workDir string, status string) error {
 	if statusFileByte, err := json.Marshal(statusFile); err != nil {
 		glog.Infof(cuwlog(fmt.Sprintf("Failed to marshal to status file, err: %v", err)))
 		return err
-	} else if err := ioutil.WriteFile(fileName, statusFileByte, 0755); err != nil {
+	} else if err := os.WriteFile(fileName, statusFileByte, 0755); err != nil {
 		glog.Infof(cuwlog(fmt.Sprintf("Failed marshal to status file, err: %v", err)))
 		return err
 	}
@@ -200,7 +201,7 @@ func setNMPStatusInStatusFile(workDir string, status string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(fileName, updatedJsonByte, 0755)
+	err = os.WriteFile(fileName, updatedJsonByte, 0755)
 	return err
 }
 
@@ -233,7 +234,7 @@ func setResourceNeedChangeInStatusFile(workDir string, resourceName string, need
 		return err
 	}
 
-	if err = ioutil.WriteFile(fileName, updatedJsonByte, 0755); err != nil {
+	if err = os.WriteFile(fileName, updatedJsonByte, 0755); err != nil {
 		return err
 	}
 	glog.V(3).Infof(cuwlog(fmt.Sprintf("%v.needChange is set to %v in status file", resourceName, needChange)))
@@ -269,7 +270,7 @@ func setResourceUpdatedInStatusFile(workDir string, resourceName string, updated
 		return err
 	}
 
-	if err = ioutil.WriteFile(fileName, updatedJsonByte, 0755); err != nil {
+	if err = os.WriteFile(fileName, updatedJsonByte, 0755); err != nil {
 		return err
 	}
 	glog.V(3).Infof(cuwlog(fmt.Sprintf("%v.updated is set to %v in status file", resourceName, updated)))
@@ -291,7 +292,7 @@ func setImageInfoInStatusFile(workDir string, from string, to string) error {
 	}
 
 	fileName := path.Join(workDir, nodemanagement.STATUS_FILE_NAME)
-	err = ioutil.WriteFile(fileName, updatedJsonByte, 0755)
+	err = os.WriteFile(fileName, updatedJsonByte, 0755)
 	return err
 }
 
@@ -334,7 +335,7 @@ func setErrorMessageInStatusFile(workDir string, statusToSet string, errorMessag
 		return err
 	}
 	fileName := path.Join(workDir, nodemanagement.STATUS_FILE_NAME)
-	err = ioutil.WriteFile(fileName, updatedJsonByte, 0755)
+	err = os.WriteFile(fileName, updatedJsonByte, 0755)
 	return err
 }
 

--- a/container/container.go
+++ b/container/container.go
@@ -7,6 +7,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"os/user"
+	"path"
+	"strconv"
+	"strings"
+
 	"github.com/boltdb/bolt"
 	"github.com/coreos/go-iptables/iptables"
 	docker "github.com/fsouza/go-dockerclient"
@@ -23,14 +31,6 @@ import (
 	"github.com/open-horizon/anax/resource"
 	"github.com/open-horizon/anax/worker"
 	"golang.org/x/sys/unix"
-	"io"
-	"io/ioutil"
-	"math/big"
-	"os"
-	"os/user"
-	"path"
-	"strconv"
-	"strings"
 )
 
 const LABEL_PREFIX = "openhorizon.anax"
@@ -1285,7 +1285,7 @@ func (b *ContainerWorker) ResourcesCreate(agreementId string, agreementProtocol 
 
 		glog.V(5).Infof("Writing raw config to file in %v. Config data: %v", workloadRWStorageDir, string(configureRaw))
 		// write raw to workloadRWStorageDir
-		if err := ioutil.WriteFile(path.Join(workloadRWStorageDir, "Configure"), configureRaw, 0644); err != nil {
+		if err := os.WriteFile(path.Join(workloadRWStorageDir, "Configure"), configureRaw, 0644); err != nil {
 			return nil, err
 		}
 	} else {

--- a/download/download_worker.go
+++ b/download/download_worker.go
@@ -3,6 +3,12 @@ package download
 import (
 	"bufio"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"sort"
+	"strings"
+
 	"github.com/boltdb/bolt"
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/config"
@@ -14,11 +20,6 @@ import (
 	"github.com/open-horizon/anax/persistence"
 	"github.com/open-horizon/anax/semanticversion"
 	"github.com/open-horizon/anax/worker"
-	"io/ioutil"
-	"os"
-	"path"
-	"sort"
-	"strings"
 )
 
 const (
@@ -241,7 +242,7 @@ func (w *DownloadWorker) DownloadAgentUpgradePackages(org string, filePath strin
 				if cutil.SliceContains(manifest.Software.FileList, HZN_AGENTINSTALL_FILE) || cutil.SliceContains(manifest.Software.FileList, ALLFILES) {
 					if err = w.DownloadCSSObject(CSSSHAREDORG, swType, HZN_AGENTINSTALL_FILE, filePath, nmpName); err != nil {
 						return exchangecommon.STATUS_DOWNLOAD_FAILED, fmt.Errorf("Error downloading css object %v/%v/%v: %v", CSSSHAREDORG, swType, HZN_AGENTINSTALL_FILE, err)
-					} else if err := os.Chmod(path.Join(filePath, nmpName, HZN_AGENTINSTALL_FILE), 0755); err != nil {
+					} else if err := os.Chmod(path.Join(filePath, nmpName, HZN_AGENTINSTALL_FILE), 0600); err != nil {
 						return exchangecommon.STATUS_PRECHECK_FAILED, err
 					}
 				}

--- a/policy/policy_file.go
+++ b/policy/policy_file.go
@@ -4,6 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/open-horizon/anax/config"
 	"github.com/open-horizon/anax/cutil"
@@ -11,10 +16,6 @@ import (
 	"github.com/open-horizon/anax/externalpolicy"
 	"github.com/open-horizon/anax/i18n"
 	"golang.org/x/text/message"
-	"io/ioutil"
-	"os"
-	"strings"
-	"time"
 )
 
 // The purpose this file is to abstract the Policy struct and the files that it lives within as
@@ -731,7 +732,7 @@ func WritePolicyFile(newPolicy *Policy, name string) error {
 
 	if bytes, err := json.MarshalIndent(newPolicy, "", "    "); err != nil {
 		return errors.New(fmt.Sprintf("Unable to marshal policy %v to file, error: %v", newPolicy, err))
-	} else if err := ioutil.WriteFile(name, bytes, 0644); err != nil {
+	} else if err := os.WriteFile(name, bytes, 0644); err != nil {
 		return errors.New(fmt.Sprintf("Unable to write policy file %v, error: %v", name, err))
 	} else {
 		return nil


### PR DESCRIPTION
## Description

CWE-732: Insecure File Permissions refers to a vulnerability where a file or directory has permissions that are too permissive, allowing unauthorized users or processes to read, modify, or execute it. This can lead to a range of security risks, such as unauthorized data access, data corruption, privilege escalation, and even remote code execution in some cases.

Starting from Go 1.16, the **ioutil** package has been deprecated.

Fixes # (#4239 )

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Ran unit-tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.
