### PR TITLE
Issue open-horizon#4087 - Bug: k8s auto upgrade fails if using all-in…

### DIFF
--- a/clusterupgrade/cluster_install_files.go
+++ b/clusterupgrade/cluster_install_files.go
@@ -93,8 +93,10 @@ func TrustNewCert(httpClient *http.Client, certPath string) error {
 func ValidateConfigAndCert(exchangeURL string, certPath string) error {
 	httpClient := cliutils.GetHTTPClient(config.HTTPRequestTimeoutS)
 
-	if err := TrustNewCert(httpClient, certPath); err != nil {
-		return err
+	if strings.HasPrefix(strings.ToLower(exchangeURL), "https") {
+		if err := TrustNewCert(httpClient, certPath); err != nil {
+			return err
+		}
 	}
 
 	// get retry count and retry interval from env


### PR DESCRIPTION
…-one with http (ie. without https)

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #4087 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
