### PR TITLE
Issue open-horizon#4276 - Bug: Anax in container unable to start a se…

### DIFF
--- a/agreementbot/secret_updater_test.go
+++ b/agreementbot/secret_updater_test.go
@@ -5,9 +5,10 @@ package agreementbot
 
 import (
 	//"fmt"
+	"testing"
+
 	"github.com/open-horizon/anax/events"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // Ensure that the secret manager queueing is working.
@@ -29,7 +30,7 @@ func Test_SUM_Queue(t *testing.T) {
 	sus.AddSecretUpdate(su2)
 
 	// Now test the secret update manager.
-	sum := NewSecretUpdateManager()
+	sum := NewSecretUpdateManager(60, 60, 300, 30)
 	sum.SetUpdateEvent(sus)
 
 	assert.True(t, len(sum.PendingUpdates) == 1, "There should be 1 pending update")

--- a/anax-in-container/horizon-container
+++ b/anax-in-container/horizon-container
@@ -254,10 +254,11 @@ start() {
 	fi
 
 	dockerSocketPath="/var/run/docker.sock"
-	if [ ! -f dockerSocketPath ]; then
+	if [ ! -S $dockerSocketPath ]; then
 		# Rancher desktop (with MobyD) uses $HOME/.rd/docker.sock instead of /var/run/docker.sock
 		dockerSocketPath="$HOME/.rd/docker.sock"
 	fi
+	echo "dockerSocketPath: $dockerSocketPath"
 
 	# Start socat, if not already running
 	if isMacos; then


### PR DESCRIPTION
…rvice now with latest anax code

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
