### PR TITLE
Issue 4295: Copy over the agent-install README as overview.md

### DIFF
--- a/.github/workflows/copydocs.yml
+++ b/.github/workflows/copydocs.yml
@@ -22,3 +22,15 @@ jobs:
         dst_repo_name: open-horizon.github.io
         dst_branch: master
         src_branch: master
+    - name: Copycat Action
+      uses: andstor/copycat-action@v3
+      with:
+        commit_message: "Syncing overview from anax"
+        clean: false
+        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        src_path: 'agent-install/README.md'
+        dst_path: '/docs/anax/docs/overview.md'
+        dst_owner: open-horizon
+        dst_repo_name: open-horizon.github.io
+        dst_branch: master
+        src_branch: master

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 ---
 copyright:
-years: 2022 - 2023
-lastupdated: "2023-02-05"
+years: 2022 - 2025
+lastupdated: "2025-03-22"
 layout: page
 title: "Agent (anax)"
-description: "Open Horizon Anax Documentation"
+description: "Open Horizon Anax Agent Documentation"
 
 nav_order: 5
 has_children: true
@@ -29,6 +29,10 @@ Automatic agent upgrade is a policy-based node management feature that allows an
 ## [Instructions for starting an agent in a container on Linux](agent_container_manual_deploy.md)
 
 Use these instructions to start the agent in a container and have more control over the details than that allowed by the `horzion-container` script.
+
+## [{{site.data.keyword.horizon}} Agent Installation overview](overview.md)
+
+This section contains an overview of the installation script, including OS and CPU architecture requirements, a description, detailed usage information including commandline flags, installing anax-in-container, and an installation package tree.
 
 ## [{{site.data.keyword.horizon}} Agreement Bot APIs](agreement_bot_api.md)
 


### PR DESCRIPTION
# Pull Request Template

## Description

Updated copydocs.yml to add a second copy command.  The second command copies agent-install.README.md to the docs repo at /docs/anax/docs/overview.md

Further, updated /docs/anax/docs/index.md to point to the new overview.md file.

Fixes #4295 and [docs issue 612](https://github.com/open-horizon/open-horizon.github.io/issues/612)

## How Has This Been Tested?

Need to find a way to test the GitHub Action to confirm that it works.

## Additional Context (Please include any Screenshots/gifs if relevant)

...

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->

@johnwalicki and @naphelps FYI