### PR TITLE
Issue open-horizon#4232 - Fix CWE-22 Path/Directory Traversal issues

### DIFF
--- a/cutil/cutil.go
+++ b/cutil/cutil.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -819,10 +820,11 @@ func GetDockerEndpoint() string {
 // extrace the version in certificate file. The version should be in the first line in this format -----OpenHorizon Version x.x.x-----
 func GetCertificateVersion(certFilePath string) string {
 	var version string
-	if cert, err := os.Open(certFilePath); err != nil {
-		glog.Errorf(fmt.Sprintf("unable to open Certificate file %v, error %v", certFilePath, err))
+	cleanedPath := filepath.Clean(certFilePath)
+	if cert, err := os.Open(cleanedPath); err != nil {
+		glog.Errorf(fmt.Sprintf("unable to open Certificate file %v, error %v", cleanedPath, err))
 	} else if certBytes, err := io.ReadAll(cert); err != nil {
-		glog.Errorf(fmt.Sprintf("unable to read Certificate file %v, error %v", certFilePath, err))
+		glog.Errorf(fmt.Sprintf("unable to read Certificate file %v, error %v", cleanedPath, err))
 	} else {
 		lines := strings.Split(string(certBytes), "\n")
 		for _, line := range lines {


### PR DESCRIPTION
Description

CWE-22 (Path/Directory Traversal) is a type of vulnerability that occurs when an application allows users to manipulate file paths in a way that can access files or directories that are outside of the intended directory. This can lead to security issues such as unauthorized access to sensitive files, data leakage, or even arbitrary code execution in some cases.

Fixes https://github.com/open-horizon/anax/issues/4232

Canonical Path Resolution: The filepath.Clean() method removes redundant or malicious path elements (e.g., .., .) that could be used for directory traversal.