### PR TITLE
Issue #4300 - Copy agent-install README to Docs repo

### DIFF
--- a/.github/workflows/copyagentreadme.yml
+++ b/.github/workflows/copyagentreadme.yml
@@ -1,0 +1,24 @@
+name : Copy Agent Install Docs
+on: 
+  push:
+    branches:
+      - master
+    paths:
+      - 'agent-install/**'
+ 
+jobs:
+  copy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Copycat Action
+      uses: andstor/copycat-action@v3
+      with:
+        commit_message: "Syncing Agent Install Instructions from anax"
+        clean: false
+        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        src_path: 'agent-install/README.md'
+        dst_path: '/docs/anax/docs/overview.md'
+        dst_owner: open-horizon
+        dst_repo_name: open-horizon.github.io
+        dst_branch: master
+        src_branch: master


### PR DESCRIPTION
# Pull Request Template

## Description

GitHub Action which will copy the agent-install/README.md to the Docs repo

First step toward fixing  #  4300

## Type of change

- [x] This change requires a documentation update

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
