### PR TITLE
Update libxml2 version

### DIFF
--- a/anax-in-container/Dockerfile.alpine.amd64
+++ b/anax-in-container/Dockerfile.alpine.amd64
@@ -10,7 +10,7 @@ ARG DOCKER_VER=19.03.8
 # shadow-utils contains groupadd and adduser commands
 # install docker cli
 # make required directories
-RUN microdnf update -y --nodocs && microdnf clean all && microdnf install --nodocs -y shadow-utils \
+RUN microdnf update -y libxml2 --nodocs && microdnf clean all && microdnf install --nodocs -y shadow-utils \
     && microdnf install --nodocs -y openssl ca-certificates \
     && microdnf install -y wget iptables vim-minimal procps tar \
     && wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \

--- a/anax-in-container/Dockerfile.ubi.amd64
+++ b/anax-in-container/Dockerfile.ubi.amd64
@@ -12,7 +12,7 @@ ARG DOCKER_VER=26.1.4
 # Install docker cli, which requires tar / gunzip to unpack, then remove tar / gzip packages
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng tar gzip"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN microdnf update -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf upgrade -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager krb5-libs \
   && curl -4fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz \

--- a/anax-in-container/Dockerfile.ubi.arm64
+++ b/anax-in-container/Dockerfile.ubi.arm64
@@ -12,7 +12,7 @@ ARG DOCKER_VER=24.0.9
 # Install docker cli, which requires tar / gunzip to unpack, then remove tar / gzip packages
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng tar gzip"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && curl -4fsSLO https://download.docker.com/linux/static/stable/aarch64/docker-${DOCKER_VER}.tgz \
   && tar xzvf docker-${DOCKER_VER}.tgz --strip 1 -C /usr/bin docker/docker \

--- a/anax-in-container/Dockerfile.ubi.ppc64el
+++ b/anax-in-container/Dockerfile.ubi.ppc64el
@@ -17,7 +17,7 @@ COPY EPEL.repo /etc/yum.repos.d
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng tar gzip"
 RUN  microdnf clean all \
   && rm -rf /var/cache/dnf /var/cache/PackageKit \
-  && microdnf update -y --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+  && microdnf update -y libxml2 --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && curl -4fsSLO https://download.docker.com/linux/static/stable/ppc64le/docker-${DOCKER_VER}.tgz \
   && tar xzvf docker-${DOCKER_VER}.tgz --strip 1 -C /usr/bin docker/docker \

--- a/anax-in-container/Dockerfile.ubi.s390x
+++ b/anax-in-container/Dockerfile.ubi.s390x
@@ -12,7 +12,7 @@ ARG DOCKER_VER=18.06.3-ce
 # Install docker cli, which requires tar / gunzip to unpack, then remove tar / gzip packages
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng tar gzip"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && curl -4fsSLO https://download.docker.com/linux/static/stable/s390x/docker-${DOCKER_VER}.tgz \
   && tar xzvf docker-${DOCKER_VER}.tgz --strip 1 -C /usr/bin docker/docker \

--- a/anax-in-container/Dockerfile_agbot.ubi
+++ b/anax-in-container/Dockerfile_agbot.ubi
@@ -11,7 +11,7 @@ LABEL description="The Agbot scans all the edge nodes in the system initiating d
 # agbot_start.sh calls envsubst (from gettext)
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng gettext"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf upgrade -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager krb5-libs \
   && microdnf clean all --disableplugin=subscription-manager \

--- a/anax-in-k8s/Dockerfile.ubi.amd64
+++ b/anax-in-k8s/Dockerfile.ubi.amd64
@@ -9,7 +9,7 @@ LABEL description="The agent in a container that is used solely for the purpose 
 # anax does not use iptables directly but the github.com/coreos/go-iptables/iptables dependency needs the directory structure
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng tar"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update libxml2  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/anax-in-k8s/Dockerfile.ubi.arm64
+++ b/anax-in-k8s/Dockerfile.ubi.arm64
@@ -9,7 +9,7 @@ LABEL description="The agent in a container that is used solely for the purpose 
 # anax does not use iptables directly but the github.com/coreos/go-iptables/iptables dependency needs the directory structure
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng tar"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.amd64
+++ b/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.amd64
@@ -10,7 +10,7 @@ LABEL description=""
 # Create required directories
 # Create cronjobuser
 ARG REQUIRED_RPMS="shadow-utils jq"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.arm64
+++ b/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.arm64
@@ -10,7 +10,7 @@ LABEL description=""
 # Create required directories
 # Create cronjobuser
 ARG REQUIRED_RPMS="shadow-utils jq"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.ppc64el
+++ b/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.ppc64el
@@ -15,7 +15,7 @@ COPY EPEL.repo /etc/yum.repos.d
 ARG REQUIRED_RPMS="shadow-utils jq"
 RUN microdnf clean all \
   && rm -rf /var/cache/dnf /var/cache/PackageKit \
-  && microdnf update -y --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \ 
+  && microdnf update -y libxml2 --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \ 
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.s390x
+++ b/anax-in-k8s/Dockerfile.ubi.auto-upgrade-cron.s390x
@@ -13,7 +13,7 @@ COPY EPEL.repo /etc/yum.repos.d
 # Create required directories
 # Create cronjobuser
 ARG REQUIRED_RPMS="shadow-utils jq"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/anax-in-k8s/Dockerfile.ubi.ppc64el
+++ b/anax-in-k8s/Dockerfile.ubi.ppc64el
@@ -14,7 +14,7 @@ COPY EPEL.repo /etc/yum.repos.d
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng"
 RUN microdnf clean all \
   && rm -rf /var/cache/dnf /var/cache/PackageKit \
-  && microdnf update -y --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \ 
+  && microdnf update -y libxml2 --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \ 
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/anax-in-k8s/Dockerfile.ubi.s390x
+++ b/anax-in-k8s/Dockerfile.ubi.s390x
@@ -12,7 +12,7 @@ COPY EPEL.repo /etc/yum.repos.d
 # anax does not use iptables directly but the github.com/coreos/go-iptables/iptables dependency needs the directory structure
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/css/image/cloud-sync-service-amd64/Dockerfile.ubi
+++ b/css/image/cloud-sync-service-amd64/Dockerfile.ubi
@@ -7,7 +7,7 @@ LABEL description="Provides the management hub side of the Model Management Syst
 # shadow-utils contains groupadd and adduser commands
 # css_start.sh calls envsubst (from gettext)
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils gettext"
-RUN  microdnf update  -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf clean all --disableplugin=subscription-manager \
   && groupadd -g 1000 cssuser && adduser -u 1000 -g cssuser cssuser \

--- a/ess/image/edge-sync-service-amd64/Dockerfile.ubi
+++ b/ess/image/edge-sync-service-amd64/Dockerfile.ubi
@@ -5,7 +5,7 @@ LABEL summary="Edge node Model Management System."
 LABEL description="Provides the edge node side of the Model Management System to be used by the CLI service test tools when also testing object models."
 
 # yum is not installed, use microdnf instead
-RUN microdnf update -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN microdnf update -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf install -y --nodocs openssl ca-certificates --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf clean all --disableplugin=subscription-manager \
 	&& rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/ess/image/edge-sync-service-arm64/Dockerfile.ubi
+++ b/ess/image/edge-sync-service-arm64/Dockerfile.ubi
@@ -5,7 +5,7 @@ LABEL summary="Edge node Model Management System."
 LABEL description="Provides the edge node side of the Model Management System to be used by the CLI service test tools when also testing object models."
 
 # yum is not installed, use microdnf instead
-RUN microdnf update -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN microdnf update -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf install -y --nodocs openssl ca-certificates --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf clean all --disableplugin=subscription-manager \
 	&& rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/ess/image/edge-sync-service-ppc64el/Dockerfile.ubi
+++ b/ess/image/edge-sync-service-ppc64el/Dockerfile.ubi
@@ -7,7 +7,7 @@ LABEL description="Provides the edge node side of the Model Management System to
 # yum is not installed, use microdnf instead
 RUN microdnf clean all \
   	&& rm -rf /var/cache/dnf /var/cache/PackageKit \
-  	&& microdnf update -y --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+  	&& microdnf update -y libxml2 --nodocs --nobest --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf install -y --nodocs openssl ca-certificates --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf clean all --disableplugin=subscription-manager \
 	&& rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \

--- a/ess/image/edge-sync-service-s390x/Dockerfile.ubi
+++ b/ess/image/edge-sync-service-s390x/Dockerfile.ubi
@@ -5,7 +5,7 @@ LABEL summary="Edge node Model Management System."
 LABEL description="Provides the edge node side of the Model Management System to be used by the CLI service test tools when also testing object models."
 
 # yum is not installed, use microdnf instead
-RUN microdnf update -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN microdnf update -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf install -y --nodocs openssl ca-certificates --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
 	&& microdnf clean all --disableplugin=subscription-manager \
 	&& rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.* \


### PR DESCRIPTION
### CVE description

libxml2 before 2.12.10 and 2.13.x before 2.13.6 has a use-after-free in xmlSchemaIDCFillNodeTables and xmlSchemaBubbleIDCNodeTables in xmlschemas.c. To exploit this, a crafted XML document must be validated against an XML schema with certain identity constraints, or a crafted XML schema must be used.

### References 
[4319](https://github.com/open-horizon/anax/issues/4319)