### PR TITLE
Issue open-horizon#4337 - Fix CVE-338: Weak Pseudo-Random

### DIFF
--- a/cutil/cutil.go
+++ b/cutil/cutil.go
@@ -3,7 +3,7 @@ package cutil
 import (
 	"bufio"
 	"crypto/md5"
-	"crypto/rand"
+	crypto_rand "crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -64,7 +64,7 @@ func SecureRandomString() (string, error) {
 
 	// pad out the password to make it <=15 chars
 	bytes := make([]byte, 63)
-	if _, err := rand.Read(bytes); err != nil {
+	if _, err := crypto_rand.Read(bytes); err != nil {
 		return "", err
 	}
 	randStr += base64.URLEncoding.EncodeToString(bytes)
@@ -82,7 +82,7 @@ func GenerateAgreementId() (string, error) {
 
 	bytes := make([]byte, 32, 32)
 	agreementIdString := ""
-	_, err := rand.Read(bytes)
+	_, err := crypto_rand.Read(bytes)
 	if err == nil {
 		agreementIdString = hex.EncodeToString(bytes)
 	}
@@ -93,7 +93,7 @@ func GenerateRandomNodeId() (string, error) {
 
 	bytes := make([]byte, 20, 20)
 	nodeIdString := ""
-	_, err := rand.Read(bytes)
+	_, err := crypto_rand.Read(bytes)
 	if err == nil {
 		nodeIdString = hex.EncodeToString(bytes)
 	}


### PR DESCRIPTION
### CWE Description

When a non-cryptographic PRNG is used in a cryptographic context, it can expose the cryptography to certain types of attacks. Often a pseudo-random number generator (PRNG) is not designed for cryptography. Sometimes a mediocre source of randomness is sufficient or preferable for algorithms that use random numbers. Weak generators generally take less processing power and/or do not use the precious, finite, entropy sources on a system. While such PRNGs might have very useful features, these same features could be used to break the cryptography

### References 
[4337](https://github.com/open-horizon/anax/issues/4337)