### PR TITLE
Issue open-horizon#4340 - Use-xz-instead-of-zstd-for-deb

### DIFF
--- a/pkg/deb/Makefile
+++ b/pkg/deb/Makefile
@@ -71,6 +71,6 @@ horizon-cli-deb: require-version
 	envsubst < horizon-cli-control.tmpl > horizon-cli/DEBIAN/control
 	mkdir -p debs
 	rm -f debs/horizon-cli_*$(DISTRO)_$(arch).deb
-	dpkg-deb --build horizon-cli debs/horizon-cli_$(VERSION)$(BUILD_NUMBER)_$(arch).deb
+	dpkg-deb -Zxz --build horizon-cli debs/horizon-cli_$(VERSION)$(BUILD_NUMBER)_$(arch).deb
 
 .PHONY: all horizon-deb horizon-cli-deb


### PR DESCRIPTION
### Description 
This PR updates Debian packaging step so that both the control and data archives inside the .deb use XZ compression instead of the default Zstd. This resolves installation failures on systems where Zstd-compressed archives aren’t handled by dpkg.


<img width="672" alt="Zrzut ekranu 2025-06-16 o 15 12 04" src="https://github.com/user-attachments/assets/9a3b17f1-1a85-4003-8133-5d792a73fcdb" />

### References
[4340](https://github.com/open-horizon/anax/issues/4340)