### PR TITLE
Issue open-horizon#4340 - Use-xz-instead-of-zstd-for-deb

### DIFF
--- a/pkg/deb/Makefile
+++ b/pkg/deb/Makefile
@@ -41,7 +41,7 @@ horizon-deb: require-version
 	envsubst < horizon-control.tmpl > horizon/DEBIAN/control
 	mkdir -p debs
 	rm -f debs/horizon_*$(DISTRO)_$(arch).deb
-	dpkg-deb --build horizon debs/horizon_$(VERSION)$(BUILD_NUMBER)_$(arch).deb
+	dpkg-deb -Zxz --build horizon debs/horizon_$(VERSION)$(BUILD_NUMBER)_$(arch).deb
 
 # Remember to up VERSION above. If building the deb on mac, first: brew install dpkg
 horizon-cli-deb: require-version


### PR DESCRIPTION
### Description 
This PR updates Debian packaging step so that both the control and data archives inside the .deb use XZ compression instead of the default Zstd. This resolves installation failures on systems where Zstd-compressed archives aren’t handled by dpkg.

### References
[4340](https://github.com/open-horizon/anax/issues/4340)