### PR TITLE
Issue open-horizon#4387 - fix CVE-2024-22667

### DIFF
--- a/anax-in-container/Dockerfile_agbot.ubi
+++ b/anax-in-container/Dockerfile_agbot.ubi
@@ -10,8 +10,8 @@ LABEL description="The Agbot scans all the edge nodes in the system initiating d
 # add agbotuser
 # agbot_start.sh calls envsubst (from gettext)
 # Create required directories
-ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng gettext"
-RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables psmisc procps-ng gettext"
+RUN microdnf update -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf upgrade -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager krb5-libs \
   && microdnf clean all --disableplugin=subscription-manager \


### PR DESCRIPTION
### CVE description 
Vim before 9.0.2142 has a stack-based buffer overflow because did_set_langmap in map.c calls sprintf to write to the error buffer that is passed down to the option callback functions.

[4387](https://github.com/open-horizon/anax/issues/4387)