### PR TITLE
Issue open-horizon#4395 - Fix CVE-2025-6965

### DIFF
--- a/anax-in-container/Dockerfile_agbot.ubi
+++ b/anax-in-container/Dockerfile_agbot.ubi
@@ -11,7 +11,7 @@ LABEL description="The Agbot scans all the edge nodes in the system initiating d
 # agbot_start.sh calls envsubst (from gettext)
 # Create required directories
 ARG REQUIRED_RPMS="openssl ca-certificates shadow-utils jq iptables vim-minimal psmisc procps-ng gettext"
-RUN  microdnf update  -y libxml2 --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+RUN  microdnf update  -y libxml2 sqlite --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
   && microdnf install -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager ${REQUIRED_RPMS} \
   && microdnf upgrade -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager krb5-libs \
   && microdnf clean all --disableplugin=subscription-manager \


### PR DESCRIPTION
### CVE description
There exists a vulnerability in SQLite versions before 3.50.2 where the number of aggregate terms could exceed the number of columns available. This could lead to a memory corruption issue. We recommend upgrading to version 3.50.2 or above.

### references 
[4395](https://github.com/open-horizon/anax/issues/4395)