### PR TITLE
Issue open-horizon#4410 - Agent failed to parse exchange timestamp

### DIFF
--- a/cutil/cutil.go
+++ b/cutil/cutil.go
@@ -119,7 +119,7 @@ func CheckConnectivity(host string) error {
 
 // Exchange time format. Golang requires the format string to be in reference to the specific time as shown.
 // This is so that the formatter and parser can figure out what goes where in the string.
-const ExchangeTimeFormat = "2006-01-02T15:04:05.999Z[MST]"
+const ExchangeTimeFormat = "2006-01-02T15:04:05.999999999Z"
 
 func TimeInSeconds(timestamp string, format string) int64 {
 	if t, err := time.Parse(format, timestamp); err != nil {


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #4410 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
