### PR TITLE
Added a new makefile target that does not clean before testing.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -314,7 +314,7 @@ test-image:
 		docker build $(DOCKER_DEV_OPTS) -t $(DOCKER_TEST_INAME) -f docker/Dockerfile ./docker && docker tag $(DOCKER_TEST_INAME) $(DOCKER_TEST_INAME):$(DOCKER_TEST_TAG); \
 	fi
 
-test: clean $(ANAX_SOURCE)/anax run-dockerreg run-mgmthub run-test
+test-no-clean: $(ANAX_SOURCE)/anax run-dockerreg run-mgmthub run-test
 	@echo -e  "\nBootstrapping the exchange"
 	docker exec $(DOCKER_TEST_CNAME) bash -c "export $(TEST_VARS) EXCHANGE_HUB_ADMIN_PW=$(EXCHANGE_HUB_ADMIN_PW) EXCHANGE_SYSTEM_ADMIN_PW=$(EXCHANGE_SYSTEM_ADMIN_PW); /root/init_exchange.sh"
 	@echo -e  "\nSetting up secrets in the vault"
@@ -323,6 +323,8 @@ test: clean $(ANAX_SOURCE)/anax run-dockerreg run-mgmthub run-test
 	$(TEST_VARS) ARCH=$(arch) CERT_LOC=$(CERT_LOC) gov/run_kube.sh $(E2EDEVTEST_TEMPFS) $(ANAX_SOURCE) $(EXCH_ROOTPW) $(DOCKER_TEST_NETWORK) $(E2EDEV_HOST_IP)
 	@echo -e  "\nStarting tests"
 	docker exec $(DOCKER_TEST_CNAME) bash -c "export $(TEST_VARS); /root/gov-combined.sh"
+
+test: clean test-no-clean
 
 test-remote: clean $(ANAX_SOURCE)/anax run-dockerreg run-test copy-cert
 	@echo -e  "\nBootstrapping the exchange"
@@ -424,5 +426,5 @@ run-mgmthub: get-agbot-image get-css-image get-vault-image get-anax-images
 		cp /etc/horizon/keys/horizonMgmtHub.crt $(E2EDEVTEST_TEMPFS)/certs/agbotapi.crt; \
 	fi
 
-.PHONY: all default stop build run distclean clean mostlyclean realclean run-test run-dockerreg test-network test e2edevtest-docker-prereqs test-image copy-cert
+.PHONY: all default stop build run distclean clean mostlyclean realclean run-test run-dockerreg test-network test test-no-clean e2edevtest-docker-prereqs test-image copy-cert
 #.SILENT: clean


### PR DESCRIPTION
# Pull Request Template

## Description

The current E2E makefile runs an environment clean before running test. This destroys any custom images loaded/pulled into docker. This pull request adds in a new target to separate out the cleaning functions without changing the existing targets. This is used for GitHub workflows where the environment is otherwise "clean" to begin with.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Custom E2E test runner for the Exchange's repository.

## Additional Context (Please include any Screenshots/gifs if relevant)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [X] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
