### PR TITLE
Avoid k8s cli tool detection for all-in-one env

### DIFF
--- a/agent-install/edgeNodeFiles.sh
+++ b/agent-install/edgeNodeFiles.sh
@@ -176,7 +176,7 @@ function checkPrereqsAndInput () {
 
     if [[ -z "$CLUSTER_URL" && ( -z "$HZN_EXCHANGE_URL" || -z "$HZN_FSS_CSSURL" || -z "$HZN_AGBOT_URL" || -z "$HZN_FDO_SVC_URL" ) ]]; then
         detect_k8s_cli_tool
-    elif [[ "$HZN_EXCHANGE_URL" == https:* && -z "$HZN_MGMT_HUB_CERT_PATH" ]]; then
+    elif [[ "$HZN_EXCHANGE_URL" == https:* && -z "$AGENT_INSTALL_CERT" ]]; then
         detect_k8s_cli_tool
     elif [[ -z "$HZN_EXCHANGE_USER_AUTH" ]]; then
         detect_k8s_cli_tool
@@ -245,16 +245,17 @@ function checkPrereqsAndInput () {
     echo ""
 
     if [[ ${HZN_EXCHANGE_URL} == "https:"* ]]; then
-        if  [[ -z "$HZN_MGMT_HUB_CERT_PATH" ]]; then
+        if  [[ -z "$AGENT_INSTALL_CERT" ]]; then
             echo "Getting the agent-install.crt..."
             HUB_CERT_NAME=$($K8S_CLI_TOOL get configmap ibm-edge-ca-cert-name -n $NAMESPACE -o jsonpath="{.data['ca_secret_name']}")
             ${K8S_CLI_TOOL} -n ${NAMESPACE} get secret ${HUB_CERT_NAME} -ojson \
                 | jq -r '.data["tls.crt"]' \
                 | base64 -d > /tmp/ieam.crt
-            export HZN_MGMT_HUB_CERT_PATH="/tmp/ieam.crt"
+            export AGENT_INSTALL_CERT="/tmp/ieam.crt"
         else
-            echo "HZN_MGMT_HUB_CERT_PATH is already set to: $HZN_MGMT_HUB_CERT_PATH"
+            echo "AGENT_INSTALL_CERT is already set to: $AGENT_INSTALL_CERT"
         fi
+        export HZN_MGMT_HUB_CERT_PATH="${AGENT_INSTALL_CERT}"
     else
         echo  "Skipping cert since ${HZN_EXCHANGE_URL} is using http"
     fi


### PR DESCRIPTION
# Pull Request Template

## Description

edgeNodeFiles should not attempt to detect k8s cli tool for all in one env with https

Fixes #4425 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Testing on all-in-one with https and with downstream product

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
